### PR TITLE
Fix assert from delay between reliable messages

### DIFF
--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -1885,7 +1885,7 @@ namespace yojimbo
 
     void ReliableOrderedChannel::AddMessagePacketEntry( const uint16_t * messageIds, int numMessageIds, uint16_t sequence )
     {
-        SentPacketEntry * sentPacket = m_sentPackets->Insert( sequence );
+        SentPacketEntry * sentPacket = m_sentPackets->Insert( sequence, true );
         yojimbo_assert( sentPacket );
         if ( sentPacket )
         {
@@ -2167,7 +2167,7 @@ namespace yojimbo
 
     void ReliableOrderedChannel::AddFragmentPacketEntry( uint16_t messageId, uint16_t fragmentId, uint16_t sequence )
     {
-        SentPacketEntry * sentPacket = m_sentPackets->Insert( sequence );
+        SentPacketEntry * sentPacket = m_sentPackets->Insert( sequence, true );
         yojimbo_assert( sentPacket );
         if ( sentPacket )
         {

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -1412,12 +1412,13 @@ namespace yojimbo
             Insert an entry in the sequence buffer.
             IMPORTANT: If another entry exists at the sequence modulo buffer size, it is overwritten.
             @param sequence The sequence number.
+            @param guaranteed_order Whether sequence is always the newest value (when sending) or can be out of order (when receiving).
             @returns The sequence buffer entry, which you must fill with your data. NULL if a sequence buffer entry could not be added for your sequence number (if the sequence number is too old for example).
          */
 
-        T * Insert( uint16_t sequence )
+        T * Insert( uint16_t sequence, bool guaranteed_order = false )
         {
-            if ( sequence_greater_than( sequence + 1, m_sequence ) )
+            if ( sequence_greater_than( sequence + 1, m_sequence ) || guaranteed_order )
             {
                 RemoveEntries( m_sequence, sequence );
                 m_sequence = sequence + 1;


### PR DESCRIPTION
If there are over 32768 unreliable packets sent between reliable
messages, which can happen in under ten minutes at 60 fps, then the
sequence number of the next reliable message appears to be old,
causing an assertion failure. To avoid this, always interpret outbound
sequence values as newer than prior values.

Fixes #138