### PR TITLE
Added support for using a custom registry with vcpkg and also hiding …

### DIFF
--- a/vcpkg/consume_yojimbo/CMakeLists.txt
+++ b/vcpkg/consume_yojimbo/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+MESSAGE("**********************************")
+MESSAGE("Consume Yojimbo -- START --")
+MESSAGE("**********************************")
+
+project(consume-yojimbo CXX)
+
+find_package(yojimbo CONFIG REQUIRED)
+
+add_executable(consume_yojimbo src/main.cpp)
+
+target_link_libraries(consume_yojimbo yojimbo::yojimbo )
+
+MESSAGE("**********************************")
+MESSAGE("Consume Yojimbo -- DONE --")
+MESSAGE("**********************************")

--- a/vcpkg/consume_yojimbo/readme.md
+++ b/vcpkg/consume_yojimbo/readme.md
@@ -1,0 +1,25 @@
+Notes:
+
+1. Make sure to adjust the "baseline" field for the "default-registry" in `vcpkg-configuration.cmake` to the commit hash of your vcpkg installation
+
+`{
+
+    "default-registry": {
+        "baseline": "bd1ef2df46303989eeb048eb7aa9b816aa46365e", <=== This one
+        "kind": "builtin"
+    },
+
+    "registries": [
+        {
+            "baseline": "default",
+            "kind": "filesystem",
+            "path": "../registry",
+            "packages": [
+                "mbedtls",
+                "yojimbo"
+            ]
+        }
+    ]
+}`
+
+2. `src/main.cpp` is just `#include`ing the yojimbo header, but not really using it.

--- a/vcpkg/consume_yojimbo/src/main.cpp
+++ b/vcpkg/consume_yojimbo/src/main.cpp
@@ -1,0 +1,5 @@
+#include <yojimbo/yojimbo.h>
+
+int main() {
+	return 0;
+}

--- a/vcpkg/consume_yojimbo/vcpkg-configuration.json
+++ b/vcpkg/consume_yojimbo/vcpkg-configuration.json
@@ -1,0 +1,19 @@
+{
+
+    "default-registry": {
+        "baseline": "bd1ef2df46303989eeb048eb7aa9b816aa46365e",
+        "kind": "builtin"
+    },
+
+    "registries": [
+        {
+            "baseline": "default",
+            "kind": "filesystem",
+            "path": "../registry",
+            "packages": [
+                "mbedtls",
+                "yojimbo"
+            ]
+        }
+    ]
+}

--- a/vcpkg/consume_yojimbo/vcpkg.json
+++ b/vcpkg/consume_yojimbo/vcpkg.json
@@ -1,0 +1,10 @@
+{
+    "name": "consume-yojimbo",
+    "version": "0.0.1",
+    "description": [
+        "Testing yojimbo integration."
+    ],
+    "dependencies": [
+        "yojimbo"
+    ]
+}

--- a/vcpkg/readme_vcpkg.md
+++ b/vcpkg/readme_vcpkg.md
@@ -1,6 +1,10 @@
 The directory /vcpkg contains files to build and install yojimbo and its dependencies with the vcpkg package manager.
 Documentation: https://vcpkg.io
 
+
+Directory: /ports
+=======================
+
 Files
 ---------------
 
@@ -30,4 +34,23 @@ B. Integrate the port into your vcpkg installation (advanced)
 2. Add the yojimbo port from this repo to the ports of your checked out port.
 
 3. In your vcpkg fork with the yojimbo port added run: vcpkg x-add-version --all
+
+
+
+
+Directory: /registry
+=======================
+
+This directory contains a custom registry with ports for yojimbo and mbedtls (taken from vcpkg and changed to provide a cmake config file). It is consumed by the /consume_yojimbo directory
+
+
+Directory: /consume_yojimbo
+============================
+This is a very simple project consuming yojimbo and also demonstrating the use of hiding away the transitive dependencies sodium and mbedtls. 
+You can just directly open the folder in Visual Studio and run the cmake configuration and the build. 
+
+It should also work on Linux, but was only tested on Windows.
+
+Make sure you load the vcpkg toolchain file, either by using  `vcpkg.exe integrate install` or directly loading the file like `cmake ../my/project -DCMAKE_TOOLCHAIN_FILE=<vcpkg-root>/scripts/buildsystems/vcpkg.cmake`
+
 

--- a/vcpkg/registry/ports/mbedtls/2.24.0/cmake/mbedtlsConfig.cmake
+++ b/vcpkg/registry/ports/mbedtls/2.24.0/cmake/mbedtlsConfig.cmake
@@ -1,0 +1,49 @@
+message("****** mbedtlsConfig - START - ******")
+
+############################################################
+##
+
+  # Compute the installation prefix relative to this file.
+    get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+    if(_IMPORT_PREFIX STREQUAL "/")
+      set(_IMPORT_PREFIX "")
+    endif()
+    MESSAGE("_IMPORT_PREFIX = ${_IMPORT_PREFIX}")
+  
+  ## External libraries and headers
+  
+  add_library( mbedtls STATIC IMPORTED )  
+  target_include_directories( mbedtls INTERFACE "${_IMPORT_PREFIX}/include"  )
+    
+  add_library( mbedx509 STATIC IMPORTED )  
+  target_include_directories( mbedx509 INTERFACE "${_IMPORT_PREFIX}/include"  )
+  
+  add_library( mbedcrypto STATIC IMPORTED )  
+  target_include_directories( mbedcrypto INTERFACE "${_IMPORT_PREFIX}/include"  )
+  
+  ## External library binaries
+  if(WIN32)
+    if(${CMAKE_BUILD_TYPE}_ STREQUAL "Debug_")
+        set_target_properties(mbedtls    PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/debug/lib/mbedtls.lib     )
+        set_target_properties(mbedx509   PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/debug/lib/mbedx509.lib    )
+        set_target_properties(mbedcrypto PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/debug/lib/mbedcrypto.lib  )
+    else()
+        set_target_properties(mbedtls    PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/lib/mbedtls.lib     )
+        set_target_properties(mbedx509   PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/lib/mbedx509.lib    )
+        set_target_properties(mbedcrypto PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/lib/mbedcrypto.lib  )
+    endif()
+  ELSEIF(UNIX)
+    if(${CMAKE_BUILD_TYPE}_ STREQUAL "Debug_")
+        set_target_properties(mbedtls    PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/debug/lib/libmbedtls.a    )
+        set_target_properties(mbedx509   PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/debug/lib/libmbedx509.a   )
+        set_target_properties(mbedcrypto PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/debug/lib/libmbedcrypto.a )
+    else()
+        set_target_properties(mbedtls    PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/lib/libmbedtls.a    )
+        set_target_properties(mbedx509   PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/lib/libmbedx509.a   )
+        set_target_properties(mbedcrypto PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/lib/libmbedcrypto.a )
+    endif()
+  ENDIF()
+  
+message("****** mbedtlsConfig - DONE - ******")

--- a/vcpkg/registry/ports/mbedtls/2.24.0/enable-pthread.patch
+++ b/vcpkg/registry/ports/mbedtls/2.24.0/enable-pthread.patch
@@ -1,0 +1,102 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8833246..f68ab02 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,6 +28,7 @@ set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)
+ option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)
++option(ENABLE_PTHREAD "Build mbed TLS with pthread" OFF)
+ 
+ option(ENABLE_PROGRAMS "Build mbed TLS programs." ON)
+ 
+@@ -231,6 +232,8 @@ else()
+     set(LIB_INSTALL_DIR lib)
+ endif()
+ 
++include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
++
+ if(ENABLE_ZLIB_SUPPORT)
+     find_package(ZLIB)
+ 
+@@ -239,6 +242,17 @@ if(ENABLE_ZLIB_SUPPORT)
+     endif(ZLIB_FOUND)
+ endif(ENABLE_ZLIB_SUPPORT)
+ 
++if(ENABLE_PTHREAD)
++    if(WIN32)
++        find_package(pthreads_windows REQUIRED)
++        include_directories(${PThreads4W_INCLUDE_DIR})
++    else()
++        set(CMAKE_THREAD_PREFER_PTHREAD ON)
++        find_package(Threads REQUIRED)
++    endif()
++    set(LINK_WITH_PTHREAD ON)
++endif()
++
+ add_subdirectory(include)
+ 
+ add_subdirectory(3rdparty)
+diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
+index 62c0f62..7923202 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -1,10 +1,14 @@
+ option(INSTALL_MBEDTLS_HEADERS "Install mbed TLS headers." ON)
+ 
++configure_file(mbedtls/config_threading.h.in mbedtls/config_threading.h)
++
+ if(INSTALL_MBEDTLS_HEADERS)
+ 
+     file(GLOB headers "mbedtls/*.h")
+     file(GLOB psa_headers "psa/*.h")
+-
++    
++    set(headers ${headers} ${CMAKE_CURRENT_BINARY_DIR}/mbedtls/config_threading.h)
++    
+     install(FILES ${headers}
+         DESTINATION include/mbedtls
+         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
+index 1e6e052..51c20da 100644
+--- a/include/mbedtls/config.h
++++ b/include/mbedtls/config.h
+@@ -24,6 +24,8 @@
+  *  limitations under the License.
+  */
+ 
++#include "mbedtls/config_threading.h"
++
+ #ifndef MBEDTLS_CONFIG_H
+ #define MBEDTLS_CONFIG_H
+ 
+diff --git a/include/mbedtls/config_threading.h.in b/include/mbedtls/config_threading.h.in
+new file mode 100644
+index 0000000..9d5d42e
+--- /dev/null
++++ b/include/mbedtls/config_threading.h.in
+@@ -0,0 +1,6 @@
++#cmakedefine ENABLE_PTHREAD
++
++#ifdef ENABLE_PTHREAD
++#define MBEDTLS_THREADING_C
++#define MBEDTLS_THREADING_PTHREAD
++#endif
+\ No newline at end of file
+diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
+index 33e2cfc..4b99331 100644
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -137,7 +137,11 @@ if(ENABLE_ZLIB_SUPPORT)
+ endif(ENABLE_ZLIB_SUPPORT)
+ 
+ if(LINK_WITH_PTHREAD)
+-    set(libs ${libs} pthread)
++    if(WIN32)
++        set(libs ${libs} ${PThreads4W_LIBRARY})
++    else()
++        set(libs ${libs} pthread)
++    endif()
+ endif()
+ 
+ if(LINK_WITH_TRUSTED_STORAGE)

--- a/vcpkg/registry/ports/mbedtls/2.24.0/portfile.cmake
+++ b/vcpkg/registry/ports/mbedtls/2.24.0/portfile.cmake
@@ -1,0 +1,48 @@
+MESSAGE("*******************************************")
+MESSAGE("Custom mbedtls port from Yojimbo - START - ")
+MESSAGE("*******************************************")
+
+set(VCPKG_LIBRARY_LINKAGE static)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ARMmbed/mbedtls
+    REF 523f0554b6cdc7ace5d360885c3f5bbcc73ec0e8 # mbedtls-2.24.0
+    SHA512 1ce78f34e8d87c2ce0454e0a08f4c6e5b3129d4b24cfa44162af21c2e8b5dc7feabf849e4fa547ce3781b5ce11aaf675cfed47412bae40091fbdd87bbcdbee07
+    HEAD_REF master
+    PATCHES
+        enable-pthread.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    pthreads ENABLE_PTHREAD
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DENABLE_TESTING=OFF
+        -DENABLE_PROGRAMS=OFF
+        -DMBEDTLS_FATAL_WARNINGS=FALSE
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/cmake/mbedtlsConfig.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} )
+
+if (VCPKG_TARGET_IS_WINDOWS AND pthreads IN_LIST FEATURES)
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+endif ()
+
+vcpkg_copy_pdbs()
+
+MESSAGE("*******************************************")
+MESSAGE("Custom mbedtls port from Yojimbo - DONE -  ")
+MESSAGE("*******************************************")

--- a/vcpkg/registry/ports/mbedtls/2.24.0/vcpkg-cmake-wrapper.cmake
+++ b/vcpkg/registry/ports/mbedtls/2.24.0/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,29 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(MBEDTLS_INCLUDE_DIR mbedtls/ssl.h)
+
+find_library(MBEDTLS_CRYPTO_LIBRARY mbedcrypto)
+find_package(pthreads_windows QUIET)
+set(MBEDTLS_CRYPTO_LIBRARY ${MBEDTLS_CRYPTO_LIBRARY} ${PThreads4W_LIBRARY})
+find_library(MBEDTLS_X509_LIBRARY mbedx509)
+find_library(MBEDTLS_TLS_LIBRARY mbedtls)
+set(MBEDTLS_LIBRARIES ${MBEDTLS_CRYPTO_LIBRARY} ${MBEDTLS_X509_LIBRARY} ${MBEDTLS_TLS_LIBRARY})
+
+if (MBEDTLS_INCLUDE_DIR AND EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h")
+    file(
+        STRINGS ${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h _MBEDTLS_VERLINE
+        REGEX "^#define[ \t]+MBEDTLS_VERSION_STRING[\t ].*"
+    )
+    string(REGEX REPLACE ".*MBEDTLS_VERSION_STRING[\t ]+\"(.*)\"" "\\1" MBEDTLS_VERSION ${_MBEDTLS_VERLINE})
+endif()
+
+find_package_handle_standard_args(
+    mbedTLS
+    REQUIRED_VARS
+        MBEDTLS_INCLUDE_DIR
+        MBEDTLS_CRYPTO_LIBRARY
+        MBEDTLS_X509_LIBRARY
+        MBEDTLS_TLS_LIBRARY
+        PThreads4W_FOUND
+    VERSION_VAR MBEDTLS_VERSION
+)

--- a/vcpkg/registry/ports/mbedtls/2.24.0/vcpkg.json
+++ b/vcpkg/registry/ports/mbedtls/2.24.0/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "mbedtls",
+  "version-string": "2.24.0",
+  "port-version": 3,
+  "description": "An open source, portable, easy to use, readable and flexible SSL library",
+  "homepage": "https://github.com/ARMmbed/mbedtls",
+  "supports": "!uwp",
+  "features": {
+    "pthreads": {
+      "description": "Multi-threading support",
+      "dependencies": [
+        {
+          "name": "pthreads",
+          "platform": "windows"
+        }
+      ]
+    }
+  }
+}

--- a/vcpkg/registry/ports/yojimbo/1.2.1/CMakeLists.txt
+++ b/vcpkg/registry/ports/yojimbo/1.2.1/CMakeLists.txt
@@ -1,0 +1,185 @@
+cmake_minimum_required(VERSION 3.16)
+
+
+MESSAGE("*********************************************************************")
+MESSAGE("******  Yojimbo -- START --")
+
+#############################################################
+## Project Definition
+#############################################################
+project(Yojimbo C CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CURRENT_PORT_DIR}/cmake/")
+include("${CURRENT_PORT_DIR}/cmake/yojimbo_lib.cmake")
+
+find_package(unofficial-sodium CONFIG REQUIRED)
+find_package(mbedtls           CONFIG REQUIRED)
+
+############################################################
+## Yojimbo Static Library
+############################################################
+##
+  add_library(yojimbo STATIC
+      ${SOURCE_PATH}/yojimbo.cpp
+      ${SOURCE_PATH}/tlsf/tlsf.c
+      ${SOURCE_PATH}/netcode.io/netcode.c
+      ${SOURCE_PATH}/reliable.io/reliable.c  )
+
+  target_link_libraries( yojimbo PRIVATE unofficial-sodium::sodium mbedtls mbedx509 mbedcrypto )
+
+  target_compile_definitions( yojimbo PUBLIC NETCODE_ENABLE_TESTS=0 RELIABLE_ENABLE_TESTS=0 )      
+  
+  target_include_directories( yojimbo 
+    PRIVATE 
+        ${SOURCE_PATH} 
+        ${SOURCE_PATH}/netcode.io 
+        ${SOURCE_PATH}/reliable.io 
+    INTERFACE
+        ${CMAKE_INSTALL_PREFIX}/include
+    )
+
+  ############################################################
+  ## Yojimbo Static TEST Library and Test App
+  ############################################################
+  ##
+ ##if(${YOJIMBO_TESTS}) 
+    ## library
+    add_library(yojimbo_test STATIC
+      ${SOURCE_PATH}/yojimbo.cpp
+      ${SOURCE_PATH}/tlsf/tlsf.c
+      ${SOURCE_PATH}/netcode.io/netcode.c
+      ${SOURCE_PATH}/reliable.io/reliable.c
+    )
+    target_link_libraries( yojimbo_test  unofficial-sodium::sodium mbedtls mbedx509 mbedcrypto )    
+    target_compile_definitions( yojimbo_test PUBLIC NETCODE_ENABLE_TESTS=1 RELIABLE_ENABLE_TESTS=1 )    
+    target_include_directories( yojimbo_test 
+      INTERFACE
+          $<BUILD_INTERFACE:${SOURCE_PATH}> 
+          $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include> 
+      PRIVATE 
+          "${SOURCE_PATH}/netcode.io" 
+          "${SOURCE_PATH}/reliable.io" 
+    )
+    
+    target_include_directories( yojimbo PRIVATE "${VCPKG_LIBSODIUM_BASE}/include"  )
+    target_include_directories( yojimbo PRIVATE "${VCPKG_MBEDTLS_BASE}/include"  )
+            
+    ## executable
+    add_executable(testapp ${SOURCE_PATH}/test.cpp )
+    target_link_libraries(testapp yojimbo_test)    
+    ##
+  ##endif()  
+    
+  ############################################################
+  ## Client App Target
+  ############################################################
+  ##
+      add_executable(client ${SOURCE_PATH}/client.cpp )
+      target_link_libraries( client yojimbo )
+    
+  ############################################################
+  ## Server App Target
+  ############################################################
+  ##
+      add_executable(server ${SOURCE_PATH}/server.cpp )
+      target_link_libraries( server yojimbo )
+    
+  ############################################################
+  ## Secure Client App Target
+  ############################################################
+  ##
+      add_executable(secure_client ${SOURCE_PATH}/secure_client.cpp )
+      target_link_libraries( secure_client yojimbo )
+    
+  ############################################################
+  ## Secure Server App Target
+  ############################################################
+  ##
+      add_executable(secure_server ${SOURCE_PATH}/secure_server.cpp )
+      target_link_libraries( secure_server yojimbo )
+    
+  ############################################################
+  ## Client Server App Target
+  ############################################################
+  ##
+      add_executable(client_server ${SOURCE_PATH}/client_server.cpp )
+      target_link_libraries( client_server yojimbo )
+    
+  ############################################################
+  ## Loopback App Target
+  ############################################################
+  ##
+      add_executable(loopback ${SOURCE_PATH}/loopback.cpp )
+      target_link_libraries( loopback yojimbo )
+    
+  ############################################################
+  ## Soak App Target
+  ############################################################
+  ##
+      add_executable(soak ${SOURCE_PATH}/soak.cpp )
+      target_link_libraries( soak yojimbo )
+    
+############################################################
+## Install
+############################################################
+##
+  
+  #if(YOJIMBO_TESTS)
+      SET(TEST_INSTALL testapp)
+  #endif()
+  
+  ## yojimbo + EXPORT
+  install(
+      TARGETS
+          yojimbo
+      EXPORT yojimbo_targets
+      #RUNTIME  DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+      LIBRARY  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+      ARCHIVE  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib     
+      INCLUDES DESTINATION ${CMAKE_INSTALL_PREFIX}/include    )
+  
+       CMAKE_POLICY(SET CMP0022 NEW)
+  ## install cmake files for find_package
+  install(EXPORT yojimbo_targets      
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/share/yojimbo
+      NAMESPACE yojimbo::
+      FILE yojimboTargets.cmake
+      EXPORT_LINK_INTERFACE_LIBRARIES
+      )
+
+      # final config file
+      install(FILES ${CURRENT_PORT_DIR}/cmake/yojimboConfig.cmake DESTINATION ${CMAKE_INSTALL_PREFIX}/share/yojimbo)
+
+
+  if( ${CMAKE_BUILD_TYPE}_ STREQUAL "Debug_" )
+    vprint(CMAKE_BUILD_TYPE)
+    message("Skipping header installation.")
+  else()
+    vprint(CMAKE_BUILD_TYPE)
+    message("Installing headers")
+    install(  FILES   ${SOURCE_PATH}/yojimbo.h 
+                      ${SOURCE_PATH}/shared.h 
+              DESTINATION 
+                      ${CMAKE_INSTALL_PREFIX}/include/yojimbo
+    )
+  endif()
+  
+  ## The rest
+  install(
+      TARGETS
+          ${TEST_INSTALL}
+          client
+          server
+          secure_client
+          secure_server
+          client_server
+          loopback
+          soak
+      RUNTIME  DESTINATION ${CMAKE_INSTALL_PREFIX}/examples/yojimbo
+      LIBRARY  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+      ARCHIVE  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib     
+      INCLUDES DESTINATION ${CMAKE_INSTALL_PREFIX}/include    )
+      
+
+MESSAGE(STATUS "******  Yojimbo -- DONE --")
+MESSAGE("*********************************************************************")

--- a/vcpkg/registry/ports/yojimbo/1.2.1/cmake/yojimboConfig.cmake
+++ b/vcpkg/registry/ports/yojimbo/1.2.1/cmake/yojimboConfig.cmake
@@ -1,0 +1,5 @@
+find_package(unofficial-sodium CONFIG REQUIRED)
+find_package(mbedtls           CONFIG REQUIRED)
+
+#include(yojimboTargets.cmake)
+include( "${CMAKE_CURRENT_LIST_DIR}/yojimboTargets.cmake" )

--- a/vcpkg/registry/ports/yojimbo/1.2.1/cmake/yojimbo_lib.cmake
+++ b/vcpkg/registry/ports/yojimbo/1.2.1/cmake/yojimbo_lib.cmake
@@ -1,0 +1,36 @@
+# compares a and b and puts the result into the variable name referenced in result
+function(max  a  b result)    
+    if ( ${a} GREATER  ${b} )
+        SET(${result} ${a} PARENT_SCOPE)
+    else()
+        SET(${result} ${b} PARENT_SCOPE)
+    endif()
+endfunction()
+
+# formatted variable output
+function(vprint varname)
+    if(NOT DEFINED vprint_width)
+        SET (vprint_width 30) # formatting width
+    endif()
+    
+    SET(varcontent ${${varname}} )
+    
+    string(LENGTH "${varname}" vname_length )
+    math(EXPR padding_length ${vprint_width}-${vname_length})
+    max( ${padding_length}  0 padding_length)
+    string(REPEAT " " ${padding_length} vname_padding)
+    MESSAGE( "${varname}${vname_padding} = ${varcontent}")
+endfunction()
+
+macro(print_all_vars)
+    message("=================================================================")
+    message("Defined CMake Variables: ")
+    message("=================================================================")
+    get_cmake_property(_variableNames VARIABLES)
+    list (SORT _variableNames)
+    foreach (_variableName ${_variableNames})
+        vprint(${_variableName})
+    endforeach()
+    message("=================================================================")
+endmacro(print_all_vars)
+

--- a/vcpkg/registry/ports/yojimbo/1.2.1/portfile.cmake
+++ b/vcpkg/registry/ports/yojimbo/1.2.1/portfile.cmake
@@ -1,0 +1,106 @@
+message("*** Yojimbo portfile - START - ***")
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# make some functions available, mainly for logging / printing variables
+# but also the mbedtls and libsodium config files which their ports are lacking.
+# libsodium has some "unofficial" config - I decided to roll my own here. ~Yorlik
+
+list(APPEND CMAKE_MODULE_PATH "${CURRENT_PORT_DIR}/cmake/")
+message("CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
+include(yojimbo_lib) # load functions
+
+## Download stuff
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO networkprotocol/yojimbo
+        REF v1.2.1
+        SHA512 1c16331b5fa743c953e776c097e8a9e30c29c76c35632cff87f70294db7d7e04b0ce66ea5d1b7930ce746bd7f2d7203a5abf1c9918571f81fcb7453126b09080
+    )
+
+    vcpkg_from_github(
+        OUT_SOURCE_PATH NETCODE_SOURCE_PATH
+        REPO networkprotocol/netcode
+        REF v1.2.1
+        SHA512 ac03f83ccf548c0ebfc1dfae69248f301d52351d306cf34ef25e07c88d15e544b55cb4dc09c23db84f90e2aee83688d40591f3ce0ef92dc5dc95b53dab301539
+    )
+
+    vcpkg_from_github(
+        OUT_SOURCE_PATH RELIABLE_SOURCE_PATH
+        REPO networkprotocol/reliable
+        REF v1.2
+        SHA512 45c7d2734de565f1700942a178d062081c70cdb9d4dc2509e5db616ab23f1e4f7d3f5e214d42267f019e5c1867a304bb537b6023eb78574f7a6ebf1ff43174bb
+    )
+
+message("*** Yojimbo portfile - Downloads finished - ***")
+
+## move netcode dependencies
+## todo: make vcpkg ports for these and just declare them as dependencies like mbedtls and libsodium
+
+    if(WIN32)
+        message("Windows OS. Copying files ...")
+        STRING(REPLACE "/" "\\" NETCODE_SOURCE_PATH  ${NETCODE_SOURCE_PATH}  )
+        STRING(REPLACE "/" "\\" RELIABLE_SOURCE_PATH ${RELIABLE_SOURCE_PATH} )
+        STRING(REPLACE "/" "\\" THESOURCE ${SOURCE_PATH} )
+        execute_process(
+            COMMAND cmd /C "xcopy ${NETCODE_SOURCE_PATH}  ${THESOURCE}\\netcode.io  /E /I /F /H /R /-Y /Q"
+            COMMAND cmd /C "xcopy ${RELIABLE_SOURCE_PATH} ${THESOURCE}\\reliable.io /E /I /F /H /R /-Y /Q"
+        )
+        SET(VCPKG_TARGET_TRIPLET "x64-windows-static")
+
+    elseif(UNIX)
+        message("Unix like OS. Copying files ...")
+        vprint(NETCODE_SOURCE_PATH)
+        vprint(RELIABLE_SOURCE_PATH)
+        SET( THESOURCE ${SOURCE_PATH} )
+        execute_process(
+            COMMAND cp -v -r ${NETCODE_SOURCE_PATH}/.  -t ${THESOURCE}/netcode.io/
+            COMMAND cp -v -r ${RELIABLE_SOURCE_PATH}/. -t ${THESOURCE}/reliable.io/
+        )
+        message("Unix like OS. Copying files ... DONE!")
+        SET(VCPKG_TARGET_TRIPLET "x64-linux")
+
+    else()
+        message(FATAL_ERROR "Unrecognized OS.")
+    endif()
+
+
+## Install main CMakeLists.txt into yojimbo source tree
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+    message("*** Yojimbo portfile - Yojimbo CMakeLists.txt installed - ***")
+
+## vcpkg feature Check
+    set(BUILD_YOJIMBO_TESTS 0)
+    if("tests" IN_LIST FEATURES)
+        set(BUILD_YOJIMBO_TESTS 1)
+    endif()
+
+message("*** Yojimbo portfile - Yojimbo feature checks done - ***")
+
+## Configure cmake for build phase
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        GENERATOR "Ninja"
+        OPTIONS
+            -DSOURCE_PATH=${SOURCE_PATH}
+            -DCURRENT_PORT_DIR=${CURRENT_PORT_DIR}
+            -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT_DIR}/scripts/buildsystems/vcpkg.cmake
+    )
+
+    message("*** Yojimbo portfile - CMake configured - ***")
+        
+## On windows install debug info
+    vcpkg_copy_pdbs()
+    message("*** Yojimbo portfile - .pdb files copied - ***")
+
+## Install artifacts
+    vcpkg_install_cmake()
+
+## Install usage and copyright
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+    file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+## Finalize
+    vcpkg_fixup_cmake_targets()
+
+message("*** Yojimbo portfile - DONE - ***")

--- a/vcpkg/registry/ports/yojimbo/1.2.1/usage
+++ b/vcpkg/registry/ports/yojimbo/1.2.1/usage
@@ -1,0 +1,11 @@
+------------------------------------------------------------------
+Using Yojimbo in your CMakeLists.txt:    
+    
+    SET(VCPKG_ROOT_DIR=/path/to/vcpkg_root)
+    
+    find_package( yojimbo   REQUIRED)
+    find_package( libsodium REQUIRED)
+    find_package( mbedtls   REQUIRED)
+    .. add your "main" target
+    target_link_libraries(main PRIVATE yojimbo::yojimbo)
+------------------------------------------------------------------

--- a/vcpkg/registry/ports/yojimbo/1.2.1/vcpkg-configuration.json
+++ b/vcpkg/registry/ports/yojimbo/1.2.1/vcpkg-configuration.json
@@ -1,0 +1,13 @@
+{
+
+    "registries": [
+        {
+            "baseline": "default",
+            "kind": "filesystem",
+            "path": "../../../../registry",
+            "packages": [
+                "mbedtls"
+            ]
+        }
+    ]
+}

--- a/vcpkg/registry/ports/yojimbo/1.2.1/vcpkg.json
+++ b/vcpkg/registry/ports/yojimbo/1.2.1/vcpkg.json
@@ -1,0 +1,8 @@
+{
+    "name": "yojimbo",
+    "version-semver": "1.2.1",
+    "dependencies": [
+        "libsodium",
+        "mbedtls"
+    ]
+}

--- a/vcpkg/registry/versions/baseline.json
+++ b/vcpkg/registry/versions/baseline.json
@@ -1,0 +1,14 @@
+{
+    "default": {
+        
+        "mbedtls": {
+            "baseline": "2.24.0",
+            "port-version": 3
+        },
+
+        "yojimbo": {
+            "baseline": "1.2.1",
+            "port-version": 0
+        }
+    }
+}

--- a/vcpkg/registry/versions/m-/mbedtls.json
+++ b/vcpkg/registry/versions/m-/mbedtls.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "path": "$/ports/mbedtls/2.24.0",
+      "version-string": "2.24.0",
+      "port-version": 3
+    }
+  ]
+}

--- a/vcpkg/registry/versions/y-/yojimbo.json
+++ b/vcpkg/registry/versions/y-/yojimbo.json
@@ -1,0 +1,9 @@
+{
+    "versions": [
+        {
+            "version": "1.2.1",
+            "port-version": 0,
+            "path": "$/ports/yojimbo/1.2.1"            
+        }
+    ]
+}


### PR DESCRIPTION
Extended the vcpkg possibilities.
Adding a variant using a custom vcpkg registry and hiding away the transitive dependencies when consuming yojimbo.
See the readme files in /vcpkg directory
Should make consumption of yojimbo with vcpkg even easier.
Signed-off-by: Yorlik <mckillroy@gmail.com>