### PR TITLE
Update vcpkg dependancy paths

### DIFF
--- a/vcpkg/ports/yojimbo/cmake/libsodiumConfig.cmake
+++ b/vcpkg/ports/yojimbo/cmake/libsodiumConfig.cmake
@@ -8,7 +8,7 @@ endif()
 ############################################################
   # External library paths
   if(WIN32)
-    SET(VCPKG_LIBSODIUM_BASE "${VCPKG_ROOT_DIR}/packages/libsodium_x64-windows-static" )
+    SET(VCPKG_LIBSODIUM_BASE "${VCPKG_ROOT_DIR}/installed/x64-windows")
   elseif(UNIX)
     SET(VCPKG_LIBSODIUM_BASE "${VCPKG_ROOT_DIR}/installed/x64-linux")
   else()

--- a/vcpkg/ports/yojimbo/cmake/mbedtlsConfig.cmake
+++ b/vcpkg/ports/yojimbo/cmake/mbedtlsConfig.cmake
@@ -12,7 +12,7 @@ endif()
   
     # External library paths
   if(WIN32)
-    SET(VCPKG_MBEDTLS_BASE   "${VCPKG_ROOT_DIR}/packages/mbedtls_x64-windows-static" )
+    SET(VCPKG_MBEDTLS_BASE   "${VCPKG_ROOT_DIR}/installed/x64-windows")
   elseif(UNIX)
     SET(VCPKG_MBEDTLS_BASE   "${VCPKG_ROOT_DIR}/installed/x64-linux")
   else()


### PR DESCRIPTION
It appears both libsodium and mbedtls no longer create packages