### PR TITLE
Assert when messages are too large to be sent

### DIFF
--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -1826,7 +1826,12 @@ namespace yojimbo
 
             if ( entry->block )
                 break;
-            
+		
+            if ( numMessageIds == 0 ) {
+                // Increase your ClientServerConfig's maxPacketSize and maxPacketFragments, or send smaller messages!
+                yojimbo_assert( entry->measuredBits <= availableBits );
+            }
+		
             if ( entry->timeLastSent + m_config.messageResendTime <= m_time && availableBits >= (int) entry->measuredBits )
             {                
                 int messageBits = entry->measuredBits + messageTypeBits;


### PR DESCRIPTION
Helps alleviate https://github.com/networkprotocol/yojimbo/issues/185 by providing a clear error message rather than silently failing to send reliable messages on the channel.