### PR TITLE
Expose `GetClientUserData` on YojimboServer class. Fix address serialization bug in matcher code.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
         submodules: recursive
     - name: Setup premake
       uses: abel0b/setup-premake@v1
-
+    
     # Install libsodium from apt
     - name: Setup (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install libsodium-dev
-
+  
     # Install libsodium from brew
     - name: Setup (MacOS)
       if: runner.os == 'MacOS'
-      run: brew reinstall libsodium
+      run: brew install libsodium
 
     # Build with premake + make
     - name: Build (gmake)
@@ -64,3 +64,4 @@ jobs:
     - name: Test (vs2019)
       if: runner.os == 'Windows'
       run: "& ./bin/${{ matrix.configuration }}/test.exe"
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
         submodules: recursive
     - name: Setup premake
       uses: abel0b/setup-premake@v1
-    
+
     # Install libsodium from apt
     - name: Setup (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install libsodium-dev
-  
+
     # Install libsodium from brew
     - name: Setup (MacOS)
       if: runner.os == 'MacOS'
-      run: brew install libsodium
+      run: brew reinstall libsodium
 
     # Build with premake + make
     - name: Build (gmake)
@@ -64,4 +64,3 @@ jobs:
     - name: Test (vs2019)
       if: runner.os == 'Windows'
       run: "& ./bin/${{ matrix.configuration }}/test.exe"
-      

--- a/include/yojimbo_server.h
+++ b/include/yojimbo_server.h
@@ -63,6 +63,8 @@ namespace yojimbo
 
         uint64_t GetClientId( int clientIndex ) const;
 
+        const uint8_t * GetClientUserData( int clientIndex ) const;
+
         netcode_address_t * GetClientAddress( int clientIndex ) const;
 
         int GetNumConnectedClients() const;

--- a/include/yojimbo_server_interface.h
+++ b/include/yojimbo_server_interface.h
@@ -144,6 +144,13 @@ namespace yojimbo
         virtual uint64_t GetClientId( int clientIndex ) const = 0;
 
         /**
+            Get the user data of the client.
+            @param clientIndex the index of the client slot in [0,maxClients-1], where maxClients corresponds to the value passed into the last call to Server::Start.
+            @returns The user data of the client.
+         */
+        const uint8_t * GetClientUserData( int clientIndex ) const;
+
+        /**
             Get the address of the client
             @param clientIndex the index of the client slot in [0,maxClients-1], where maxClients corresponds to the value passed into the last call to Server::Start.
             @returns The address of the client.

--- a/matcher/main.go
+++ b/matcher/main.go
@@ -179,9 +179,9 @@ func (token *connectToken) Write(buffer []byte) error {
 		return errors.Wrap(err, "failed to encrypt message")
 	}
 	binary.LittleEndian.PutUint32(buffer[connectTokenPrivateBytes+61:], (uint32)(token.TimeoutSeconds))
-	offset := writeAddresses(buffer[1024+61+4:], token.ServerAddresses)
-	copy(buffer[1024+61+4+offset:], token.ClientToServerKey[:])
-	copy(buffer[1024+61+4+offset+keyBytes:], token.ServerToClientKey[:])
+	offset := writeAddresses(buffer[connectTokenPrivateBytes+61+4:], token.ServerAddresses)
+	copy(buffer[connectTokenPrivateBytes+61+4+offset:], token.ClientToServerKey[:])
+	copy(buffer[connectTokenPrivateBytes+61+4+offset+keyBytes:], token.ServerToClientKey[:])
 	return nil
 }
 

--- a/matcher/main.go
+++ b/matcher/main.go
@@ -60,13 +60,14 @@ func writeAddresses(buffer []byte, addresses []net.UDPAddr) int {
 			buffer[offset+4] = ipv4[3]
 			buffer[offset+5] = (byte)(port & 0xFF)
 			buffer[offset+6] = (byte)(port >> 8)
+			offset += 7
 		} else {
 			buffer[offset] = addressIPV6
 			copy(buffer[offset+1:], addr.IP)
 			buffer[offset+17] = (byte)(port & 0xFF)
 			buffer[offset+18] = (byte)(port >> 8)
+			offset += 19
 		}
-		offset += 19
 	}
 	return offset
 }

--- a/premake5.lua
+++ b/premake5.lua
@@ -7,7 +7,7 @@ solution "Yojimbo"
     configurations { "Debug", "Release" }
     includedirs { ".", "include", "sodium", "tlsf", "netcode", "reliable", "serialize" }
     if not os.istarget "windows" then
-        targetdir "bin/"  
+        targetdir "bin/"
     end
     rtti "Off"
     warnings "Extra"
@@ -64,6 +64,7 @@ project "client"
         links { "yojimbo", "sodium-builtin", "tlsf", "netcode", "reliable" }
     filter "system:not windows"
         links { "yojimbo", "sodium", "tlsf", "netcode", "reliable" }
+        libdirs { "/opt/homebrew/lib" }
 
 project "server"
     files { "server.cpp", "shared.h" }
@@ -71,6 +72,7 @@ project "server"
         links { "yojimbo", "sodium-builtin", "tlsf", "netcode", "reliable" }
     filter "system:not windows"
         links { "yojimbo", "sodium", "tlsf", "netcode", "reliable" }
+        libdirs { "/opt/homebrew/lib" }
 
 project "loopback"
     files { "loopback.cpp", "shared.h" }
@@ -78,6 +80,7 @@ project "loopback"
         links { "yojimbo", "sodium-builtin", "tlsf", "netcode", "reliable" }
     filter "system:not windows"
         links { "yojimbo", "sodium", "tlsf", "netcode", "reliable" }
+        libdirs { "/opt/homebrew/lib" }
 
 project "soak"
     files { "soak.cpp", "shared.h" }
@@ -85,6 +88,7 @@ project "soak"
         links { "yojimbo", "sodium-builtin", "tlsf", "netcode", "reliable" }
     filter "system:not windows"
         links { "yojimbo", "sodium", "tlsf", "netcode", "reliable" }
+        libdirs { "/opt/homebrew/lib" }
 
 project "test"
     files { "test.cpp" }
@@ -93,6 +97,7 @@ project "test"
         links { "yojimbo", "sodium-builtin", "tlsf", "netcode", "reliable" }
     filter "system:not windows"
         links { "yojimbo", "sodium", "tlsf", "netcode", "reliable" }
+        libdirs { "/opt/homebrew/lib" }
 
 newaction
 {
@@ -102,7 +107,7 @@ newaction
 
     execute = function ()
 
-        files_to_delete = 
+        files_to_delete =
         {
             "Makefile",
             "*.make",
@@ -120,7 +125,7 @@ newaction
             "*.xcworkspace"
         }
 
-        directories_to_delete = 
+        directories_to_delete =
         {
             "obj",
             "ipch",

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -7,17 +7,17 @@
 
         1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer 
+        2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
            in the documentation and/or other materials provided with the distribution.
 
-        3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived 
+        3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived
            from this software without specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
     WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
@@ -31,7 +31,7 @@
 
 namespace yojimbo
 {
-    Server::Server( Allocator & allocator, const uint8_t privateKey[], const Address & address, const ClientServerConfig & config, Adapter & adapter, double time ) 
+    Server::Server( Allocator & allocator, const uint8_t privateKey[], const Address & address, const ClientServerConfig & config, Adapter & adapter, double time )
         : BaseServer( allocator, config, adapter, time )
     {
         yojimbo_assert( KeyBytes == NETCODE_KEY_BYTES );
@@ -52,12 +52,12 @@ namespace yojimbo
     {
         if ( IsRunning() )
             Stop();
-        
+
         BaseServer::Start( maxClients );
-        
+
         char addressString[MaxAddressLength];
         m_address.ToString( addressString, MaxAddressLength );
-        
+
         struct netcode_server_config_t netcodeConfig;
         netcode_default_server_config(&netcodeConfig);
         netcodeConfig.protocol_id = m_config.protocolId;
@@ -68,15 +68,15 @@ namespace yojimbo
         netcodeConfig.callback_context = this;
         netcodeConfig.connect_disconnect_callback = StaticConnectDisconnectCallbackFunction;
         netcodeConfig.send_loopback_packet_callback = StaticSendLoopbackPacketCallbackFunction;
-        
+
         m_server = netcode_server_create(addressString, &netcodeConfig, GetTime());
-        
+
         if ( !m_server )
         {
             Stop();
             return;
         }
-        
+
         netcode_server_start( m_server, maxClients );
 
         m_boundAddress.SetPort( netcode_server_get_port( m_server ) );
@@ -184,6 +184,11 @@ namespace yojimbo
     uint64_t Server::GetClientId( int clientIndex ) const
     {
         return netcode_server_client_id( m_server, clientIndex );
+    }
+
+    const uint8_t * Server::GetClientUserData( int clientIndex ) const
+    {
+        return (const uint8_t*)netcode_server_client_user_data( m_server, clientIndex );
     }
 
     netcode_address_t * Server::GetClientAddress( int clientIndex ) const


### PR DESCRIPTION
Hey there. I noticed there was no method exposed for that in `yojimbo` to access the userdata inside the connection token, so I added one.

I also noticed that my `userdata` bytes were "shifted" and including the trailing 12 bytes of the `ServerToClientKey` . After some debugging I realized that the `writeAddresses` function in the matcher code always increments the offset by 19, whether it is IPV4 or IPV6, but  `netcode` it reads only as many bytes as needed. So I fixed that too.

Cheers

