### PR TITLE
Remove redundant srand call

### DIFF
--- a/soak.cpp
+++ b/soak.cpp
@@ -41,8 +41,6 @@ static const int RELIABLE_ORDERED_CHANNEL = 1;
 
 int SoakMain()
 {
-    srand( (unsigned int) time( NULL ) );
-
     ClientServerConfig config;
     config.maxPacketSize = MaxPacketSize;
     config.clientMemory = 100 * 1024 * 1024;


### PR DESCRIPTION
It doesn't hurt anything but y'know.. made me do a double-take while reading. I left the other call in main(), since that's where srand() is called in all of the other tests.