### PR TITLE
NOMINMAX can be defined already on Windows, malloc.h is required when building without exceptions with MSVC

### DIFF
--- a/source/yojimbo_address.cpp
+++ b/source/yojimbo_address.cpp
@@ -28,7 +28,9 @@
 
 #if YOJIMBO_PLATFORM == YOJIMBO_PLATFORM_WINDOWS
 
+    #ifndef NOMINMAX
     #define NOMINMAX
+    #endif
     #define _WINSOCK_DEPRECATED_NO_WARNINGS
     #include <winsock2.h>
     #include <ws2tcpip.h>

--- a/source/yojimbo_platform.cpp
+++ b/source/yojimbo_platform.cpp
@@ -168,7 +168,9 @@ double yojimbo_time()
 //             Windows
 // ===============================
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 
 void yojimbo_sleep( double time )


### PR DESCRIPTION
Part of the changes discussed [here](https://github.com/mas-bandwidth/yojimbo/issues/203).

I am building on Windows with MSVC, MSYS2 gcc and clang. I will submit a pull request for https://github.com/mas-bandwidth/netcode too. For the github actions, I will open an issue instead, there are a couple of issues with it.