### PR TITLE
Adjust doxygen config to specify header file inputs

### DIFF
--- a/doxygen.config
+++ b/doxygen.config
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = include/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
The doxygen.config required an update after the following commit moved the source files around: https://github.com/mas-bandwidth/yojimbo/commit/fea263729484ccecff3a598c3623ed40f7ac3ee9

`$ doxygen doxygen.config` seems to produce a better result with this change.

Unsure if anything else may be required as I have no prior experience with doxygen or yojimbo.