### PR TITLE
Generate build targets for all Windows architectures

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -3,6 +3,9 @@ solution "Yojimbo"
     kind "ConsoleApp"
     language "C++"
     configurations { "Debug", "Release" }
+    if os.istarget "windows" then
+        platforms { "Win32", "x64", "ARM64" }
+    end
     includedirs { ".", "include", "sodium", "tlsf", "netcode", "reliable", "serialize" }
     if not os.istarget "windows" then
         targetdir "bin/"
@@ -18,6 +21,13 @@ solution "Yojimbo"
         symbols "Off"
         optimize "Speed"
         defines { "YOJIMBO_RELEASE", "NETCODE_RELEASE", "RELIABLE_RELEASE" }
+
+    filter "platforms:Win32"
+        architecture "x86"
+    filter "platforms:x64"
+        architecture "x86_64"
+    filter "platforms:ARM64"
+        architecture "ARM64"
 
 project "sodium-builtin"
     kind "StaticLib"


### PR DESCRIPTION
Premake5 generates a Visual Studio solution targeting Win32 by default. It can be made to target x64 by passing --arch=x86_64 but --arch=arm64 has no effect. These changes introduce a premake platform per Windows architecture (Win32, x64 and ARM64) so the Visual Studio solution generated can target them all.