### PR TITLE
Fix sodium build error in x64

### DIFF
--- a/sodium/sodium_utils.h
+++ b/sodium/sodium_utils.h
@@ -73,7 +73,7 @@ int sodium_hex2bin(unsigned char * const bin, const size_t bin_maxlen,
 #define sodium_base64_ENCODED_LEN(BIN_LEN, VARIANT) \
     (((BIN_LEN) / 3U) * 4U + \
     ((((BIN_LEN) - ((BIN_LEN) / 3U) * 3U) | (((BIN_LEN) - ((BIN_LEN) / 3U) * 3U) >> 1)) & 1U) * \
-     (4U - (~((((VARIANT) & 2U) >> 1) - 1U) & (3U - ((BIN_LEN) - ((BIN_LEN) / 3U) * 3U)))) + 1U)
+     (4U - ((size_t) ~((((VARIANT) & 2U) >> 1) - 1U) & (3U - ((BIN_LEN) - ((BIN_LEN) / 3U) * 3U)))) + 1U)
 
 size_t sodium_base64_encoded_len(const size_t bin_len, const int variant);
 

--- a/sodium/sodium_utils.h
+++ b/sodium/sodium_utils.h
@@ -73,7 +73,7 @@ int sodium_hex2bin(unsigned char * const bin, const size_t bin_maxlen,
 #define sodium_base64_ENCODED_LEN(BIN_LEN, VARIANT) \
     (((BIN_LEN) / 3U) * 4U + \
     ((((BIN_LEN) - ((BIN_LEN) / 3U) * 3U) | (((BIN_LEN) - ((BIN_LEN) / 3U) * 3U) >> 1)) & 1U) * \
-     (4U - ((size_t) ~((((VARIANT) & 2U) >> 1) - 1U) & (3U - ((BIN_LEN) - ((BIN_LEN) / 3U) * 3U)))) + 1U)
+     (4U - ((0U - (((VARIANT) & 2U) >> 1)) & (3U - ((BIN_LEN) - ((BIN_LEN) / 3U) * 3U)))) + 1U)
 
 size_t sodium_base64_encoded_len(const size_t bin_len, const int variant);
 


### PR DESCRIPTION
We're getting the following error when building for x64 on Windows via the VS solution generated by premake:

```
..\sodium_codecs.c(175,12): error C2220: the following warning is treated as an error
..\sodium_codecs.c(175,12): warning C4319: '~': zero extending 'unsigned int' to 'const size_t' of greater size
```

This commit integrates the fix from the upstream repo. See https://github.com/jedisct1/libsodium/issues/1526.
