### PR TITLE
Add asserts when network simulator settings are applied too early

### DIFF
--- a/soak.cpp
+++ b/soak.cpp
@@ -62,24 +62,24 @@ int SoakMain()
 
     Server server( GetDefaultAllocator(), privateKey, serverAddress, config, adapter, time );
 
+    server.Start( 1 );
+
     server.SetLatency( 1000.0f );
     server.SetJitter( 100.0f );
     server.SetPacketLoss( 25.0f );
     server.SetDuplicates( 25.0f );
-
-    server.Start( 1 );
 
     uint64_t clientId = 0;
     yojimbo_random_bytes( (uint8_t*) &clientId, 8 );
 
     Client client( GetDefaultAllocator(), Address("0.0.0.0"), config, adapter, time );
 
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
     client.SetLatency( 1000.0f );
     client.SetJitter( 100.0f );
     client.SetPacketLoss( 25.0f );
     client.SetDuplicates( 25.0f );
-
-    client.InsecureConnect( privateKey, clientId, serverAddress );
 
     uint64_t numMessagesSentToServer = 0;
     uint64_t numMessagesSentToClient = 0;

--- a/source/yojimbo_base_client.cpp
+++ b/source/yojimbo_base_client.cpp
@@ -90,6 +90,7 @@ namespace yojimbo
 
     void BaseClient::SetLatency( float milliseconds )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetLatency( milliseconds );
@@ -98,6 +99,7 @@ namespace yojimbo
 
     void BaseClient::SetJitter( float milliseconds )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetJitter( milliseconds );
@@ -106,6 +108,7 @@ namespace yojimbo
 
     void BaseClient::SetPacketLoss( float percent )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetPacketLoss( percent );
@@ -114,6 +117,7 @@ namespace yojimbo
 
     void BaseClient::SetDuplicates( float percent )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetDuplicates( percent );

--- a/source/yojimbo_base_server.cpp
+++ b/source/yojimbo_base_server.cpp
@@ -173,6 +173,7 @@ namespace yojimbo
 
     void BaseServer::SetLatency( float milliseconds )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetLatency( milliseconds );
@@ -181,6 +182,7 @@ namespace yojimbo
 
     void BaseServer::SetJitter( float milliseconds )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetJitter( milliseconds );
@@ -189,6 +191,7 @@ namespace yojimbo
 
     void BaseServer::SetPacketLoss( float percent )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetPacketLoss( percent );
@@ -197,6 +200,7 @@ namespace yojimbo
 
     void BaseServer::SetDuplicates( float percent )
     {
+        yojimbo_assert( m_networkSimulator );
         if ( m_networkSimulator )
         {
             m_networkSimulator->SetDuplicates( percent );

--- a/test.cpp
+++ b/test.cpp
@@ -1320,11 +1320,6 @@ void test_client_server_messages()
 
     server.Start( MaxClients );
 
-    client.SetLatency( 250 );
-    client.SetJitter( 100 );
-    client.SetPacketLoss( 25 );
-    client.SetDuplicates( 25 );
-
     server.SetLatency( 250 );
     server.SetJitter( 100 );
     server.SetPacketLoss( 25 );
@@ -1335,6 +1330,11 @@ void test_client_server_messages()
         // connect and wait until connection completes
 
         client.InsecureConnect( privateKey, clientId, serverAddress );
+
+        client.SetLatency( 250 );
+        client.SetJitter( 100 );
+        client.SetPacketLoss( 25 );
+        client.SetDuplicates( 25 );
 
         const int NumIterations = 10000;
 
@@ -1420,10 +1420,6 @@ void CreateClients( int numClients, Client ** clients, const Address & address, 
     for ( int i = 0; i < numClients; ++i )
     {
         clients[i] = YOJIMBO_NEW( GetDefaultAllocator(), Client, GetDefaultAllocator(), address, config, _adapter, time );
-        clients[i]->SetLatency( 250 );
-        clients[i]->SetJitter( 100 );
-        clients[i]->SetPacketLoss( 25 );
-        clients[i]->SetDuplicates( 25 );
     }
 }
 
@@ -1432,6 +1428,10 @@ void ConnectClients( int numClients, Client ** clients, const uint8_t privateKey
     for ( int i = 0; i < numClients; ++i )
     {
         clients[i]->InsecureConnect( privateKey, i + 1, serverAddress );
+        clients[i]->SetLatency( 250 );
+        clients[i]->SetJitter( 100 );
+        clients[i]->SetPacketLoss( 25 );
+        clients[i]->SetDuplicates( 25 );
     }
 }
 
@@ -1488,11 +1488,6 @@ void test_client_server_start_stop_restart()
 
     Server server( GetDefaultAllocator(), privateKey, serverAddress, config, adapter, time );
 
-    server.SetLatency( 250 );
-    server.SetJitter( 100 );
-    server.SetPacketLoss( 25 );
-    server.SetDuplicates( 25 );
-
     int numClients[] = { 3, 5, 1, 32, 5 };
 
     const int NumIterations = sizeof( numClients ) / sizeof( int );
@@ -1506,6 +1501,11 @@ void test_client_server_start_stop_restart()
         }        
 
         server.Start( numClients[iteration] );
+
+        server.SetLatency( 250 );
+        server.SetJitter( 100 );
+        server.SetPacketLoss( 25 );
+        server.SetDuplicates( 25 );
 
         Client * clients[MaxClients];
 


### PR DESCRIPTION
Fixes #213

## Problem

`SetLatency` / `SetJitter` / `SetPacketLoss` / `SetDuplicates` on `BaseClient` and `BaseServer` silently do nothing when called before the network simulator exists. The simulator is created in client connect / server `Start()` (and destroyed on disconnect / `Stop()`), so any settings applied too early are dropped without warning.

Several call sites in this repo hit this: for example soak.cpp configured the simulator before `Start()` / `InsecureConnect()`, so the soak test was actually running on a clean network instead of the intended 1000ms latency / 25% packet loss.

## Changes

- Add `yojimbo_assert( m_networkSimulator )` at the top of all eight setters in `BaseClient` and `BaseServer`, as suggested in the issue, so this misuse fails loudly in debug builds. Release behavior is unchanged (the existing NULL checks remain).
- Fix all call sites that applied settings too early, using the new asserts to find them:
  - test.cpp: `test_client_server_messages`, `test_client_server_start_stop_restart`, and the shared `CreateClients` / `ConnectClients` helpers. Settings are now applied after connect / `Start()`, and re-applied per restart iteration since the simulator is destroyed on `Stop()` / disconnect.
  - soak.cpp: same reordering.

## Verification

- `./bin/test` (debug): ALL TESTS PASS, with the asserts active.
- `./bin/soak` (debug): runs with the simulator settings actually applied.
- Release config builds clean (asserts compile out, NULL-check behavior preserved).
