### PR TITLE
[docs] Add INSTALL file with Conan instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,17 @@
+Installing yojimbo
+==================
+
+The Yojimbo library can be installed in several ways,
+depending on your needs and preferences.
+Below are the instructions for installing yojimbo using package managers.
+
+## Installing via Conan
+
+yojimbo is available on [Conan Center](https://conan.io/center/recipes/yojimbo).
+
+First, install the dependencies:
+
+    conan install --requires="yojimbo/[*]" --build=missing
+
+The yojimbo package in Conan Center is maintained by the ConanCenterIndex community.
+To report an outdated version or a packaging issue, please open an issue at https://github.com/conan-io/conan-center-index.


### PR DESCRIPTION
Greetings!

The Yojimbo project is now available on conan.io via https://github.com/conan-io/conan-center-index/pull/27827. See https://conan.io/center/recipes/yojimbo?version=1.2.1 for extra information in the web interface.

I opened this new PR to provide a chance for users to learn how to install Yojimbo using Conan. So, avoiding all the manual build steps, including managing dependencies.

The pattern `yojimbo/[*]` indicates "the latest version available".

Please let me know if it's okay, or if I should move it to another place. Regards!