### PR TITLE
Reject messages that are too large to ever fit in a packet

### DIFF
--- a/include/yojimbo_channel.h
+++ b/include/yojimbo_channel.h
@@ -102,6 +102,7 @@ namespace yojimbo
         CHANNEL_ERROR_BLOCKS_DISABLED,                          ///< The channel received a packet containing data for blocks, but this channel is configured to disable blocks. See ChannelConfig::disableBlocks.
         CHANNEL_ERROR_FAILED_TO_SERIALIZE,                      ///< Serialize read failed for a message sent to this channel. Check your message serialize functions, one of them is returning false on serialize read. This can also be caused by a desync in message read and write.
         CHANNEL_ERROR_OUT_OF_MEMORY,                            ///< The channel tried to allocate some memory but couldn't.
+        CHANNEL_ERROR_MESSAGE_TOO_LARGE,                        ///< The user tried to send a message that is too large to ever fit into a packet for this channel. Large data should be sent as a block message instead. This will assert out in development, but in production it sets this error on the channel.
     };
 
     /// Helper function to convert a channel error to a user friendly string.
@@ -116,6 +117,7 @@ namespace yojimbo
             case CHANNEL_ERROR_OUT_OF_MEMORY:           return "out of memory";
             case CHANNEL_ERROR_BLOCKS_DISABLED:         return "blocks disabled";
             case CHANNEL_ERROR_FAILED_TO_SERIALIZE:     return "failed to serialize";
+            case CHANNEL_ERROR_MESSAGE_TOO_LARGE:       return "message too large";
             default:
                 yojimbo_assert( false );
                 return "(unknown)";
@@ -132,7 +134,7 @@ namespace yojimbo
             Channel constructor.
          */
 
-        Channel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int channelIndex, double time );
+        Channel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int maxPacketSize, int channelIndex, double time );
 
         /**
             Channel destructor.
@@ -255,6 +257,7 @@ namespace yojimbo
     protected:
 
         const ChannelConfig m_config;                                                   ///< Channel configuration data.
+        const int m_maxPacketSize;                                                      ///< The maximum packet size in bytes (from ConnectionConfig::maxPacketSize). Used to detect messages that are too large to ever fit into a packet.
         Allocator * m_allocator;                                                        ///< Allocator for allocations matching life cycle of this channel.
         int m_channelIndex;                                                             ///< The channel index in [0,numChannels-1].
         double m_time;                                                                  ///< The current time.

--- a/include/yojimbo_reliable_ordered_channel.h
+++ b/include/yojimbo_reliable_ordered_channel.h
@@ -49,10 +49,11 @@ namespace yojimbo
             @param allocator The allocator to use.
             @param messageFactory Message factory for creating and destroying messages.
             @param config The configuration for this channel.
+            @param maxPacketSize The maximum packet size in bytes (see ConnectionConfig::maxPacketSize).
             @param channelIndex The channel index in [0,numChannels-1].
          */
 
-        ReliableOrderedChannel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int channelIndex, double time );
+        ReliableOrderedChannel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int maxPacketSize, int channelIndex, double time );
 
         /**
             Reliable ordered channel destructor.

--- a/include/yojimbo_unreliable_unordered_channel.h
+++ b/include/yojimbo_unreliable_unordered_channel.h
@@ -41,7 +41,7 @@ namespace yojimbo
     public:
 
         /**
-            Reliable ordered channel constructor.
+            Unreliable unordered channel constructor.
             @param allocator The allocator to use.
             @param messageFactory Message factory for creating and destroying messages.
             @param config The configuration for this channel.

--- a/include/yojimbo_unreliable_unordered_channel.h
+++ b/include/yojimbo_unreliable_unordered_channel.h
@@ -45,10 +45,11 @@ namespace yojimbo
             @param allocator The allocator to use.
             @param messageFactory Message factory for creating and destroying messages.
             @param config The configuration for this channel.
+            @param maxPacketSize The maximum packet size in bytes (see ConnectionConfig::maxPacketSize).
             @param channelIndex The channel index in [0,numChannels-1].
          */
 
-        UnreliableUnorderedChannel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int channelIndex, double time );
+        UnreliableUnorderedChannel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int maxPacketSize, int channelIndex, double time );
 
         /**
             Unreliable unordered channel destructor.

--- a/source/yojimbo_channel.cpp
+++ b/source/yojimbo_channel.cpp
@@ -419,7 +419,7 @@ namespace yojimbo
 
     // ------------------------------------------------------------------------------------
 
-    Channel::Channel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int channelIndex, double time ) : m_config( config )
+    Channel::Channel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, const int maxPacketSize, int channelIndex, double time ) : m_config( config ), m_maxPacketSize( maxPacketSize )
     {
         yojimbo_assert( channelIndex >= 0 );
         yojimbo_assert( channelIndex < MaxChannels );

--- a/source/yojimbo_connection.cpp
+++ b/source/yojimbo_connection.cpp
@@ -125,6 +125,7 @@ namespace yojimbo
                                                            *m_allocator, 
                                                            messageFactory, 
                                                            m_connectionConfig.channel[channelIndex],
+                                                           m_connectionConfig.maxPacketSize,
                                                            channelIndex, 
                                                            time ); 
                 }
@@ -136,7 +137,8 @@ namespace yojimbo
                                                            UnreliableUnorderedChannel, 
                                                            *m_allocator, 
                                                            messageFactory, 
-                                                           m_connectionConfig.channel[channelIndex], 
+                                                           m_connectionConfig.channel[channelIndex],
+                                                           m_connectionConfig.maxPacketSize,
                                                            channelIndex, 
                                                            time ); 
                 }

--- a/source/yojimbo_reliable_ordered_channel.cpp
+++ b/source/yojimbo_reliable_ordered_channel.cpp
@@ -27,8 +27,8 @@
 
 namespace yojimbo
 {
-    ReliableOrderedChannel::ReliableOrderedChannel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, int channelIndex, double time ) 
-        : Channel( allocator, messageFactory, config, channelIndex, time )
+    ReliableOrderedChannel::ReliableOrderedChannel( Allocator & allocator, MessageFactory & messageFactory, const ChannelConfig & config, const int maxPacketSize, int channelIndex, double time )
+        : Channel( allocator, messageFactory, config, maxPacketSize, channelIndex, time )
     {
         yojimbo_assert( config.type == CHANNEL_TYPE_RELIABLE_ORDERED );
 
@@ -154,6 +154,27 @@ namespace yojimbo
 
         message->SetId( m_sendMessageId );
 
+        MeasureStream measureStream;
+        measureStream.SetContext( context );
+        measureStream.SetAllocator( &m_messageFactory->GetAllocator() );
+        message->SerializeInternal( measureStream );
+
+        const int measuredBits = measureStream.GetBitsProcessed();
+
+        const bool isOverBudget = m_config.packetBudget > 0 && measuredBits > m_config.packetBudget * 8;
+        const bool isOverPacketSize = measuredBits > m_maxPacketSize * 8;
+        const bool isTooLarge = ( isOverBudget || isOverPacketSize ) && !message->IsBlockMessage();
+
+        yojimbo_assert( !isTooLarge );
+
+        if ( isTooLarge )
+        {
+            // You tried to send a message that is too large to ever fit into a packet for this channel. Large data should be sent as a block message instead.
+            SetErrorLevel( CHANNEL_ERROR_MESSAGE_TOO_LARGE );
+            m_messageFactory->ReleaseMessage( message );
+            return;
+        }
+
         MessageSendQueueEntry * entry = m_messageSendQueue->Insert( m_sendMessageId );
 
         yojimbo_assert( entry );
@@ -169,11 +190,7 @@ namespace yojimbo
             yojimbo_assert( ((BlockMessage*)message)->GetBlockSize() <= m_config.maxBlockSize );
         }
 
-        MeasureStream measureStream;
-		measureStream.SetContext( context );
-        measureStream.SetAllocator( &m_messageFactory->GetAllocator() );
-        message->SerializeInternal( measureStream );
-        entry->measuredBits = measureStream.GetBitsProcessed();
+        entry->measuredBits = measuredBits;
         m_counters[CHANNEL_COUNTER_MESSAGES_SENT]++;
         m_sendMessageId++;
     }
@@ -264,9 +281,6 @@ namespace yojimbo
         uint16_t previousMessageId = 0;
         int usedBits = ConservativeMessageHeaderBits;
         int giveUpCounter = 0;
-#ifdef YOJIMBO_DEBUG
-        const int maxBits = availableBits;
-#endif // YOJIMBO_DEBUG
 
         for ( int i = 0; i < messageLimit; ++i )
         {
@@ -284,8 +298,8 @@ namespace yojimbo
             if ( entry->block )
                 break;
 
-            // Increase your max packet size!
-            yojimbo_assert( entry->measuredBits <= uint32_t(maxBits) );
+            // Messages that are too large to fit in a packet are rejected in SendMessage()
+            yojimbo_assert( (m_config.packetBudget <= 0 || entry->measuredBits <= uint32_t(m_config.packetBudget * 8)) && entry->measuredBits <= uint32_t(m_maxPacketSize * 8) );
             
             if ( entry->timeLastSent + m_config.messageResendTime <= m_time && availableBits >= (int) entry->measuredBits )
             {                

--- a/source/yojimbo_unreliable_unordered_channel.cpp
+++ b/source/yojimbo_unreliable_unordered_channel.cpp
@@ -29,12 +29,14 @@ namespace yojimbo
 {
     UnreliableUnorderedChannel::UnreliableUnorderedChannel( Allocator & allocator, 
                                                             MessageFactory & messageFactory, 
-                                                            const ChannelConfig & config, 
+                                                            const ChannelConfig & config,
+                                                            const int maxPacketSize,
                                                             int channelIndex, 
                                                             double time ) 
         : Channel( allocator, 
                    messageFactory, 
-                   config, 
+                   config,
+                   maxPacketSize,
                    channelIndex, 
                    time )
     {
@@ -181,6 +183,20 @@ namespace yojimbo
             }
 
             const int messageBits = messageTypeBits + measureStream.GetBitsProcessed();
+
+            const bool isOverBudget = m_config.packetBudget > 0 && messageBits > m_config.packetBudget * 8;
+            const bool isOverPacketSize = messageBits > m_maxPacketSize * 8;
+            const bool isTooLarge = isOverBudget || isOverPacketSize;
+
+            yojimbo_assert( !isTooLarge );
+
+            if ( isTooLarge )
+            {
+                // You tried to send a message that is too large to ever fit into a packet for this channel. Large data should be sent as a block message over a reliable-ordered channel.
+                SetErrorLevel( CHANNEL_ERROR_MESSAGE_TOO_LARGE );
+                m_messageFactory->ReleaseMessage( message );
+                break;
+            }
             
             if ( usedBits + messageBits > availableBits )
             {


### PR DESCRIPTION
Fixes #216, following the approach discussed there.

## Changes

- New `CHANNEL_ERROR_MESSAGE_TOO_LARGE` error level (appended at the end of `ChannelErrorLevel`).
- Channels now receive `ConnectionConfig::maxPacketSize` through their constructor, so they can tell when a message can never fit.
- `ReliableOrderedChannel::SendMessage`: oversized regular messages are rejected when queued — assert in development, error level in production, same pattern as `CHANNEL_ERROR_SEND_QUEUE_FULL`. Block messages are exempt since they go through the fragment/resend path.
- `UnreliableUnorderedChannel::GetPacketData`: at the existing drop site, "does not fit in this packet" (normal, still dropped silently) is now distinguished from "can never fit in any packet" (assert + error level). Block messages are not exempt here, since on unreliable channels blocks must fit within the packet size (as documented in `ChannelConfig`).
- The misleading "Increase your max packet size!" assert in `GetMessagesToSend` is replaced by one that checks the invariant the send-time check establishes, and the stale `maxBits` debug variable is removed.

One deviation from the plan in #216: I proposed setting the error level in `GetMessagesToSend` for the reliable channel, but since channels now know the max packet size, the whole check could move to `SendMessage`, which is simpler and reports the misuse at the call site. `GetMessagesToSend` keeps an assert as a regression backstop.

The second commit fixes a copy-paste in the `UnreliableUnorderedChannel` constructor comment ("Reliable ordered channel constructor"), noticed while editing that header.

## Verification

- `./bin/test` passes in both debug and release configs.
- Reproduced the failure mode locally (temporarily setting `maxPacketSize = 4` in soak.cpp): debug builds now fail loudly at the `SendMessage` assert instead of stalling silently.
