### PR TITLE
Fix network-simulator duplicate-packet leak and block fragment-count overflow

### DIFF
--- a/include/yojimbo_config.h
+++ b/include/yojimbo_config.h
@@ -152,7 +152,11 @@ namespace yojimbo
 
         int GetMaxFragmentsPerBlock() const
         {
-            return maxBlockSize / blockFragmentSize;
+            // Round up: a block of maxBlockSize needs ceil(maxBlockSize/blockFragmentSize)
+            // fragments. Using floor here under-sizes the send-side fragment buffers when
+            // maxBlockSize is not a multiple of blockFragmentSize (see GetFragmentToSend,
+            // which counts fragments with ceil).
+            return ( maxBlockSize + blockFragmentSize - 1 ) / blockFragmentSize;
         }
     };
 

--- a/source/yojimbo_network_simulator.cpp
+++ b/source/yojimbo_network_simulator.cpp
@@ -105,6 +105,11 @@ namespace yojimbo
         if ( yojimbo_random_float( 0.0f, 100.0f ) <= m_duplicates )
         {
             PacketEntry & nextPacketEntry = m_packetEntries[m_currentIndex];
+            if ( nextPacketEntry.packetData )
+            {
+                YOJIMBO_FREE( *m_allocator, nextPacketEntry.packetData );
+                nextPacketEntry = PacketEntry();
+            }
             nextPacketEntry.to = to;
             nextPacketEntry.packetData = (uint8_t*) YOJIMBO_ALLOCATE( *m_allocator, packetBytes );
             memcpy( nextPacketEntry.packetData, packetData, packetBytes );

--- a/test.cpp
+++ b/test.cpp
@@ -754,6 +754,78 @@ void test_connection_reliable_ordered_blocks()
     check( numMessagesReceived == NumMessagesSent );
 }
 
+void test_connection_reliable_ordered_blocks_max_size()
+{
+    // Regression test: when maxBlockSize is not a multiple of blockFragmentSize, a
+    // full-size block needs ceil(maxBlockSize/blockFragmentSize) fragments. The
+    // send-side fragment buffers used to be sized with floor division, so sending a
+    // maxBlockSize block overflowed them. Here 1100/500 => floor 2, ceil 3.
+    TestMessageFactory messageFactory( GetDefaultAllocator() );
+
+    double time = 100.0;
+
+    ConnectionConfig connectionConfig;
+    connectionConfig.channel[ReliableChannel].maxBlockSize = 1100;
+    connectionConfig.channel[ReliableChannel].blockFragmentSize = 500;
+
+    Connection sender( GetDefaultAllocator(), messageFactory, connectionConfig, time );
+    Connection receiver( GetDefaultAllocator(), messageFactory, connectionConfig, time );
+
+    const int NumMessagesSent = 8;
+    const int BlockSize = connectionConfig.channel[ReliableChannel].maxBlockSize;
+
+    for ( int i = 0; i < NumMessagesSent; ++i )
+    {
+        TestBlockMessage * message = (TestBlockMessage*) messageFactory.CreateMessage( TEST_BLOCK_MESSAGE );
+        check( message );
+        message->sequence = i;
+        uint8_t * blockData = (uint8_t*) YOJIMBO_ALLOCATE( messageFactory.GetAllocator(), BlockSize );
+        for ( int j = 0; j < BlockSize; ++j )
+            blockData[j] = uint8_t( i + j );
+        message->AttachBlock( messageFactory.GetAllocator(), blockData, BlockSize );
+        sender.SendMessage( ReliableChannel, message );
+    }
+
+    int numMessagesReceived = 0;
+    uint16_t senderSequence = 0;
+    uint16_t receiverSequence = 0;
+    const int NumIterations = 10000;
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        PumpConnectionUpdate( connectionConfig, time, sender, receiver, senderSequence, receiverSequence );
+
+        while ( true )
+        {
+            Message * message = receiver.ReceiveMessage( ReliableChannel );
+            if ( !message )
+                break;
+
+            check( message->GetId() == (int) numMessagesReceived );
+            check( message->GetType() == TEST_BLOCK_MESSAGE );
+
+            TestBlockMessage * blockMessage = (TestBlockMessage*) message;
+            check( blockMessage->sequence == uint16_t( numMessagesReceived ) );
+
+            const int blockSize = blockMessage->GetBlockSize();
+            check( blockSize == BlockSize );
+
+            const uint8_t * blockData = blockMessage->GetBlockData();
+            check( blockData );
+            for ( int j = 0; j < blockSize; ++j )
+                check( blockData[j] == uint8_t( numMessagesReceived + j ) );
+
+            ++numMessagesReceived;
+            messageFactory.ReleaseMessage( message );
+        }
+
+        if ( numMessagesReceived == NumMessagesSent )
+            break;
+    }
+
+    check( numMessagesReceived == NumMessagesSent );
+}
+
 void test_connection_reliable_ordered_messages_and_blocks()
 {
     TestMessageFactory messageFactory( GetDefaultAllocator() );
@@ -2533,6 +2605,7 @@ int main()
 
         RUN_TEST( test_connection_reliable_ordered_messages );
         RUN_TEST( test_connection_reliable_ordered_blocks );
+        RUN_TEST( test_connection_reliable_ordered_blocks_max_size );
         RUN_TEST( test_connection_reliable_ordered_messages_and_blocks );
         RUN_TEST( test_connection_reliable_ordered_messages_and_blocks_multiple_channels );
         RUN_TEST( test_connection_unreliable_unordered_messages );


### PR DESCRIPTION
Two bugs found while auditing the library.

## 1. Memory leak in the network simulator's duplicate-packet path

`NetworkSimulator::SendPacket` ([source/yojimbo_network_simulator.cpp](source/yojimbo_network_simulator.cpp)) frees any packet already occupying the ring slot before writing a new one on the **normal** path:

```cpp
if ( packetEntry.packetData ) { YOJIMBO_FREE( *m_allocator, packetEntry.packetData ); packetEntry = PacketEntry(); }
```

…but the **duplicate** branch allocated straight over `nextPacketEntry.packetData` with no such guard. With duplicates enabled and the ring wrapping onto a slot that still holds an undelivered packet, that buffer leaks. Fixed by mirroring the free-before-overwrite guard.

## 2. Block fragment-count overflow when maxBlockSize isn't a multiple of blockFragmentSize

`ChannelConfig::GetMaxFragmentsPerBlock()` ([include/yojimbo_config.h](include/yojimbo_config.h)) used floor division:

```cpp
return maxBlockSize / blockFragmentSize;
```

but a block is split into `ceil(blockSize / blockFragmentSize)` fragments (see `GetFragmentToSend`). `SendBlockData` sizes its `ackedFragment` bit array and `fragmentSendTime` array from `GetMaxFragmentsPerBlock()`. So when `maxBlockSize` is not a multiple of `blockFragmentSize`, sending a near-max block produces more fragments than those buffers hold — **a debug assert in `GetFragmentToSend`, and out-of-bounds heap writes in release**. Fixed by rounding up. The receive path was already bounded by the serialize limits, so this is a send-side fix.

Example: `maxBlockSize = 1100`, `blockFragmentSize = 500` → floor gives 2 but a full block needs 3 fragments. (yojimbo's own test suite already used non-divisible configs like 1024/200, but only ever sent small blocks, so it never hit the boundary.)

## Test

Adds `test_connection_reliable_ordered_blocks_max_size`, which sends full-size blocks over a channel whose `maxBlockSize` (1100) is not a multiple of `blockFragmentSize` (500). It **traps on the old code** (exit 133, the fragment-count assert) and **passes with the fix**. Full suite passes in debug and release.

## Notes

- Independent of the sodium PRs (#252/#253); branches off `main`.
- No wire-format concern in practice: both ends run the same build, and `GetMaxFragmentsPerBlock()` only affects the fragment-count field width, which changes only for previously-unsendable configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)