### PR TITLE
Add GitHub Actions CI (Linux, macOS, Windows, sanitizers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install premake5
         run: |
           curl -fsSL "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-${{ matrix.premake }}.tar.gz" | tar xz
+          chmod +x premake5
           echo "$PWD" >> "$GITHUB_PATH"
       - name: Generate makefiles
         run: premake5 gmake
@@ -50,6 +51,7 @@ jobs:
       - name: Install premake5
         run: |
           curl -fsSL "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-linux.tar.gz" | tar xz
+          chmod +x premake5
           echo "$PWD" >> "$GITHUB_PATH"
       - name: Generate makefiles (system libsodium)
         run: premake5 gmake --sodium=system
@@ -66,6 +68,7 @@ jobs:
       - name: Install premake5
         run: |
           curl -fsSL "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-linux.tar.gz" | tar xz
+          chmod +x premake5
           echo "$PWD" >> "$GITHUB_PATH"
       - name: Generate makefiles
         run: premake5 gmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  PREMAKE_VERSION: "5.0.0-beta8"
+
+jobs:
+  build-test:
+    name: build & test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            premake: linux
+          - os: macos-latest
+            premake: macosx
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install premake5
+        run: |
+          curl -fsSL "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-${{ matrix.premake }}.tar.gz" | tar xz
+          echo "$PWD" >> "$GITHUB_PATH"
+      - name: Generate makefiles
+        run: premake5 gmake
+      - name: Build (debug)
+        run: make -j config=debug
+      - name: Test (debug)
+        run: ./bin/test
+      - name: Build (release)
+        run: make -j config=release
+      - name: Test (release)
+        run: ./bin/test
+
+  system-sodium:
+    name: build & test (linux, --sodium=system)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install libsodium
+        run: sudo apt-get update && sudo apt-get install -y libsodium-dev
+      - name: Install premake5
+        run: |
+          curl -fsSL "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-linux.tar.gz" | tar xz
+          echo "$PWD" >> "$GITHUB_PATH"
+      - name: Generate makefiles (system libsodium)
+        run: premake5 gmake --sodium=system
+      - name: Build (debug)
+        run: make -j config=debug
+      - name: Test (debug)
+        run: ./bin/test
+
+  sanitizers:
+    name: sanitizers (linux, ASan+UBSan+LSan)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install premake5
+        run: |
+          curl -fsSL "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-linux.tar.gz" | tar xz
+          echo "$PWD" >> "$GITHUB_PATH"
+      - name: Generate makefiles
+        run: premake5 gmake
+      - name: Build (sanitized)
+        # nonnull-attribute is excluded: netcode encrypts zero-length plaintexts, and
+        # libsodium's AEAD then does memcpy(dst, NULL, 0) — benign UB in upstream code.
+        run: |
+          SAN="-fsanitize=address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
+          make -j config=debug test CC=clang CXX=clang++ \
+            CFLAGS="$SAN" CXXFLAGS="$SAN" LDFLAGS="-fsanitize=address,undefined"
+      - name: Test (sanitized)
+        run: ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./bin/test
+
+  windows:
+    name: build & test (windows, MSVC)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate solution (premake vs2022)
+        shell: bash
+        run: |
+          curl -fsSL -o premake.zip "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-windows.zip"
+          unzip -o premake.zip
+          ./premake5.exe vs2022
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Build (debug x64)
+        run: msbuild Yojimbo.sln /p:Configuration=Debug /p:Platform=x64 /m
+      - name: Test (debug x64)
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Recurse -Filter test.exe | Select-Object -First 1
+          if (-not $exe) { Write-Error "test.exe not found"; exit 1 }
+          Write-Host "Running $($exe.FullName)"
+          & $exe.FullName
+          exit $LASTEXITCODE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,19 @@ env:
 
 jobs:
   build-test:
-    name: build & test (${{ matrix.os }})
+    name: build & test (${{ matrix.label }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
+            label: linux x86-64
             premake: linux
-          - os: macos-latest
+          - os: macos-13
+            label: macOS x86-64 (Intel)
+            premake: macosx-x64
+          - os: macos-14
+            label: macOS arm64 (Apple Silicon)
             premake: macosx
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,9 +46,37 @@ jobs:
       - name: Test (release)
         run: ./bin/test
 
+  windows:
+    name: build & test (windows MSVC x64, ${{ matrix.config }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate solution (premake vs2022)
+        shell: bash
+        run: |
+          curl -fsSL -o premake.zip "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-windows.zip"
+          unzip -o premake.zip
+          ./premake5.exe vs2022
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Build (${{ matrix.config }} x64)
+        run: msbuild Yojimbo.sln /p:Configuration=${{ matrix.config }} /p:Platform=x64 /m
+      - name: Test (${{ matrix.config }} x64)
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Recurse -Filter test.exe | Select-Object -First 1
+          if (-not $exe) { Write-Error "test.exe not found"; exit 1 }
+          Write-Host "Running $($exe.FullName)"
+          & $exe.FullName
+          exit $LASTEXITCODE
+
   system-sodium:
     name: build & test (linux, --sodium=system)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install libsodium
@@ -59,10 +92,14 @@ jobs:
         run: make -j config=debug
       - name: Test (debug)
         run: ./bin/test
+      - name: Build (release)
+        run: make -j config=release
+      - name: Test (release)
+        run: ./bin/test
 
   sanitizers:
     name: sanitizers (linux, ASan+UBSan+LSan)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install premake5
@@ -81,27 +118,3 @@ jobs:
             CFLAGS="$SAN" CXXFLAGS="$SAN" LDFLAGS="-fsanitize=address,undefined"
       - name: Test (sanitized)
         run: ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./bin/test
-
-  windows:
-    name: build & test (windows, MSVC)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Generate solution (premake vs2022)
-        shell: bash
-        run: |
-          curl -fsSL -o premake.zip "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-windows.zip"
-          unzip -o premake.zip
-          ./premake5.exe vs2022
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-      - name: Build (debug x64)
-        run: msbuild Yojimbo.sln /p:Configuration=Debug /p:Platform=x64 /m
-      - name: Test (debug x64)
-        shell: pwsh
-        run: |
-          $exe = Get-ChildItem -Recurse -Filter test.exe | Select-Object -First 1
-          if (-not $exe) { Write-Error "test.exe not found"; exit 1 }
-          Write-Host "Running $($exe.FullName)"
-          & $exe.FullName
-          exit $LASTEXITCODE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ jobs:
           - os: ubuntu-24.04
             label: linux x86-64
             premake: linux
-          - os: macos-13
-            label: macOS x86-64 (Intel)
-            premake: macosx-x64
+          # macOS x86-64 (Intel, macos-13) temporarily disabled — runner is slow to allocate.
           - os: macos-14
             label: macOS arm64 (Apple Silicon)
             premake: macosx


### PR DESCRIPTION
Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that builds and tests on every push to `main` and on PRs.

## Jobs

- **build-test** — Linux and macOS, debug **and** release, bundled libsodium (the default). Runs `premake5 gmake && make && ./bin/test`.
- **system-sodium** — Linux with `--sodium=system` + `libsodium-dev`, so both libsodium link paths stay green.
- **sanitizers** — Linux ASan + UBSan + LSan run of the suite. This is the highest-value job: it's the class of check that would have automatically caught all three bugs found this session (the BitReader alignment UB, the block fragment-count heap overflow, and the network-simulator leak). It excludes only `nonnull-attribute`, which fires benignly on libsodium's `memcpy(dst, NULL, 0)` when netcode encrypts a zero-length AEAD plaintext (upstream behaviour, not a real bug).
- **windows** — MSVC via `premake vs2022` + msbuild (x64 debug), which also exercises the bundled libsodium on the one platform the rest of my testing couldn't reach.

premake5 is pinned to `v5.0.0-beta8`.

## Validation

Locally verified (macOS/arm64): the bundled and `--sodium=system` build+test paths, and the sanitized build+run (clean: the only sanitizer hit is the benign `nonnull-attribute` one, which is excluded). YAML validated. The Linux and Windows jobs run for real on this PR — I'll confirm they go green and iterate if the runners surface anything (the Windows/MSVC build of the amalgamated `sodium.c` in particular hasn't been compiled by MSVC before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)