### PR TITLE
README: add CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # yojimbo
 
+[![CI](https://github.com/mas-bandwidth/yojimbo/actions/workflows/ci.yml/badge.svg)](https://github.com/mas-bandwidth/yojimbo/actions/workflows/ci.yml)
+
 **yojimbo** is a network library for client/server games written in C++.
 
 It's designed around the networking requirements of competitive multiplayer games like first person shooters. 


### PR DESCRIPTION
Adds the GitHub Actions CI status badge to the top of the README (standard for open-source projects). It reflects the `CI` workflow's status on `main` and links to the Actions runs.

This is a follow-up: the badge commit on the CI branch (#255) landed after that PR had already auto-merged, so it never reached `main`. This re-applies it off current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)