### PR TITLE
Fix minor audit findings (bounds assert, unchecked reassembly alloc, init leak)

### DIFF
--- a/reliable/reliable.c
+++ b/reliable/reliable.c
@@ -1258,6 +1258,16 @@ void reliable_endpoint_receive_packet( struct reliable_endpoint_t * endpoint, ui
             reassembly_data->packet_data = (uint8_t*) endpoint->allocate_function( endpoint->allocator_context, packet_buffer_size );
             reassembly_data->packet_bytes = 0;
             reassembly_data->packet_header_bytes = 0;
+
+            if ( !reassembly_data->packet_data )
+            {
+                reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] ignoring fragment. could not allocate reassembly buffer (%d bytes)\n",
+                    endpoint->config.name, packet_buffer_size );
+                reliable_sequence_buffer_remove_with_cleanup( endpoint->fragment_reassembly, sequence, reliable_fragment_reassembly_data_cleanup );
+                endpoint->counters[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_INVALID]++;
+                return;
+            }
+
             memset( reassembly_data->fragment_received, 0, sizeof( reassembly_data->fragment_received ) );
         }
 

--- a/source/yojimbo.cpp
+++ b/source/yojimbo.cpp
@@ -55,15 +55,22 @@ extern "C" int netcode_enable_packet_tagging();
 
 bool InitializeYojimbo()
 {
-    g_defaultAllocator = new yojimbo::DefaultAllocator();
-
+    // Create the default allocator only once everything else has initialised, so a
+    // failure partway through doesn't leak it (callers don't call ShutdownYojimbo
+    // when InitializeYojimbo returns false).
     if ( netcode_init() != NETCODE_OK )
         return false;
 
     if ( reliable_init() != RELIABLE_OK )
         return false;
 
-    return sodium_init() != -1;
+    if ( sodium_init() == -1 )
+        return false;
+
+    yojimbo_assert( g_defaultAllocator == NULL );
+    g_defaultAllocator = new yojimbo::DefaultAllocator();
+
+    return true;
 }
 
 void EnablePacketTagging()

--- a/source/yojimbo_connection.cpp
+++ b/source/yojimbo_connection.cpp
@@ -324,7 +324,7 @@ namespace yojimbo
         {
             const int channelIndex = packet.channelEntry[i].channelIndex;
             yojimbo_assert( channelIndex >= 0 );
-            yojimbo_assert( channelIndex <= m_connectionConfig.numChannels );
+            yojimbo_assert( channelIndex < m_connectionConfig.numChannels );
             m_channel[channelIndex]->ProcessPacketData( packet.channelEntry[i], packetSequence );
             if ( m_channel[channelIndex]->GetErrorLevel() != CHANNEL_ERROR_NONE )
             {


### PR DESCRIPTION
Three low-severity items from an audit pass. All small, no behavioural change on the happy path.

1. **Off-by-one bounds assert** — `Connection::ProcessPacket` asserted `channelIndex <= numChannels`; it should be `<` (indexes `m_channel[numChannels]`). Harmless in practice — the serialize step already bounds `channelIndex` to `[0, numChannels-1]` — but the assert was wrong.
2. **Unchecked reassembly allocation** — `reliable_endpoint_receive_packet` didn't check the fragment-reassembly buffer allocation; on failure the subsequent `reliable_store_fragment_data` would `memcpy` into `NULL`. Now it logs, removes the reassembly entry, counts an invalid fragment, and returns. Not reachable with the default config (`max_fragments = 8`), but possible with a large `maxPacketFragments`.
3. **Init error-path leak** — `InitializeYojimbo()` created the default allocator first and returned `false` on a later init failure without freeing it (callers don't call `ShutdownYojimbo` on failure). It now creates the allocator only after `netcode`/`reliable`/`sodium` init succeed, and asserts it isn't already set.

## Validation

Full test suite passes in **debug**, **release**, and under **ASan + UBSan** locally. CI covers Linux/macOS/Windows + sanitizers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)