### PR TITLE
Remove vestigial SODIUM_STATIC define in yojimbo.cpp

### DIFF
--- a/source/yojimbo.cpp
+++ b/source/yojimbo.cpp
@@ -25,10 +25,6 @@
 #include "yojimbo.h"
 #include "yojimbo_utils.h"
 
-#ifdef _MSC_VER
-#define SODIUM_STATIC
-#endif // #ifdef _MSC_VER
-
 #include <sodium.h>
 
 static yojimbo::Allocator * g_defaultAllocator;


### PR DESCRIPTION
`yojimbo.cpp` defined `SODIUM_STATIC` (MSVC-only) before `#include <sodium.h>` to suppress libsodium's `dllimport` decoration. The amalgamated bundled libsodium has no `SODIUM_EXPORT`/`__declspec(dllimport)` macros at all, so `SODIUM_STATIC` is never referenced — this is dead code from before the sodium prune/amalgamation.

No behavioural change. Builds and tests pass in debug and release locally; CI covers Windows/MSVC where the define would have mattered if it were still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)