### PR TITLE
Fix return type in hand-declared netcode_enable_packet_tagging prototype

### DIFF
--- a/source/yojimbo.cpp
+++ b/source/yojimbo.cpp
@@ -44,7 +44,7 @@ extern "C" int reliable_init();
 extern "C" void netcode_term();
 extern "C" void reliable_term();
 
-extern "C" int netcode_enable_packet_tagging();
+extern "C" void netcode_enable_packet_tagging();
 
 #define NETCODE_OK 1
 #define RELIABLE_OK 1


### PR DESCRIPTION
`yojimbo.cpp` declared `netcode_enable_packet_tagging` as returning `int`, but the real function is `void` ([netcode.h](https://github.com/mas-bandwidth/yojimbo/blob/main/netcode/netcode.h) and its definition in netcode.c). Calling a function through a prototype with the wrong return type is undefined behavior — unnoticed in practice because `EnablePacketTagging()` ignores the phantom return value, but it can trip LTO cross-TU type checking and is UB per the standard.

The prototypes in this file are intentionally hand-declared so yojimbo carries no header dependency on `netcode.h`/`reliable.h` — so this corrects just the one mismatched declaration, keeping that design intact. The other four hand-declared prototypes and the `NETCODE_OK`/`RELIABLE_OK` constants were verified to match the real headers.

Full suite passes in debug and release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)