### PR TITLE
yojimbo.cpp: include netcode.h/reliable.h instead of hand-declared prototypes

### DIFF
--- a/source/yojimbo.cpp
+++ b/source/yojimbo.cpp
@@ -24,6 +24,8 @@
 
 #include "yojimbo.h"
 #include "yojimbo_utils.h"
+#include "netcode.h"
+#include "reliable.h"
 
 #include <sodium.h>
 
@@ -37,17 +39,6 @@ namespace yojimbo
         return *g_defaultAllocator;
     }
 }
-
-extern "C" int netcode_init();
-extern "C" int reliable_init();
-
-extern "C" void netcode_term();
-extern "C" void reliable_term();
-
-extern "C" void netcode_enable_packet_tagging();
-
-#define NETCODE_OK 1
-#define RELIABLE_OK 1
 
 bool InitializeYojimbo()
 {


### PR DESCRIPTION
Replaces the hand-rolled `extern "C"` prototypes and locally re-defined `NETCODE_OK` / `RELIABLE_OK` constants in `yojimbo.cpp` with `#include "netcode.h"` / `#include "reliable.h"`, so the compiler enforces agreement with the real declarations and they can't silently drift. (One already had: `netcode_enable_packet_tagging` was declared `int` but is `void` — fixed in #259; this removes the hazard class.)

Scope note: this touches only the `.cpp` — the public `yojimbo.h` still has no dependency on `netcode.h`/`reliable.h`, so library users are unaffected. Several other yojimbo source files (`yojimbo_client.cpp`, `yojimbo_server.cpp`, `yojimbo_platform.cpp`, the base classes) already include these headers directly.

Full suite passes in debug and release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)