### PR TITLE
Fuzz the untrusted-input parsers; fix three bugs they found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,44 @@ jobs:
             CFLAGS="$SAN" CXXFLAGS="$SAN" LDFLAGS="-fsanitize=address,undefined"
       - name: Test (sanitized)
         run: ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./bin/test
+
+  fuzz:
+    name: fuzz (linux libFuzzer, ASan+UBSan)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      # Coverage-guided libFuzzer over the untrusted-input parsers. Each target is built
+      # without -DFUZZ_STANDALONE (libFuzzer supplies main) and time-boxed. Debug defines
+      # stay on so the libraries' asserts and the message-factory leak check are live —
+      # that check is what surfaces leaks in the connection deserialization error paths.
+      # nonnull-attribute is excluded for the same reason as the sanitizers job (libsodium
+      # memcpy(dst, NULL, 0) on zero-length AEAD plaintext).
+      - name: Build and run fuzz targets
+        run: |
+          set -euo pipefail
+          SAN="-fsanitize=fuzzer,address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
+          RUN="-max_total_time=60 -print_final_stats=1 -rss_limit_mb=4096"
+
+          echo "::group::build fuzz_reliable"
+          clang $SAN -DRELIABLE_DEBUG -Ireliable -Ifuzz \
+            fuzz/fuzz_reliable.c reliable/reliable.c -o fuzz_reliable
+          echo "::endgroup::"
+
+          echo "::group::build fuzz_netcode"
+          clang $SAN -DNETCODE_DEBUG -Inetcode -Isodium -Ifuzz \
+            fuzz/fuzz_netcode.c sodium/sodium.c -o fuzz_netcode
+          echo "::endgroup::"
+
+          echo "::group::build fuzz_connection"
+          clang++ -std=c++11 $SAN -DYOJIMBO_DEBUG -DNETCODE_DEBUG -DRELIABLE_DEBUG -DSERIALIZE_DEBUG \
+            -I. -Iinclude -Isodium -Itlsf -Inetcode -Ireliable -Iserialize -Ifuzz \
+            fuzz/fuzz_connection.cpp source/*.cpp netcode/netcode.c reliable/reliable.c tlsf/tlsf.c sodium/sodium.c \
+            -o fuzz_connection
+          echo "::endgroup::"
+
+          for t in fuzz_reliable fuzz_netcode fuzz_connection; do
+            echo "::group::run $t"
+            mkdir -p "corpus/$t"
+            UBSAN_OPTIONS=halt_on_error=1 ./"$t" "corpus/$t" $RUN
+            echo "::endgroup::"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,32 +90,40 @@ ref/SSSE3/AVX2, Poly1305 donna/SSE2) selected at runtime. Key facts:
   reliable reassembly NULL-alloc check, InitializeYojimbo error-path leak). #258 remove dead
   `SODIUM_STATIC`. #259 fix `netcode_enable_packet_tagging` prototype (`int`→`void`). #260
   `yojimbo.cpp` include netcode.h/reliable.h instead of hand-declared prototypes.
-- **#261 (open):** matcher `expireSeconds` uint64→int64 (always-true expiry check) + safer
-  `verboseError`/key defaults.
+- #261 matcher `expireSeconds` uint64→int64 (always-true expiry check) + safer
+  `verboseError`/key defaults. #262 CLAUDE.md working notes + first fuzz harnesses.
 
-## CURRENT TASK — in progress: fuzzing (`fuzz/`)
+## Fuzzing (`fuzz/`)
 
-Goal: libFuzzer harnesses over the untrusted-input parsers, wired into CI. Status:
-- `fuzz/fuzz_reliable.c` — targets `reliable_endpoint_receive_packet`. **Works**: 300k
-  random inputs clean under ASan+UBSan (standalone mode).
-- `fuzz/fuzz_connection.cpp` — targets `yojimbo::Connection::ProcessPacket` (ReadStream +
-  channel/message/block deserialization). **NEEDS DEBUGGING**: standalone build exits **1
-  with no output** even at `FUZZ_ITERS=0/1/50`. Next step was to isolate whether it's process
-  init/exit vs an iteration. Prime suspect: `TestMessageFactory`'s destructor calls **`exit(1)`
-  on message leaks** (debug builds) — the per-iteration factory may be reporting a leak, which
-  could be (a) a harness lifetime issue, or (b) a REAL leak the fuzzer found in ProcessPacket's
-  error path. Confirm by checking whether the "you leaked messages" line prints (it may be lost
-  if `exit` races) — try building with `-DYOJIMBO_DEBUG_MESSAGE_LEAKS=0`, or add a print at top
-  of `main`, or run under lldb. Resolve before wiring into CI.
-- Harnesses are **dual-mode**: define `-DFUZZ_STANDALONE` for an ordinary ASan/UBSan driver
-  (Apple clang has no libFuzzer); real libFuzzer (`-fsanitize=fuzzer,...`) runs on Linux CI.
-  Standalone build commands are in the git history of this session / `fuzz/README.md`.
-- **TODO:** fix fuzz_connection; add `fuzz/README.md` build+run docs; add a `netcode_read_packet`
-  harness; add a CI job (Linux clang `-fsanitize=fuzzer,address,undefined`, short
-  `-max_total_time` per target); the fuzz targets are standalone (not in the premake build), so
-  they won't affect existing CI jobs.
+libFuzzer harnesses over the untrusted-input parsers, dual-mode (`-DFUZZ_STANDALONE` for an
+ASan/UBSan driver since Apple clang has no libFuzzer; `-fsanitize=fuzzer` on Linux CI). See
+`fuzz/README.md` for the canonical build/run commands. All three run clean at ≥300k
+standalone inputs under ASan+UBSan, and a `fuzz` CI job builds + time-boxes them.
+- `fuzz/fuzz_reliable.c` — `reliable_endpoint_receive_packet`.
+- `fuzz/fuzz_netcode.c` — `netcode_read_packet` (`#include "netcode.c"` — the reader and its
+  replay-protection / packet-type symbols are internal to that TU; tests are off by default).
+- `fuzz/fuzz_connection.cpp` — `yojimbo::Connection::ProcessPacket`. An earlier "exits 1
+  with no output" was the `TestMessageFactory` dtor's `exit(1)` leak check firing (its report
+  was swallowed by the default log level, hence silent). It was a REAL bug the fuzzer found,
+  not a harness artifact. Bringing it to clean turned up **three library bugs, now fixed:**
+  1. **Message leak** in `SerializeBlockFragment` (`source/yojimbo_channel.cpp`): the "block
+     fragment attached to non-block message" error path returned without releasing the just
+     -created message.
+  2. **`bufferSize > 0` assert** in `Connection::ProcessPacket` (`yojimbo_connection.cpp`) on a
+     zero-payload packet — reachable because a packet that is exactly a reliable header hands
+     the reader 0 payload bytes. Now rejected up front as a read failure.
+  3. **`ChannelPacketData` union misread** (`yojimbo_unreliable_unordered_channel.cpp`):
+     `ProcessPacketData` read `packetData.message` without checking `blockMessage`, so a block
+     fragment addressed to an unreliable channel was reinterpreted as a message-pointer array
+     → wild pointer deref (SEGV in `Message::SetId`). The unreliable channel never *sends* a
+     top-level block fragment (its blocks go inline via `SerializeMessageBlock`), so receiving
+     one is malformed; now treated as a serialize failure like the reliable channel does.
+  Regression tests for (2) and (3) are in `test.cpp`
+  (`test_connection_reject_empty_packet`, `test_connection_unreliable_rejects_block_fragment`);
+  both verified to fail without their fix. (1) is covered by the fuzzer.
 
 ## Suggested next improvements (from the audit)
 
-Fuzzing (this task) is #1. Then: time-boxed sanitized `soak` in CI; `SECURITY.md` disclosure
-policy; commit the libsodium amalgamation generator under `tools/`; `.clang-format`.
+Fuzzing is done. Next: time-boxed sanitized `soak` in CI; `SECURITY.md` disclosure policy;
+commit the libsodium amalgamation generator under `tools/`; `.clang-format`; seed corpora for
+the fuzz targets so time-boxed CI reaches post-decrypt paths faster.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,30 +1,51 @@
-# Fuzz targets (work in progress)
+# Fuzz targets
 
-libFuzzer harnesses over yojimbo's untrusted-input parsers. Standalone (not part of
-the premake build), so they don't affect the normal build or CI.
+libFuzzer harnesses over yojimbo's untrusted-input parsers — the code that runs on raw,
+attacker-controlled bytes off the wire. Standalone from the premake build (their own
+sources), so they don't affect the normal build; a CI job builds and runs them under real
+libFuzzer on Linux (see `.github/workflows/ci.yml`, job `fuzz`).
 
 Each target is **dual-mode**:
-- **Real libFuzzer** (Linux clang, coverage-guided) — the intended CI mode.
-- **Standalone** (`-DFUZZ_STANDALONE`) — an ordinary executable that replays file
-  args or feeds pseudo-random buffers (`FUZZ_ITERS` env var). Needed because Apple
-  clang ships no libFuzzer. Build it with ASan+UBSan to shake out crashes.
+- **Real libFuzzer** (Linux clang, coverage-guided) — the CI mode. Built with
+  `-fsanitize=fuzzer,address,undefined`; libFuzzer supplies `main`.
+- **Standalone** (`-DFUZZ_STANDALONE`) — an ordinary executable that replays file args or
+  feeds pseudo-random buffers (`FUZZ_ITERS` env var, default 200k). Needed because Apple
+  clang ships no libFuzzer. Build it with ASan+UBSan to shake out crashes locally.
 
 ## Targets
 - `fuzz_reliable.c` — `reliable_endpoint_receive_packet` (header parse, ack decode,
-  fragment reassembly). **Working**: 300k standalone inputs clean under ASan+UBSan.
-- `fuzz_connection.cpp` — `yojimbo::Connection::ProcessPacket` (ReadStream +
-  channel/message/block deserialization). **WIP — standalone build exits 1 with no
-  output; needs debugging.** Prime suspect: `TestMessageFactory` dtor calls `exit(1)`
-  on message leaks in debug builds. See CLAUDE.md "CURRENT TASK".
+  fragment reassembly).
+- `fuzz_netcode.c` — `netcode_read_packet` (prefix/type parse, length checks, sequence
+  decode, AEAD + connect-token decryption). Includes `netcode.c` directly because the
+  reader and its replay-protection / packet-type symbols are internal to that TU.
+- `fuzz_connection.cpp` — `yojimbo::Connection::ProcessPacket` (bitpacker ReadStream,
+  ConnectionPacket / ChannelPacketData serialization, per-channel message + block-fragment
+  reading) over a reliable-ordered and an unreliable-unordered channel.
+
+All three run clean (≥300k standalone inputs under ASan+UBSan). Bugs found and fixed while
+bringing `fuzz_connection` up: a message leak on the "block fragment attached to non-block
+message" error path; a `bufferSize > 0` assert on a zero-payload packet; and a
+`ChannelPacketData` union misread (a block fragment addressed to an unreliable channel was
+read as a message-pointer array → wild pointer). Regression tests for the latter two are in
+`test.cpp` (`test_connection_reject_empty_packet`,
+`test_connection_unreliable_rejects_block_fragment`).
 
 ## Build — standalone, sanitized (macOS/Apple clang or Linux)
 
 reliable:
 ```
-clang -DFUZZ_STANDALONE -DRELIABLE_DEBUG -I reliable -I fuzz \
+clang -DFUZZ_STANDALONE -DRELIABLE_DEBUG -Ireliable -Ifuzz \
   -fsanitize=address,undefined -fno-sanitize-recover=all -g \
   fuzz/fuzz_reliable.c reliable/reliable.c -o /tmp/fz_reliable
 FUZZ_ITERS=300000 UBSAN_OPTIONS=halt_on_error=1 /tmp/fz_reliable
+```
+
+netcode:
+```
+clang -DFUZZ_STANDALONE -DNETCODE_DEBUG -Inetcode -Isodium -Ifuzz \
+  -fsanitize=address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=all -g \
+  fuzz/fuzz_netcode.c sodium/sodium.c -o /tmp/fz_netcode
+FUZZ_ITERS=300000 UBSAN_OPTIONS=halt_on_error=1 /tmp/fz_netcode
 ```
 
 connection:
@@ -37,12 +58,16 @@ clang++ -std=c++11 -DFUZZ_STANDALONE -DYOJIMBO_DEBUG -DNETCODE_DEBUG -DRELIABLE_
 FUZZ_ITERS=100000 /tmp/fz_connection
 ```
 
-## Build — real libFuzzer (Linux clang), intended CI mode
-Swap `-DFUZZ_STANDALONE` for `-fsanitize=fuzzer` (added to the sanitizer set), drop the
-standalone `main`, and pass a corpus dir + `-max_total_time=N`. Not yet wired into CI.
+`-fno-sanitize=nonnull-attribute` is required for any target that links libsodium (netcode,
+connection): netcode encrypts zero-length AEAD plaintexts, so libsodium does
+`memcpy(dst, NULL, 0)` — benign UB in upstream code.
 
-## TODO
-- Fix `fuzz_connection` (see CLAUDE.md).
-- Add a `netcode_read_packet` target.
-- Add a CI job: Linux clang `-fsanitize=fuzzer,address,undefined`, short `-max_total_time`
-  per target, seeded from a small corpus.
+## Build — real libFuzzer (Linux clang), the CI mode
+Swap `-DFUZZ_STANDALONE` for `-fsanitize=fuzzer` (added to the sanitizer set) and pass a
+corpus dir + `-max_total_time=N`. Exactly what the `fuzz` CI job does; see it for the
+canonical commands.
+
+## Ideas for later
+- Seed corpora (a captured valid packet per target) so the time-boxed CI runs reach the
+  post-decrypt / reassembled-payload paths faster.
+- A `netcode` connect-token / server-side read target.

--- a/fuzz/fuzz_connection.cpp
+++ b/fuzz/fuzz_connection.cpp
@@ -20,6 +20,9 @@ static void ensure_init()
     if ( !g_init )
     {
         InitializeYojimbo();
+        // The message-leak check in ~MessageFactory reports at ERROR level before
+        // calling exit(1); the default log level (NONE) would swallow the report.
+        yojimbo_log_level( YOJIMBO_LOG_LEVEL_ERROR );
         g_init = true;
     }
 }

--- a/fuzz/fuzz_netcode.c
+++ b/fuzz/fuzz_netcode.c
@@ -1,0 +1,80 @@
+/*
+    Fuzz target: netcode_read_packet().
+
+    Feeds arbitrary bytes into netcode's packet-read path — prefix/type parsing, length
+    checks, sequence decoding, AEAD decryption and connect-token decryption — the code
+    that runs on raw, attacker-controlled UDP payloads before a client or server trusts
+    anything. Every packet type is allowed and fixed (zero) keys are used, so the header
+    parse and the decrypt/MAC-reject paths are all exercised.
+
+    netcode_read_packet and the replay-protection / packet-type symbols are internal to
+    netcode.c (not declared in netcode.h), so the harness includes the translation unit
+    directly. netcode.c's own tests are behind NETCODE_ENABLE_TESTS (off) and it defines
+    no main, so this just pulls in the implementation.
+*/
+
+#include "netcode.c"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#define FUZZ_PROTOCOL_ID     0x1122334455667788ULL
+#define FUZZ_TIMESTAMP       ( (uint64_t) 1000000 )
+
+static int g_init = 0;
+static uint8_t g_packet_key[NETCODE_KEY_BYTES];
+static uint8_t g_private_key[NETCODE_KEY_BYTES];
+
+static void ensure_init( void )
+{
+    if ( g_init )
+        return;
+    netcode_init();
+    memset( g_packet_key, 0, sizeof( g_packet_key ) );
+    memset( g_private_key, 0, sizeof( g_private_key ) );
+    g_init = 1;
+}
+
+int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )
+{
+    ensure_init();
+
+    // Mirror the real receive path: netcode never hands more than a full UDP packet to
+    // the reader, and it ignores empty buffers.
+    if ( size == 0 || size > NETCODE_MAX_PACKET_BYTES )
+        return 0;
+
+    // netcode_read_packet takes a mutable buffer; copy the immutable fuzzer input.
+    uint8_t buffer[NETCODE_MAX_PACKET_BYTES];
+    memcpy( buffer, data, size );
+
+    uint8_t allowed_packets[NETCODE_CONNECTION_NUM_PACKETS];
+    memset( allowed_packets, 1, sizeof( allowed_packets ) );
+
+    // Reset replay protection every input so a repeated sequence number never masks the
+    // post-decrypt path on a later input.
+    struct netcode_replay_protection_t replay_protection;
+    netcode_replay_protection_reset( &replay_protection );
+
+    uint64_t sequence = 0;
+
+    void * packet = netcode_read_packet( buffer,
+                                         (int) size,
+                                         &sequence,
+                                         g_packet_key,
+                                         FUZZ_PROTOCOL_ID,
+                                         FUZZ_TIMESTAMP,
+                                         g_private_key,
+                                         allowed_packets,
+                                         &replay_protection,
+                                         NULL,
+                                         NULL );
+
+    if ( packet )
+        netcode_default_free_function( NULL, packet );
+
+    return 0;
+}
+
+#include "fuzz_standalone.h"

--- a/source/yojimbo_channel.cpp
+++ b/source/yojimbo_channel.cpp
@@ -315,6 +315,7 @@ namespace yojimbo
                 if ( !message->IsBlockMessage() )
                 {
                     yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: received block fragment attached to non-block message (SerializeBlockFragment)\n" );
+                    messageFactory.ReleaseMessage( message );
                     return false;
                 }
 

--- a/source/yojimbo_connection.cpp
+++ b/source/yojimbo_connection.cpp
@@ -311,6 +311,15 @@ namespace yojimbo
             return false;
         }
 
+        // A packet that is exactly a reliable header reaches us with zero payload bytes.
+        // That's never a valid connection packet, so fail it like any other malformed read.
+        if ( !packetData || packetBytes <= 0 )
+        {
+            yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to read packet (empty payload)\n" );
+            m_errorLevel = CONNECTION_ERROR_READ_PACKET_FAILED;
+            return false;
+        }
+
         ConnectionPacket packet;
 
         if ( !ReadPacket( context, *m_messageFactory, m_connectionConfig, packet, packetData, packetBytes ) )

--- a/source/yojimbo_unreliable_unordered_channel.cpp
+++ b/source/yojimbo_unreliable_unordered_channel.cpp
@@ -239,6 +239,17 @@ namespace yojimbo
             return;
         }
 
+        // An unreliable-unordered channel never sends a top-level block fragment
+        // (its block messages are serialized inline, see SerializeUnorderedMessages),
+        // so packetData here must hold the message union member. If blockMessage is set
+        // the packet is malformed: reading packetData.message would reinterpret the
+        // block union member as a message-pointer array. Treat it as a serialize failure.
+        if ( packetData.blockMessage )
+        {
+            SetErrorLevel( CHANNEL_ERROR_FAILED_TO_SERIALIZE );
+            return;
+        }
+
         for ( int i = 0; i < (int) packetData.message.numMessages; ++i )
         {
             Message * message = packetData.message.messages[i];

--- a/test.cpp
+++ b/test.cpp
@@ -1196,6 +1196,87 @@ void test_connection_unreliable_unordered_blocks()
     check( numMessagesReceived == NumMessagesSent );
 }
 
+void test_connection_reject_empty_packet()
+{
+    // A packet that is exactly a reliable header reaches Connection::ProcessPacket with
+    // zero payload bytes. That must be rejected cleanly, not fed to the bit reader (which
+    // used to trip the bufferSize > 0 assert in ReadPacket).
+
+    TestMessageFactory messageFactory( GetDefaultAllocator() );
+
+    double time = 100.0;
+
+    ConnectionConfig connectionConfig;
+    connectionConfig.numChannels = 1;
+    connectionConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+
+    Connection connection( GetDefaultAllocator(), messageFactory, connectionConfig, time );
+
+    uint8_t buffer[1] = { 0 };
+
+    check( !connection.ProcessPacket( NULL, 0, buffer, 0 ) );
+    check( connection.GetErrorLevel() == CONNECTION_ERROR_READ_PACKET_FAILED );
+}
+
+void test_connection_unreliable_rejects_block_fragment()
+{
+    // An unreliable-unordered channel never sends a top-level block fragment (its blocks
+    // are serialized inline). A peer that puts a block fragment on that channel index used
+    // to be misread through the ChannelPacketData union (a BlockMessage* reinterpreted as a
+    // message-pointer array) and crash. It must instead be rejected as a serialize failure.
+
+    TestMessageFactory messageFactory( GetDefaultAllocator() );
+
+    double time = 100.0;
+
+    // Sender speaks reliable-ordered on channel 0, so it emits a top-level block fragment.
+    ConnectionConfig senderConfig;
+    senderConfig.numChannels = 1;
+    senderConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+
+    // Receiver treats channel 0 as unreliable-unordered.
+    ConnectionConfig receiverConfig;
+    receiverConfig.numChannels = 1;
+    receiverConfig.channel[0].type = CHANNEL_TYPE_UNRELIABLE_UNORDERED;
+
+    Connection sender( GetDefaultAllocator(), messageFactory, senderConfig, time );
+    Connection receiver( GetDefaultAllocator(), messageFactory, receiverConfig, time );
+
+    TestBlockMessage * message = (TestBlockMessage*) messageFactory.CreateMessage( TEST_BLOCK_MESSAGE );
+    check( message );
+    message->sequence = 0;
+    const int blockSize = 64;
+    uint8_t * blockData = (uint8_t*) YOJIMBO_ALLOCATE( messageFactory.GetAllocator(), blockSize );
+    for ( int i = 0; i < blockSize; ++i )
+        blockData[i] = (uint8_t) i;
+    message->AttachBlock( messageFactory.GetAllocator(), blockData, blockSize );
+    sender.SendMessage( 0, message );
+
+    // The sender is never acked, so it keeps re-sending the block fragment every tick.
+    // Feed each generated packet to the receiver until its unreliable channel rejects the
+    // fragment and the connection drops into the channel error state.
+    uint8_t * packetData = (uint8_t*) alloca( senderConfig.maxPacketSize );
+    uint16_t sequence = 0;
+    bool sawChannelError = false;
+
+    for ( int i = 0; i < 64 && !sawChannelError; ++i )
+    {
+        int packetBytes = 0;
+        if ( sender.GeneratePacket( NULL, sequence, packetData, senderConfig.maxPacketSize, packetBytes ) && packetBytes > 0 )
+            receiver.ProcessPacket( NULL, sequence, packetData, packetBytes );
+
+        sender.AdvanceTime( time );
+        receiver.AdvanceTime( time );
+        time += 0.1;
+        sequence++;
+
+        if ( receiver.GetErrorLevel() == CONNECTION_ERROR_CHANNEL )
+            sawChannelError = true;
+    }
+
+    check( sawChannelError );
+}
+
 void PumpClientServerUpdate( double & time, Client ** client, int numClients, Server ** server, int numServers, float deltaTime = 0.1f )
 {
     for ( int i = 0; i < numClients; ++i )
@@ -2610,6 +2691,8 @@ int main()
         RUN_TEST( test_connection_reliable_ordered_messages_and_blocks_multiple_channels );
         RUN_TEST( test_connection_unreliable_unordered_messages );
         RUN_TEST( test_connection_unreliable_unordered_blocks );
+        RUN_TEST( test_connection_reject_empty_packet );
+        RUN_TEST( test_connection_unreliable_rejects_block_fragment );
 
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );


### PR DESCRIPTION
Adds libFuzzer harnesses over yojimbo's packet-deserialization paths, wires them into CI, and fixes three bugs that fuzzing `Connection::ProcessPacket` surfaced.

## Harnesses (`fuzz/`)
Dual-mode: `-DFUZZ_STANDALONE` gives an ordinary ASan/UBSan driver for local use (Apple clang ships no libFuzzer); real libFuzzer (`-fsanitize=fuzzer`) runs on Linux CI.

- `fuzz_reliable.c` — `reliable_endpoint_receive_packet`
- `fuzz_netcode.c` — `netcode_read_packet` (`#include "netcode.c"`; the reader and its replay-protection / packet-type symbols are internal to that TU, tests off by default)
- `fuzz_connection.cpp` — `yojimbo::Connection::ProcessPacket`

A new `fuzz` CI job builds all three and runs each time-boxed (60s) under ASan+UBSan. All three run clean at ≥300k standalone inputs locally (`fuzz_connection` at 2M).

## Library bugs found and fixed
All reachable from a malicious or buggy peer, on already-decrypted/authenticated payloads:

1. **Message leak** in `SerializeBlockFragment` (`source/yojimbo_channel.cpp`) — the "block fragment attached to non-block message" error path returned without releasing the message it had just created.
2. **`bufferSize > 0` assert** in `Connection::ProcessPacket` (`source/yojimbo_connection.cpp`) on a zero-payload packet — a packet that is exactly a reliable header hands the reader 0 payload bytes. Now rejected up front as a read failure.
3. **`ChannelPacketData` union misread** in `UnreliableUnorderedChannel::ProcessPacketData` (`source/yojimbo_unreliable_unordered_channel.cpp`) — it read `packetData.message` without checking `blockMessage`, so a block fragment addressed to an unreliable channel was reinterpreted as a message-pointer array → wild-pointer deref (SEGV in `Message::SetId`). The unreliable channel never *sends* a top-level block fragment (its blocks go inline via `SerializeMessageBlock`), so receiving one is malformed; now treated as a serialize failure, matching the reliable channel.

## Tests
Regression tests for (2) and (3) added to `test.cpp` (`test_connection_reject_empty_packet`, `test_connection_unreliable_rejects_block_fragment`); both were verified to fail without their fix (assert / SEGV) and pass with it. (1) is covered by the fuzzer. Full suite passes in debug, release, and the ASan+UBSan sanitized build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)