### PR TITLE
Add time-boxed sanitized soak to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,34 @@ jobs:
             UBSAN_OPTIONS=halt_on_error=1 ./"$t" "corpus/$t" $RUN
             echo "::endgroup::"
           done
+
+  soak:
+    name: soak (linux, sanitized, time-boxed)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install premake5
+        run: |
+          curl -fsSL "https://github.com/premake/premake-core/releases/download/v${PREMAKE_VERSION}/premake-${PREMAKE_VERSION}-linux.tar.gz" | tar xz
+          chmod +x premake5
+          echo "$PWD" >> "$GITHUB_PATH"
+      - name: Generate makefiles
+        run: premake5 gmake
+      - name: Build soak (sanitized)
+        # Same sanitizer flags and nonnull-attribute carve-out as the sanitizers job.
+        run: |
+          SAN="-fsanitize=address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
+          make -j config=debug soak CC=clang CXX=clang++ \
+            CFLAGS="$SAN" CXXFLAGS="$SAN" LDFLAGS="-fsanitize=address,undefined"
+      - name: Run soak (time-boxed)
+        # Bounded iteration count so the normally-endless soak exits cleanly and the
+        # sanitizers run their end-of-process (incl. leak) checks. Output is verbose, so
+        # keep it in a file and only surface the tail on failure.
+        run: |
+          set -o pipefail
+          if ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+               ./bin/soak 20000 > soak.log 2>&1; then
+            echo "soak completed cleanly ($(grep -c 'received message' soak.log) messages exchanged)"
+          else
+            echo "soak failed (exit $?)"; tail -50 soak.log; exit 1
+          fi

--- a/soak.cpp
+++ b/soak.cpp
@@ -39,7 +39,7 @@ void interrupt_handler( int /*dummy*/ )
 static const int UNRELIABLE_UNORDERED_CHANNEL = 0;
 static const int RELIABLE_ORDERED_CHANNEL = 1;
 
-int SoakMain()
+int SoakMain( int iterations )
 {
     ClientServerConfig config;
     config.maxPacketSize = MaxPacketSize;
@@ -94,8 +94,14 @@ int SoakMain()
     double timeForNextClientMessage = 0;
     double timeForNextServerMessage = 0;
 
-    while ( !quit )
+    // iterations <= 0 runs until interrupted (SIGINT); a positive count time-boxes the
+    // run so it exits cleanly — used by CI to soak under sanitizers for a bounded time.
+    int iteration = 0;
+
+    while ( !quit && ( iterations <= 0 || iteration < iterations ) )
     {
+        iteration++;
+
         client.SendPackets();
         server.SendPackets();
 
@@ -374,9 +380,12 @@ int SoakMain()
     return 0;
 }
 
-int main()
+int main( int argc, char ** argv )
 {
     printf( "\nsoak\n" );
+
+    // Optional iteration count: `soak [iterations]`. Zero or absent runs until Ctrl-C.
+    int iterations = ( argc > 1 ) ? atoi( argv[1] ) : 0;
 
     if ( !InitializeYojimbo() )
     {
@@ -388,7 +397,7 @@ int main()
 
     srand( (unsigned int) time( NULL ) );
 
-    int result = SoakMain();
+    int result = SoakMain( iterations );
 
     ShutdownYojimbo();
 


### PR DESCRIPTION
Adds a sanitized, time-boxed run of the soak test to CI — catching bugs the unit tests don't, by exercising the full client/server/netcode/reliable/channel stack under high latency, jitter, 25% packet loss, and 25% duplicates with ASan+UBSan+LSan.

## Why a code change was needed
`soak` ran an endless `while(!quit)` loop terminated only by SIGINT, so it couldn't exit cleanly in CI (and a killed process skips the sanitizers' end-of-process leak checks).

## Change
- **`soak.cpp`**: optional iteration count — `soak [iterations]`. Zero or absent runs until Ctrl-C exactly as before; a positive count time-boxes the run and exits cleanly through the normal disconnect/stop path. Backwards-compatible.
- **`.github/workflows/ci.yml`**: new `soak` job (ubuntu-24.04) that builds soak with the same sanitizer flags as the existing `sanitizers` job and runs `./bin/soak 20000` under `ASAN_OPTIONS=detect_leaks=1`. Verbose per-message output is redirected to a file; only the tail is surfaced on failure, so a green run stays readable.

## Verification
Locally (macOS, ASan+UBSan — no LSan on macOS): sanitized `./bin/soak 20000` exits 0 with 12,263 messages exchanged and zero sanitizer reports; the connection establishes and blocks/messages flow both directions. Normal build + full unit suite still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)