### PR TITLE
Add .clang-format encoding the existing house style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,39 @@
+# Encodes yojimbo's existing house style (also used by the in-tree netcode / reliable /
+# serialize sources): Allman braces, 4-space indent, spaces inside parentheses, pointers and
+# references spaced on both sides, indented case labels and namespaces, and no column limit.
+#
+# This is provided for formatting NEW/edited code consistently; it is not enforced in CI, and
+# the existing sources have not been mass-reformatted. The vendored third-party code under
+# sodium/ and tlsf/ opts out via its own .clang-format (DisableFormat) so it stays as
+# upstream — sodium/ in particular is verified byte-identical to libsodium.
+---
+Language: Cpp
+BasedOnStyle: LLVM
+
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 0
+
+BreakBeforeBraces: Allman
+NamespaceIndentation: All
+IndentCaseLabels: true
+AccessModifierOffset: -4
+AlwaysBreakTemplateDeclarations: No
+
+PointerAlignment: Middle
+ReferenceAlignment: Middle
+
+SpacesInParentheses: true
+SpaceInEmptyParentheses: false
+SpacesInSquareBrackets: false
+
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
+
+AlignAfterOpenBracket: Align
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: true
+SortIncludes: false

--- a/sodium/.clang-format
+++ b/sodium/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/tlsf/.clang-format
+++ b/tlsf/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
Codifies yojimbo's existing style (also used by the in-tree netcode/reliable/serialize sources) so new and edited code stays consistent — without reformatting anything that exists today.

**Style captured**: Allman braces, 4-space indent, spaces inside parentheses `( x )`, middle-aligned pointers/references (`Type * name`, `Type & ref`), indented case labels and namespaces, no column limit, inline short methods, templates kept on one line.

**Config only** — existing sources are intentionally not mass-reformatted (they predate any formatter and contain trailing whitespace and mixed cast/paren styles the config normalizes). The vendored third-party code under `sodium/` and `tlsf/` opts out via its own `DisableFormat` `.clang-format`, so it stays byte-for-byte as upstream — important because `sodium/` is verified identical to libsodium 1.0.20.

**Validated** with clang-format 22.1.5: the config parses cleanly with no errors, reproduces the house style on the main sources (remaining diffs on existing files are trailing-whitespace stripping and normalization of the sources' own inconsistencies), and the guards leave `sodium/` and `tlsf/` completely untouched.

No CI enforcement is added; this is for editor/local use and consistent new contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)