### PR TITLE
Fix uninitialized block.message deref on a disabled-blocks channel

### DIFF
--- a/source/yojimbo_channel.cpp
+++ b/source/yojimbo_channel.cpp
@@ -31,6 +31,13 @@ namespace yojimbo
         channelIndex = 0;
         blockMessage = 0;
         messageFailedToSerialize = 0;
+        // Zero both arms of the message/block union so Free() is safe no matter which one the
+        // serializer populates — or if it bails out after setting blockMessage but before
+        // initializing the block pointers (e.g. a block fragment on a disableBlocks channel,
+        // which returns early). Writing block.message clears the high bytes that a bare
+        // message.numMessages = 0 would leave uninitialized.
+        block.message = NULL;
+        block.fragmentData = NULL;
         message.numMessages = 0;
         initialized = 1;
     }

--- a/test.cpp
+++ b/test.cpp
@@ -1277,6 +1277,66 @@ void test_connection_unreliable_rejects_block_fragment()
     check( sawChannelError );
 }
 
+void test_connection_reliable_block_fragment_on_disabled_blocks()
+{
+    // A peer sends a block fragment on a reliable-ordered channel, but the receiver has
+    // blocks disabled on that channel. ChannelPacketData::Serialize reads blockMessage=1 then
+    // returns early on disableBlocks, before SerializeBlockFragment initializes the block
+    // pointers. The packet destructor's Free() must not then dereference an uninitialized
+    // block.message (it used to, because Initialize() only zeroed part of the union).
+
+    TestMessageFactory messageFactory( GetDefaultAllocator() );
+
+    double time = 100.0;
+
+    // Sender: reliable-ordered with blocks enabled, so it emits a real block fragment.
+    ConnectionConfig senderConfig;
+    senderConfig.numChannels = 1;
+    senderConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+
+    // Receiver: reliable-ordered on the same channel, but with blocks disabled.
+    ConnectionConfig receiverConfig;
+    receiverConfig.numChannels = 1;
+    receiverConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+    receiverConfig.channel[0].disableBlocks = true;
+
+    Connection sender( GetDefaultAllocator(), messageFactory, senderConfig, time );
+    Connection receiver( GetDefaultAllocator(), messageFactory, receiverConfig, time );
+
+    TestBlockMessage * message = (TestBlockMessage*) messageFactory.CreateMessage( TEST_BLOCK_MESSAGE );
+    check( message );
+    message->sequence = 0;
+    const int blockSize = 2000;   // > fragment size, but even a single fragment reproduces it
+    uint8_t * blockData = (uint8_t*) YOJIMBO_ALLOCATE( messageFactory.GetAllocator(), blockSize );
+    for ( int i = 0; i < blockSize; ++i )
+        blockData[i] = (uint8_t) i;
+    message->AttachBlock( messageFactory.GetAllocator(), blockData, blockSize );
+    sender.SendMessage( 0, message );
+
+    // Feed generated block-fragment packets to the receiver. Before the fix this crashed in
+    // the packet destructor; after it, the read simply fails and the connection errors.
+    uint8_t * packetData = (uint8_t*) alloca( senderConfig.maxPacketSize );
+    uint16_t sequence = 0;
+
+    for ( int i = 0; i < 64; ++i )
+    {
+        int packetBytes = 0;
+        if ( sender.GeneratePacket( NULL, sequence, packetData, senderConfig.maxPacketSize, packetBytes ) && packetBytes > 0 )
+            receiver.ProcessPacket( NULL, sequence, packetData, packetBytes );
+
+        sender.AdvanceTime( time );
+        receiver.AdvanceTime( time );
+        time += 0.1;
+        sequence++;
+
+        if ( receiver.GetErrorLevel() != CONNECTION_ERROR_NONE )
+            break;
+    }
+
+    // The receiver rejected the disallowed block fragment without crashing.
+    check( receiver.GetErrorLevel() != CONNECTION_ERROR_NONE );
+}
+
 void PumpClientServerUpdate( double & time, Client ** client, int numClients, Server ** server, int numServers, float deltaTime = 0.1f )
 {
     for ( int i = 0; i < numClients; ++i )
@@ -2693,6 +2753,7 @@ int main()
         RUN_TEST( test_connection_unreliable_unordered_blocks );
         RUN_TEST( test_connection_reject_empty_packet );
         RUN_TEST( test_connection_unreliable_rejects_block_fragment );
+        RUN_TEST( test_connection_reliable_block_fragment_on_disabled_blocks );
 
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );


### PR DESCRIPTION
A memory-safety bug in the connection deserializer, reachable from post-authentication attacker-controlled input.

## The bug
`ChannelPacketData::Initialize()` only zeroed `message.numMessages` — the low 4 bytes of the `message`/`block` union. When `ChannelPacketData::Serialize` (read) sees `blockMessage=1` on a channel with `disableBlocks` set, it returns early, **before** `SerializeBlockFragment` nulls the block pointers. That leaves `block.message`'s high 4 bytes uninitialized, and the `ConnectionPacket` destructor's `Free()` — trusting `blockMessage=1` — dereferences the garbage pointer (SEGV in `Message::Release`, `this = 0xbebebebe...`).

Trigger: a peer sends a block fragment on a reliable-ordered channel that the receiver has configured with blocks disabled.

## The fix
`Initialize()` now zeros both union arms (`block.message` and `block.fragmentData`), so `Free()` is safe regardless of how serialization exits.

## Test
Found by the connection fuzzer once it started varying the channel config. `test_connection_reliable_block_fragment_on_disabled_blocks` reproduces it deterministically (sender with blocks enabled emits a block fragment → receiver with `disableBlocks` reads it) and was verified to **crash without the fix** and pass with it. Full suite green in debug, release, and ASan+UBSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)