### PR TITLE
Add a nightly extended-fuzzing workflow with dictionaries

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,96 @@
+name: Fuzz (nightly)
+
+# Extended, coverage-guided fuzzing that would be too slow for the per-PR gate. Each target
+# runs far longer than the 60s CI smoke run, seeded from the committed corpus plus a corpus
+# that persists (and grows) across nights via the cache, and uses a libFuzzer dictionary where
+# one helps. A crash fails that target's job and uploads the reproducer as an artifact.
+#
+# This is a separate workflow from ci.yml so it never blocks pull requests.
+
+on:
+  schedule:
+    - cron: '17 7 * * *'   # daily at 07:17 UTC
+  workflow_dispatch:
+    inputs:
+      max_total_time:
+        description: 'Seconds to fuzz each target'
+        required: false
+        default: '900'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: nightly fuzz (${{ matrix.target }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_reliable
+          - fuzz_netcode
+          - fuzz_netcode_connect_token
+          - fuzz_connection
+          - fuzz_connection_structured
+    steps:
+      - uses: actions/checkout@v4
+
+      # Persist the discovered corpus across runs: restore the newest prior cache for this
+      # target, and save a fresh entry keyed by run id (cache entries are immutable, so a
+      # unique key each run + a prefix restore-key gives a growing corpus).
+      - name: Restore corpus
+        uses: actions/cache@v4
+        with:
+          path: corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Build ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          SAN="-fsanitize=fuzzer,address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
+          case "${{ matrix.target }}" in
+            fuzz_reliable)
+              clang $SAN -DRELIABLE_DEBUG -Ireliable -Ifuzz \
+                fuzz/fuzz_reliable.c reliable/reliable.c -o "${{ matrix.target }}" ;;
+            fuzz_netcode)
+              clang $SAN -DNETCODE_DEBUG -Inetcode -Isodium -Ifuzz \
+                fuzz/fuzz_netcode.c sodium/sodium.c -o "${{ matrix.target }}" ;;
+            fuzz_netcode_connect_token)
+              clang $SAN -DNETCODE_DEBUG -Inetcode -Isodium -Ifuzz \
+                fuzz/fuzz_netcode_connect_token.c sodium/sodium.c -o "${{ matrix.target }}" ;;
+            *)
+              clang++ -std=c++11 $SAN -DYOJIMBO_DEBUG -DNETCODE_DEBUG -DRELIABLE_DEBUG -DSERIALIZE_DEBUG \
+                -I. -Iinclude -Isodium -Itlsf -Inetcode -Ireliable -Iserialize -Ifuzz \
+                fuzz/${{ matrix.target }}.cpp source/*.cpp netcode/netcode.c reliable/reliable.c tlsf/tlsf.c sodium/sodium.c \
+                -o "${{ matrix.target }}" ;;
+          esac
+
+      - name: Fuzz ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          mkdir -p "corpus/${{ matrix.target }}"
+          DICT=""
+          if [ -f "fuzz/dict/${{ matrix.target }}.dict" ]; then
+            DICT="-dict=fuzz/dict/${{ matrix.target }}.dict"
+          fi
+          T="${{ github.event.inputs.max_total_time || '900' }}"
+          echo "fuzzing ${{ matrix.target }} for ${T}s ${DICT}"
+          UBSAN_OPTIONS=halt_on_error=1 ./"${{ matrix.target }}" \
+            "corpus/${{ matrix.target }}" "fuzz/corpus/${{ matrix.target }}" \
+            $DICT -max_total_time="$T" -print_final_stats=1 -rss_limit_mb=4096
+
+      # On a crash libFuzzer writes the reproducer to the working dir; keep it.
+      - name: Upload crash reproducers
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crashes-${{ matrix.target }}
+          path: |
+            crash-*
+            oom-*
+            timeout-*
+            leak-*
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,10 @@ and **macOS Apple Silicon (macos-14)** in debug+release; **Windows MSVC** (Debug
 a **libFuzzer + MemorySanitizer** job (uninitialized-read detection — the C++ targets build
 with `-DYOJIMBO_RELEASE` so the debug `std::map` leak trackers aren't compiled in and MSan
 needs no instrumented libc++; an uninstrumented libstdc++ `std::map` traversal MSan-false
--positives, which is how the first attempt failed). macOS **Intel (macos-13)** is commented out in the matrix (slow to allocate). Badge
+-positives, which is how the first attempt failed). A separate scheduled workflow
+`fuzz-nightly.yml` runs each target far longer (matrix, persisted+growing corpus via the
+Actions cache, per-target `fuzz/dict/*.dict`), uploading any crash reproducer as an artifact;
+it never gates PRs and can be run on demand via `workflow_dispatch`. macOS **Intel (macos-13)** is commented out in the matrix (slow to allocate). Badge
 is in the README. **MSan is Linux-only — it cannot be reproduced on the macOS dev machine;
 CI is the only validator.**
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -95,6 +95,24 @@ Swap `-DFUZZ_STANDALONE` for `-fsanitize=fuzzer` (added to the sanitizer set) an
 corpus dir + `-max_total_time=N`. Exactly what the `fuzz` CI job does; see it for the
 canonical commands.
 
+## CI
+
+Three layers run in GitHub Actions:
+- **`fuzz` job** (`ci.yml`, per-PR) — 60s ASan+UBSan smoke run of each target, seeded from
+  `fuzz/corpus/`; a gate that catches regressions fast.
+- **`msan` job** (`ci.yml`, per-PR) — the same targets under MemorySanitizer for
+  uninitialized-read detection (the C++ targets build with `-DYOJIMBO_RELEASE` so no `std::map`
+  is compiled in, avoiding the need for an instrumented libc++).
+- **`Fuzz (nightly)`** (`fuzz-nightly.yml`, scheduled) — a much longer run per target with a
+  corpus that persists and grows across nights (via the Actions cache) and a libFuzzer
+  dictionary where one helps (`fuzz/dict/<target>.dict`). A crash fails that target and uploads
+  the reproducer as an artifact. Trigger it by hand from the Actions tab (`workflow_dispatch`,
+  with a `max_total_time` input) to reproduce or extend a run.
+
+Dictionaries hold byte-aligned structural tokens (the netcode version string, address-type
+tags, the structured target's op/type bytes, config selectors); they help most for the
+netcode packet framing and the structured script, less for the bitpacked message payloads.
+
 ## Seed corpora (`fuzz/corpus/<target>/`)
 
 Committed seeds of valid packets so the time-boxed CI runs start at inputs that already

--- a/fuzz/dict/fuzz_connection.dict
+++ b/fuzz/dict/fuzz_connection.dict
@@ -1,0 +1,7 @@
+# The first input byte selects the ConnectionConfig (fuzz_config.h, 6 configs).
+config_0="\x00"
+config_1="\x01"
+config_2="\x02"
+config_3="\x03"
+config_4="\x04"
+config_5="\x05"

--- a/fuzz/dict/fuzz_connection_structured.dict
+++ b/fuzz/dict/fuzz_connection_structured.dict
@@ -1,0 +1,11 @@
+# Script op bytes and message-type/config selectors for the structured target.
+op_tick="\x00"
+op_send="\x01"
+op_drop="\x04"
+type_primitives="\x00"
+type_string="\x01"
+type_bytes="\x02"
+type_block="\x03"
+config_0="\x00"
+config_1="\x01"
+config_5="\x05"

--- a/fuzz/dict/fuzz_netcode.dict
+++ b/fuzz/dict/fuzz_netcode.dict
@@ -1,0 +1,11 @@
+# Structural tokens for netcode_read_packet. The connection-request path checks the
+# 13-byte version string literally, so it is the highest-value entry.
+version_info="NETCODE 1.02\x00"
+protocol_id_le="\x88\x77\x66\x55\x44\x33\x22\x11"
+type_request="\x00"
+type_denied="\x01"
+type_challenge="\x02"
+type_response="\x03"
+type_keepalive="\x04"
+type_payload="\x05"
+type_disconnect="\x06"

--- a/fuzz/dict/fuzz_netcode_connect_token.dict
+++ b/fuzz/dict/fuzz_netcode_connect_token.dict
@@ -1,0 +1,4 @@
+# Server-address type tags in the decrypted private connect token.
+addr_none="\x00"
+addr_ipv4="\x01"
+addr_ipv6="\x02"


### PR DESCRIPTION
The last of the fuzzing-hardening items: extended fuzzing that's too slow for the per-PR gate.

## `fuzz-nightly.yml`
- **Scheduled** (daily) plus **`workflow_dispatch`** with a `max_total_time` input, in a separate workflow so it never blocks PRs.
- **Matrix** over all five targets, built with `-fsanitize=fuzzer,address,undefined`, running much longer than the 60s CI smoke run.
- **Persisted, growing corpus** via the Actions cache (unique key per run + prefix restore-key), seeded from the committed `fuzz/corpus/<target>`. Each night builds on the last night's discoveries.
- **Dictionaries** (`fuzz/dict/<target>.dict`) of byte-aligned structural tokens where they help: the netcode version string + packet types, connect-token address tags, the structured script's op/type bytes, and the connection config selectors.
- **Crash reproducers** uploaded as artifacts on failure.

## Validation
The nightly workflow only runs on schedule/dispatch, so this PR's CI doesn't exercise it. After merge I'll trigger a short manual run (`workflow_dispatch`, small `max_total_time`) to confirm the build, dictionary parsing, corpus cache, and run all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)