### PR TITLE
test: print the random seed and allow passing it to reproduce failures

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -2693,9 +2693,19 @@ void interrupt_handler( int /*dummy*/ )
 }
 #endif // #if SOAK
 
-int main()
+int main( int argc, char ** argv )
 {
-    srand( time( NULL ) );
+    // The tests are randomized (packet loss, ordering, ids). Seed rand() from the clock by
+    // default, but let a seed be passed on the command line so a flaky failure can be
+    // reproduced exactly: rerun `./bin/test <seed>` with the value printed below. Print and
+    // flush the seed first so it survives even if a later test aborts.
+    unsigned int seed = ( argc > 1 ) ? (unsigned int) strtoul( argv[1], NULL, 0 )
+                                     : (unsigned int) time( NULL );
+
+    printf( "test random seed %u\n", seed );
+    fflush( stdout );
+
+    srand( seed );
 
     printf( "\n" );
 


### PR DESCRIPTION
The test suite is randomized (`srand(time(NULL))`, and packet-loss/ordering via `rand()`), so a flaky failure couldn't be reproduced — which just bit the CMake-conversion CI (a one-off macOS assert that passed on re-run).

This makes runs reproducible:

```
./bin/test            # seeds from the clock, prints "test random seed N"
./bin/test <N>        # reruns with that exact seed
```

The seed is printed **and flushed** before any test runs, so it survives even if a later test aborts (buffered stdout is otherwise lost on a trap). CI logs will now always show the seed, so the next flaky failure can be reproduced locally and actually fixed.

Verified: `./bin/test 12345` produces the same run twice; default run prints a clock seed; suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)