### PR TITLE
Don't assert on an over-budget packet on the read path (remote DoS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,13 @@ production ready" is fair. I'd trust it for a real game.
   block pointers. It works, but it's a footgun — exactly where bug #3 lived.
 - *Debug invariants are blunt* — the message factory calls `exit(1)` on a leak, asserts
   `__builtin_trap()`. Effective at catching mistakes, hostile to embedding/tooling (this is
-  why the fuzzer looked "silent" until the log level was raised).
+  why the fuzzer looked "silent" until the log level was raised). A `yojimbo_assert` reachable
+  from a decrypted packet is a remote crash in debug builds. **The post-decrypt receive path
+  was audited for this**: it's largely safe (the `serialize_*` macros range-check every value,
+  and `ProcessPacketMessages`/`ProcessPacketFragment` handle bad ids/fragments with graceful
+  `CHANNEL_ERROR_DESYNC` rather than asserting). The one network-reachable assert found — the
+  `YOJIMBO_DEBUG_MESSAGE_BUDGET` per-channel budget check running on the read stream — is fixed
+  (guarded to write/measure; regression test `test_connection_reliable_over_budget_packet`).
 - *Ergonomics are low-level by design.* You hand-write serialization, manually ref-count and
   release messages, run your own fixed-timestep loop, and must remember `InitializeYojimbo()`.
   Right for the audience (engine programmers), not friendly to newcomers — and the docs had

--- a/source/yojimbo_channel.cpp
+++ b/source/yojimbo_channel.cpp
@@ -399,7 +399,12 @@ namespace yojimbo
             }
 
 #if YOJIMBO_DEBUG_MESSAGE_BUDGET
-            if ( channelConfig.packetBudget > 0 )
+            // Only assert on write/measure: this validates that *we* stay within the packet
+            // budget when producing a packet. On read the data is untrusted (post-decrypt, but
+            // still attacker-controlled), so a peer that ignores the budget must not be able to
+            // crash a debug build — the message count and sizes are already bounded by the
+            // serialize_* range checks, so an over-budget read is harmless, just larger.
+            if ( !Stream::IsReading && channelConfig.packetBudget > 0 )
             {
                 yojimbo_assert( stream.GetBitsProcessed() - startBits <= channelConfig.packetBudget * 8 );
             }

--- a/source/yojimbo_connection.cpp
+++ b/source/yojimbo_connection.cpp
@@ -52,7 +52,10 @@ namespace yojimbo
             const int numChannels = connectionConfig.numChannels;
             serialize_int( stream, numChannelEntries, 0, connectionConfig.numChannels );
 #if YOJIMBO_DEBUG_MESSAGE_BUDGET
-            yojimbo_assert( stream.GetBitsProcessed() <= ConservativePacketHeaderBits );
+            // Write/measure only — validates our own header-size estimate. (On read this is
+            // fixed-width and can't exceed the bound anyway, but keep it off the untrusted path.)
+            if ( !Stream::IsReading )
+                yojimbo_assert( stream.GetBitsProcessed() <= ConservativePacketHeaderBits );
 #endif // #if YOJIMBO_DEBUG_MESSAGE_BUDGET
             if ( numChannelEntries > 0 )
             {

--- a/test.cpp
+++ b/test.cpp
@@ -1337,6 +1337,66 @@ void test_connection_reliable_block_fragment_on_disabled_blocks()
     check( receiver.GetErrorLevel() != CONNECTION_ERROR_NONE );
 }
 
+void test_connection_reliable_over_budget_packet()
+{
+    // A peer sends more channel data than the receiver's configured packetBudget. On read this
+    // used to trip the YOJIMBO_DEBUG_MESSAGE_BUDGET assert — a remote crash in debug builds
+    // reachable from a decrypted-but-attacker-controlled packet. The message count and sizes
+    // are already bounded by the serialize_* range checks, so an over-budget read must simply
+    // be accepted, not asserted on.
+
+    TestMessageFactory messageFactory( GetDefaultAllocator() );
+
+    double time = 100.0;
+
+    // Sender: default (unlimited) packet budget, so it packs messages freely.
+    ConnectionConfig senderConfig;
+    senderConfig.numChannels = 1;
+    senderConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+
+    // Receiver: a small per-channel packet budget.
+    ConnectionConfig receiverConfig;
+    receiverConfig.numChannels = 1;
+    receiverConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+    receiverConfig.channel[0].packetBudget = 32;
+
+    Connection sender( GetDefaultAllocator(), messageFactory, senderConfig, time );
+    Connection receiver( GetDefaultAllocator(), messageFactory, receiverConfig, time );
+
+    const int NumMessages = 64;
+    for ( int i = 0; i < NumMessages; ++i )
+    {
+        TestMessage * message = (TestMessage*) messageFactory.CreateMessage( TEST_MESSAGE );
+        check( message );
+        message->sequence = (uint16_t) i;
+        sender.SendMessage( 0, message );
+    }
+
+    // The first generated packet carries far more than 32 bytes of channel data. Before the
+    // fix, processing it aborted the receiver in the budget assert; after, it reads cleanly.
+    uint8_t * packetData = (uint8_t*) alloca( senderConfig.maxPacketSize );
+    uint16_t sequence = 0;
+    bool processed = false;
+
+    for ( int i = 0; i < 8 && !processed; ++i )
+    {
+        int packetBytes = 0;
+        if ( sender.GeneratePacket( NULL, sequence, packetData, senderConfig.maxPacketSize, packetBytes ) && packetBytes > 0 )
+        {
+            check( receiver.ProcessPacket( NULL, sequence, packetData, packetBytes ) );
+            processed = true;
+        }
+
+        sender.AdvanceTime( time );
+        receiver.AdvanceTime( time );
+        time += 0.1;
+        sequence++;
+    }
+
+    check( processed );
+    check( receiver.GetErrorLevel() == CONNECTION_ERROR_NONE );
+}
+
 void PumpClientServerUpdate( double & time, Client ** client, int numClients, Server ** server, int numServers, float deltaTime = 0.1f )
 {
     for ( int i = 0; i < numClients; ++i )
@@ -2764,6 +2824,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_connection_reject_empty_packet );
         RUN_TEST( test_connection_unreliable_rejects_block_fragment );
         RUN_TEST( test_connection_reliable_block_fragment_on_disabled_blocks );
+        RUN_TEST( test_connection_reliable_over_budget_packet );
 
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );


### PR DESCRIPTION
Audits the `yojimbo_assert` calls reachable from a decrypted (but still attacker-controlled) packet, and fixes the one that's a remote-crash risk.

## Finding
The post-decrypt receive path is **largely safe**: the `serialize_*` macros range-check every deserialized value, and `ProcessPacketMessages` / `ProcessPacketFragment` handle bad message ids and fragments with a graceful `CHANNEL_ERROR_DESYNC` instead of asserting. Most receive-path asserts are on values already bounded by serialize, or on non-NULL-by-construction messages.

The one genuinely network-reachable assert is the `YOJIMBO_DEBUG_MESSAGE_BUDGET` per-channel budget check in `ChannelPacketData::Serialize`, which runs on the **read** stream too. `packetBudget` is a soft, sender-side limit; a peer that ignores it can send an over-budget packet and **crash a debug-built receiver** in the assert. (Default `packetBudget` is -1/unlimited, so this affects configs that set a positive budget.)

## Fix
Guard the budget assert — and the sibling header-size assert in `ConnectionPacket::Serialize` — to write/measure only, keeping them off the untrusted read path. The message count and sizes are already bounded by the serialize range checks, so an over-budget read is harmless, just larger.

## Test
`test_connection_reliable_over_budget_packet`: a receiver with a small `packetBudget` reading an over-budget packet from an unlimited-budget sender — verified to **abort in the assert without the fix** and pass with it. Full suite green in Debug and Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)