### PR TITLE
Fix remote heap overflow in block reassembly and bracketed IPv6 parse

### DIFF
--- a/source/yojimbo_address.cpp
+++ b/source/yojimbo_address.cpp
@@ -138,17 +138,16 @@ namespace yojimbo
         m_port = 0;
         if ( address[0] == '[' )
         {
-            const int base_index = addressLength - 1;
-            for ( int i = 0; i < 6; ++i )                 // note: no need to search past 6 characters as ":65535" is longest port value
+            // Bracketed IPv6: "[addr6]" or "[addr6]:port". Locate the closing bracket, then
+            // treat only a ':' immediately after it as the port separator. Scanning for ':'
+            // from the end (as we do for IPv4 below) is wrong here because addr6 itself is full
+            // of colons, so "[::1]" with no port would misparse a colon inside the address.
+            char * closing = strrchr( address, ']' );
+            if ( closing )
             {
-                const int index = base_index - i;
-                if ( index < 3 )
-                    break;
-                if ( address[index] == ':' )
-                {
-                    m_port = uint16_t( atoi( &address[index + 1] ) );
-                    address[index-1] = '\0';
-                }
+                if ( closing[1] == ':' )
+                    m_port = uint16_t( atoi( closing + 2 ) );
+                *closing = '\0';
             }
             address += 1;
         }

--- a/source/yojimbo_reliable_ordered_channel.cpp
+++ b/source/yojimbo_reliable_ordered_channel.cpp
@@ -707,6 +707,20 @@ namespace yojimbo
                 return;
             }
 
+            // Validate the fragment write against the receive buffer BEFORE copying.
+            // blockData is allocated at maxBlockSize bytes, but when maxBlockSize is not a
+            // multiple of blockFragmentSize the fragment count rounds up, so the final fragment
+            // starts at an offset where a full blockFragmentSize write would run past the buffer.
+            // fragmentBytes is attacker-controlled in [1,blockFragmentSize] (see SerializeBlockFragment),
+            // so a peer can send an over-long final fragment. Reject anything that wouldn't fit
+            // rather than overflowing the heap (the blockSize check below only runs after the copy).
+            if ( fragmentId * m_config.blockFragmentSize + fragmentBytes > m_config.maxBlockSize )
+            {
+                // The fragment would write past the end of the block buffer.
+                SetErrorLevel( CHANNEL_ERROR_DESYNC );
+                return;
+            }
+
             // receive the fragment
 
             if ( !m_receiveBlock->receivedFragment->GetBit( fragmentId ) )

--- a/test.cpp
+++ b/test.cpp
@@ -278,6 +278,50 @@ void test_address()
         check( address.IsLoopback() );
     }
 
+    // Regression: bracketed IPv6 with no port. Scanning for ':' from the end used to misparse
+    // a colon inside the address as a port separator, leaving the address unparseable.
+    {
+        Address address( "[::1]" );
+        check( address.IsValid() );
+        check( address.GetType() == ADDRESS_IPV6 );
+        check( address.GetPort() == 0 );
+        check( address.GetAddress6()[0] == 0x0000 );
+        check( address.GetAddress6()[1] == 0x0000 );
+        check( address.GetAddress6()[2] == 0x0000 );
+        check( address.GetAddress6()[3] == 0x0000 );
+        check( address.GetAddress6()[4] == 0x0000 );
+        check( address.GetAddress6()[5] == 0x0000 );
+        check( address.GetAddress6()[6] == 0x0000 );
+        check( address.GetAddress6()[7] == 0x0001 );
+        check( address.IsLoopback() );
+    }
+
+    {
+        Address address( "[::]" );
+        check( address.IsValid() );
+        check( address.GetType() == ADDRESS_IPV6 );
+        check( address.GetPort() == 0 );
+        for ( int i = 0; i < 8; ++i )
+            check( address.GetAddress6()[i] == 0x0000 );
+        check( !address.IsLoopback() );
+    }
+
+    {
+        Address address( "[fe80::202:b3ff:fe1e:8329]" );
+        check( address.IsValid() );
+        check( address.GetType() == ADDRESS_IPV6 );
+        check( address.GetPort() == 0 );
+        check( address.GetAddress6()[0] == 0xfe80 );
+        check( address.GetAddress6()[1] == 0x0000 );
+        check( address.GetAddress6()[2] == 0x0000 );
+        check( address.GetAddress6()[3] == 0x0000 );
+        check( address.GetAddress6()[4] == 0x0202 );
+        check( address.GetAddress6()[5] == 0xb3ff );
+        check( address.GetAddress6()[6] == 0xfe1e );
+        check( address.GetAddress6()[7] == 0x8329 );
+        check( !address.IsLoopback() );
+    }
+
     char buffer[MaxAddressLength];
 
     {
@@ -1335,6 +1379,84 @@ void test_connection_reliable_block_fragment_on_disabled_blocks()
 
     // The receiver rejected the disallowed block fragment without crashing.
     check( receiver.GetErrorLevel() != CONNECTION_ERROR_NONE );
+}
+
+// Hand-serialize a connection packet carrying a single reliable-ordered channel entry that is
+// a block fragment. Matches ConnectionPacket + ChannelPacketData::Serialize + SerializeBlockFragment
+// for a numChannels==1 config. Lets tests inject fragment fields a well-behaved sender never would.
+template <typename Stream> static bool SerializeRawBlockFragmentPacket( Stream & stream, int maxFragmentsPerBlock, int blockFragmentSize, int numFragments, int fragmentId, int fragmentSize )
+{
+    int numChannelEntries = 1;
+    serialize_int( stream, numChannelEntries, 0, 1 );   // numChannels == 1, so channelIndex is not serialized
+
+    bool blockMessage = true;
+    serialize_bool( stream, blockMessage );
+
+    uint32_t messageId = 0;
+    serialize_bits( stream, messageId, 16 );
+
+    if ( maxFragmentsPerBlock > 1 )
+        serialize_int( stream, numFragments, 1, maxFragmentsPerBlock );
+
+    if ( numFragments > 1 )
+        serialize_int( stream, fragmentId, 0, numFragments - 1 );
+
+    serialize_int( stream, fragmentSize, 1, blockFragmentSize );
+
+    uint8_t payload[2048];
+    yojimbo_assert( fragmentSize <= (int) sizeof( payload ) );
+    memset( payload, 0xAB, sizeof( payload ) );
+    serialize_bytes( stream, payload, fragmentSize );
+
+    // fragmentId != 0 here, so no message type / block message is serialized.
+    return true;
+}
+
+void test_connection_reliable_block_fragment_overflow()
+{
+    // Regression test: a peer sends a reliable-ordered block fragment whose final fragment
+    // claims a full blockFragmentSize of data, even though maxBlockSize is not a multiple of
+    // blockFragmentSize. The receive buffer (blockData) is maxBlockSize bytes, but the final
+    // fragment is copied at offset (numFragments-1)*blockFragmentSize, so a full-size copy
+    // used to run past the end of the buffer (heap-buffer-overflow, caught by ASan). The
+    // fragment must be rejected before the copy. fragmentSize is attacker-controllable in
+    // [1,blockFragmentSize], so a legitimate sender never produces this.
+
+    TestMessageFactory messageFactory( GetDefaultAllocator() );
+
+    double time = 100.0;
+
+    ConnectionConfig config;
+    config.numChannels = 1;
+    config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+    config.channel[0].maxBlockSize = 1100;      // deliberately not a multiple of blockFragmentSize
+    config.channel[0].blockFragmentSize = 500;  // => GetMaxFragmentsPerBlock() == ceil(1100/500) == 3
+
+    Connection receiver( GetDefaultAllocator(), messageFactory, config, time );
+
+    const int maxFragmentsPerBlock = config.channel[0].GetMaxFragmentsPerBlock();
+    const int blockFragmentSize = config.channel[0].blockFragmentSize;
+
+    // messageId=0 (== expected receive sequence), final fragment, full blockFragmentSize payload.
+    const int numFragments = maxFragmentsPerBlock;   // 3
+    const int fragmentId = numFragments - 1;         // 2 (final fragment)
+    const int fragmentSize = blockFragmentSize;      // 500 -> write [1000,1500) into a 1100-byte buffer
+
+    uint8_t buffer[4096];
+    memset( buffer, 0, sizeof( buffer ) );
+    WriteStream stream( buffer, sizeof( buffer ) );
+    check( SerializeRawBlockFragmentPacket( stream, maxFragmentsPerBlock, blockFragmentSize, numFragments, fragmentId, fragmentSize ) );
+    stream.Flush();
+    const int packetBytes = stream.GetBytesProcessed();
+    check( packetBytes > 0 );
+
+    // Before the fix this overflowed the receive buffer inside ProcessPacketFragment. After the
+    // fix the fragment is rejected: the read fails and the channel drops into an error state.
+    const bool processed = receiver.ProcessPacket( NULL, 0, buffer, packetBytes );
+    check( !processed );
+
+    receiver.AdvanceTime( time );
+    check( receiver.GetErrorLevel() == CONNECTION_ERROR_CHANNEL );
 }
 
 void test_connection_reliable_over_budget_packet()
@@ -2824,6 +2946,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_connection_reject_empty_packet );
         RUN_TEST( test_connection_unreliable_rejects_block_fragment );
         RUN_TEST( test_connection_reliable_block_fragment_on_disabled_blocks );
+        RUN_TEST( test_connection_reliable_block_fragment_overflow );
         RUN_TEST( test_connection_reliable_over_budget_packet );
 
         RUN_TEST( test_client_server_messages );


### PR DESCRIPTION
## Summary

Two receive-path bugs found during a code review, each with a regression test.

### 1. Remote heap buffer overflow in reliable-ordered block reassembly (security)

`ReliableOrderedChannel::ProcessPacketFragment` copied an incoming block fragment into the reassembly buffer **before** validating its size:

- `blockData` is allocated at `maxBlockSize` bytes.
- When `maxBlockSize` is not a multiple of `blockFragmentSize`, `GetMaxFragmentsPerBlock()` rounds up (`ceil`), so the final fragment starts at an offset where a full-size write runs past the end of the buffer.
- `fragmentSize` is attacker-controlled in `[1, blockFragmentSize]` (see `SerializeBlockFragment`), so a connected peer can send an over-long final fragment and corrupt heap memory on the other side. The existing `blockSize > maxBlockSize` check only ran *after* the copy.

**Fix:** reject any fragment whose write would exceed `maxBlockSize` before the `memcpy`, mirroring the pre-copy bounds check `reliable.c` already performs on its own reassembly path (`reliable_store_fragment_data`).

Confirmed with AddressSanitizer via `Connection::ProcessPacket` (crafted fragment: `numFragments=3, fragmentId=2, fragmentSize=500` into an 1100-byte buffer → `WRITE of size 500, 0 bytes after 1100-byte region`). The default config (`262144 % 1024 == 0`) is unaffected, but non-multiple configs are supported and already exercised by `test_connection_reliable_ordered_blocks_max_size` (which only covered the send side). New test: `test_connection_reliable_block_fragment_overflow`.

### 2. Bracketed IPv6 address with no port fails to parse

`Address::Parse` scanned for `:` from the end of the string to find a port, which matched a colon *inside* a bracketed IPv6 literal with no port (e.g. `"[::1]"`), leaving it unparseable and reported invalid.

**Fix:** locate the closing `]` and treat only a trailing `":port"` as the port. New tests cover `"[::1]"`, `"[::]"`, and `"[fe80::...]"` without ports.

## Testing

- Full suite passes under AddressSanitizer (debug) and via the CMake Debug build (`./bin/test`).
- Verified each regression test **fails against the pre-fix source** (rebuilt the affected object from `HEAD`): the overflow test trips ASan at the `memcpy`, and the address test fails `check( address.IsValid() )` for `"[::1]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)