### PR TITLE
Harden read-path message-array allocs and fix network-sim ring draining

### DIFF
--- a/source/yojimbo_channel.cpp
+++ b/source/yojimbo_channel.cpp
@@ -116,6 +116,15 @@ namespace yojimbo
 
                 messages = (Message**) YOJIMBO_ALLOCATE( allocator, sizeof( Message* ) * numMessages );
 
+                if ( !messages )
+                {
+                    // Out of memory. Leave the arm empty (numMessages = 0) so ChannelPacketData::Free
+                    // stays safe, then fail the read; the channel treats this as a serialize failure.
+                    numMessages = 0;
+                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate messages (SerializeOrderedMessages)\n" );
+                    return false;
+                }
+
                 for ( int i = 0; i < numMessages; ++i )
                 {
                     messages[i] = NULL;
@@ -200,6 +209,15 @@ namespace yojimbo
                 Allocator & allocator = messageFactory.GetAllocator();
 
                 messages = (Message**) YOJIMBO_ALLOCATE( allocator, sizeof( Message* ) * numMessages );
+
+                if ( !messages )
+                {
+                    // Out of memory. Leave the arm empty (numMessages = 0) so ChannelPacketData::Free
+                    // stays safe, then fail the read; the channel treats this as a serialize failure.
+                    numMessages = 0;
+                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate messages (SerializeUnorderedMessages)\n" );
+                    return false;
+                }
 
                 for ( int i = 0; i < numMessages; ++i )
                     messages[i] = NULL;

--- a/source/yojimbo_network_simulator.cpp
+++ b/source/yojimbo_network_simulator.cpp
@@ -126,8 +126,14 @@ namespace yojimbo
 
         int numPackets = 0;
 
-        for ( int i = 0; i < yojimbo_min( m_numPacketEntries, maxPackets ); ++i )
+        // Scan the whole ring, but never return more than maxPackets. Packets are stored at
+        // m_currentIndex across the entire buffer, so bounding the scan by maxPackets (rather
+        // than the output count) would strand any packet held in a slot past that index.
+        for ( int i = 0; i < m_numPacketEntries; ++i )
         {
+            if ( numPackets >= maxPackets )
+                break;
+
             if ( !m_packetEntries[i].packetData )
                 continue;
 

--- a/test.cpp
+++ b/test.cpp
@@ -449,6 +449,59 @@ void test_address()
     }
 }
 
+void test_network_simulator_drains_all_slots()
+{
+    // Regression: ReceivePackets used to scan only the first min(numEntries, maxPackets) ring
+    // slots. Packets are stored across the whole ring (at m_currentIndex), so when a caller
+    // passes maxPackets < numEntries, any packet held in a tail slot was never drained. It must
+    // scan the entire ring and only cap how many packets it returns per call.
+
+    const int NumEntries = 4;
+
+    NetworkSimulator sim( GetDefaultAllocator(), NumEntries, 0.0 );
+
+    // Negative loss/duplicate rates make those RNG checks impossible to fire (random_float is
+    // always >= 0), so sends are fully deterministic, and they mark the simulator active.
+    sim.SetPacketLoss( -1.0f );
+    sim.SetDuplicates( -1.0f );
+
+    uint8_t payload[8];
+    for ( int i = 0; i < NumEntries; ++i )
+    {
+        memset( payload, (uint8_t) i, sizeof( payload ) );
+        sim.SendPacket( i, payload, sizeof( payload ) );    // fills ring slots 0..NumEntries-1, "to" == slot
+    }
+
+    sim.AdvanceTime( 1.0 );     // past every delivery time (latency 0)
+
+    // Drain with maxPackets (2) smaller than the ring (4). Everything must come out across calls,
+    // including packets in the tail slots that the old code stranded.
+    bool seen[NumEntries] = {};
+    int totalReceived = 0;
+
+    for ( int iter = 0; iter < NumEntries + 2; ++iter )
+    {
+        uint8_t * packetData[2];
+        int packetBytes[2];
+        int to[2];
+        const int n = sim.ReceivePackets( 2, packetData, packetBytes, to );
+        check( n <= 2 );        // never returns more than maxPackets
+        for ( int i = 0; i < n; ++i )
+        {
+            check( to[i] >= 0 && to[i] < NumEntries );
+            check( !seen[to[i]] );      // no packet delivered twice
+            check( packetBytes[i] == (int) sizeof( payload ) );
+            seen[to[i]] = true;
+            totalReceived++;
+            YOJIMBO_FREE( sim.GetAllocator(), packetData[i] );
+        }
+    }
+
+    check( totalReceived == NumEntries );
+    for ( int i = 0; i < NumEntries; ++i )
+        check( seen[i] );       // tail slots (index >= maxPackets) were drained too
+}
+
 void test_bit_array()
 {
     const int Size = 300;
@@ -2932,6 +2985,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_crypto_aead_vectors );
         RUN_TEST( test_queue );
         RUN_TEST( test_address );
+        RUN_TEST( test_network_simulator_drains_all_slots );
         RUN_TEST( test_bit_array );
         RUN_TEST( test_sequence_buffer );
         RUN_TEST( test_allocator_tlsf );


### PR DESCRIPTION
## Summary

Two low-severity hardening fixes found during review (follow-up to #283). Neither is remotely exploitable, but both remove latent failure modes on paths that handle untrusted input / simulation state.

### 1. Unchecked `Message*` array allocations on the read path

`SerializeOrderedMessages` and `SerializeUnorderedMessages` (`source/yojimbo_channel.cpp`) allocated the `Message*` array while reading a packet without a NULL check, then immediately wrote through it — a null dereference on allocator exhaustion. Every other read-path allocation in those functions already checks and fails the read, so this just makes them consistent.

**Fix:** on allocation failure, reset `numMessages` to 0 (so `ChannelPacketData::Free` stays safe) and return false; the channel surfaces this as a serialize failure and drops the connection, same as the other failure paths. Not reachable with sane configs (per-packet allocations are bounded by packet size and freed per packet), but cheap insurance.

### 2. `NetworkSimulator::ReceivePackets` stranded tail-slot packets

`ReceivePackets` scanned only the first `min(numEntries, maxPackets)` ring slots. Packets are stored across the whole ring (at `m_currentIndex`), so a caller passing `maxPackets < numEntries` would strand any packet held in a tail slot. It's correct today only because every caller happens to pass `maxSimulatorPackets` (== ring size).

**Fix:** scan the entire ring and cap only how many packets are returned per call. New regression test `test_network_simulator_drains_all_slots` fills a 4-slot ring, drains with `maxPackets = 2`, and checks every slot is delivered exactly once.

## Testing

- Full suite passes under AddressSanitizer (debug) and via the CMake Debug build (`./bin/test`).
- The network-sim regression test was verified to **fail against the pre-fix source** (rebuilt that object from `HEAD`): only 2 of 4 packets drained → `check( totalReceived == NumEntries )` fires. Fix #1's failure path is covered by the existing serialize-failure handling; it's a defensive NULL check with no behavior change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)