### PR TITLE
Fuzz allocation failures + adversarial block fragments; fix two OOM crashes

### DIFF
--- a/fuzz/fuzz_config.h
+++ b/fuzz/fuzz_config.h
@@ -15,10 +15,12 @@
 
 using namespace yojimbo;
 
-const int FuzzNumConfigs = 6;
+const int FuzzNumConfigs = 8;
 
 inline void fuzz_make_config( uint8_t selector, ConnectionConfig & config )
 {
+    // New configs are appended (never inserted) so an existing corpus input's leading selector
+    // byte keeps mapping to the same config: data[0] % 8 == data[0] % 6 for data[0] in [0,5].
     switch ( selector % FuzzNumConfigs )
     {
         case 0: // reliable + unreliable, blocks enabled (the common case)
@@ -54,6 +56,25 @@ inline void fuzz_make_config( uint8_t selector, ConnectionConfig & config )
             config.numChannels = 2;
             config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
             config.channel[0].blockFragmentSize = 256;
+            config.channel[1].type = CHANNEL_TYPE_UNRELIABLE_UNORDERED;
+            break;
+
+        case 6: // maxBlockSize NOT a multiple of blockFragmentSize (1100/500 => ceil 3 fragments).
+                // The final fragment's slot starts at 2*500=1000 in an 1100-byte buffer, so an
+                // over-long (full-size) final fragment would run past the end - this is the
+                // geometry the block-reassembly bounds check has to get right.
+            config.numChannels = 1;
+            config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+            config.channel[0].maxBlockSize = 1100;
+            config.channel[0].blockFragmentSize = 500;
+            break;
+
+        case 7: // another non-multiple geometry (10000/1024 => ceil 10 fragments), plus an
+                // unreliable channel alongside.
+            config.numChannels = 2;
+            config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+            config.channel[0].maxBlockSize = 10000;
+            config.channel[0].blockFragmentSize = 1024;
             config.channel[1].type = CHANNEL_TYPE_UNRELIABLE_UNORDERED;
             break;
     }

--- a/fuzz/fuzz_connection_structured.cpp
+++ b/fuzz/fuzz_connection_structured.cpp
@@ -51,7 +51,10 @@ struct Reader
     bool done() const { return pos >= size; }
 };
 
-static void fill_message( Message * message, int type, Reader & r, ConnectionConfig & config, int channel, Allocator & allocator )
+// Returns false if the message should be discarded rather than sent (e.g. a block message whose
+// block couldn't be allocated - sending a zero-size block would trip a send-time assert; under
+// allocation-fault injection that path is reachable).
+static bool fill_message( Message * message, int type, Reader & r, ConnectionConfig & config, int channel, Allocator & allocator )
 {
     switch ( type )
     {
@@ -95,17 +98,147 @@ static void fill_message( Message * message, int type, Reader & r, ConnectionCon
             int maxBlock = config.channel[channel].maxBlockSize;
             int blockSize = 1 + ( r.u16() % ( maxBlock < 8192 ? maxBlock : 8192 ) );
             uint8_t * block = (uint8_t*) YOJIMBO_ALLOCATE( allocator, blockSize );
-            if ( block )
-            {
-                uint8_t seed = r.u8();
-                for ( int i = 0; i < blockSize; ++i )
-                    block[i] = (uint8_t) ( i + seed );
-                m->AttachBlock( allocator, block, blockSize );
-            }
+            if ( !block )
+                return false;   // allocation failed (fault injection) -> don't send a blockless block message
+            uint8_t seed = r.u8();
+            for ( int i = 0; i < blockSize; ++i )
+                block[i] = (uint8_t) ( i + seed );
+            m->AttachBlock( allocator, block, blockSize );
             break;
         }
         default: break;
     }
+    return true;
+}
+
+// Allocator used to fuzz allocation-failure paths. Delegates to malloc/free but can be told to
+// fail the Nth upcoming allocation (then it disarms), driven by the fuzz input. Failures are only
+// armed *after* construction, since the library allocates its fixed pools up front and treats
+// those as infallible; every runtime allocation (packet generate/process, message create, block
+// attach) is expected to handle NULL gracefully - that is exactly what this exercises.
+class FaultAllocator : public Allocator
+{
+public:
+    FaultAllocator() : m_countdown( -1 ) {}
+    void FailIn( int n ) { m_countdown = n; }       // fail the n-th allocation from now, once
+    void Disarm() { m_countdown = -1; }
+
+    void * Allocate( size_t size, const char * file, int line )
+    {
+        if ( m_countdown == 0 )
+        {
+            m_countdown = -1;                       // one-shot: fail this allocation, then rearm off
+            SetErrorLevel( ALLOCATOR_ERROR_OUT_OF_MEMORY );
+            return NULL;
+        }
+        if ( m_countdown > 0 )
+            m_countdown--;
+        void * p = malloc( size );
+        if ( !p )
+        {
+            SetErrorLevel( ALLOCATOR_ERROR_OUT_OF_MEMORY );
+            return NULL;
+        }
+        TrackAlloc( p, size, file, line );
+        return p;
+    }
+
+    void Free( void * p, const char * file, int line )
+    {
+        if ( !p )
+            return;
+        TrackFree( p, file, line );
+        free( p );
+    }
+
+private:
+    int m_countdown;
+};
+
+// Serialize just the connection-packet channel-entry count, matching ConnectionPacket::Serialize.
+// (ConnectionPacket itself is internal; the per-entry body is written by the library below.)
+template <typename Stream> static bool write_channel_entry_count( Stream & stream, int & numChannelEntries, int numChannels )
+{
+    serialize_int( stream, numChannelEntries, 0, numChannels );
+    return true;
+}
+
+// Feed the receiver a *hand-built* reliable-ordered block fragment whose header fields
+// (numFragments / fragmentId / fragmentSize) are fuzz-chosen and deliberately out of spec - the
+// thing the real write path never emits (e.g. a full-size final fragment). The wire bytes are
+// produced by the library's own ChannelPacketData writer, so the format stays in sync; only the
+// adversarial field *values* come from the fuzzer. advConfig uses a maxBlockSize that is not a
+// multiple of blockFragmentSize, so this targets the block-reassembly bounds check directly. The
+// receiver is Reset first so messageId 0 is the expected next block and the fragment reaches the
+// reassembly memcpy.
+static void inject_adversarial_fragment( Connection & receiver, const ConnectionConfig & advConfig,
+                                         FuzzMessageFactory & factory, Reader & r )
+{
+    const ChannelConfig & cc = advConfig.channel[0];
+    const int maxFrags = cc.GetMaxFragmentsPerBlock();
+
+    receiver.Reset();
+
+    ChannelPacketData channelData;
+    channelData.Initialize();
+    channelData.channelIndex = 0;
+    channelData.blockMessage = 1;
+    channelData.block.messageId = 0;
+
+    int numFragments = ( maxFrags > 1 ) ? ( 1 + ( r.u8() % maxFrags ) ) : 1;
+    channelData.block.numFragments = numFragments;
+
+    int fragmentId = ( numFragments > 1 ) ? ( r.u8() % numFragments ) : 0;
+    if ( r.u8() & 1 )
+        fragmentId = numFragments - 1;              // bias toward the final fragment (overflow case)
+    channelData.block.fragmentId = fragmentId;
+
+    int fragmentSize = 1 + ( r.u16() % cc.blockFragmentSize );
+    if ( r.u8() & 1 )
+        fragmentSize = cc.blockFragmentSize;        // bias toward a full-size (adversarial) fragment
+    channelData.block.fragmentSize = fragmentSize;
+
+    channelData.block.fragmentData = (uint8_t*) YOJIMBO_ALLOCATE( factory.GetAllocator(), fragmentSize );
+    if ( !channelData.block.fragmentData )
+    {
+        channelData.Free( factory );
+        return;
+    }
+    memset( channelData.block.fragmentData, r.u8(), (size_t) fragmentSize );
+    channelData.block.messageType = FUZZ_MESSAGE_BLOCK;
+
+    if ( fragmentId == 0 )
+    {
+        // Fragment 0 carries the block message; the writer serializes it after the fragment data.
+        FuzzBlockMessage * bm = (FuzzBlockMessage*) factory.CreateMessage( FUZZ_MESSAGE_BLOCK );
+        if ( !bm )
+        {
+            channelData.Free( factory );
+            return;
+        }
+        bm->sequence = r.u16();
+        channelData.block.message = bm;
+    }
+
+    uint8_t packet[8 * 1024];
+    WriteStream stream( packet, (int) sizeof( packet ) );
+    int numChannelEntries = 1;
+    if ( write_channel_entry_count( stream, numChannelEntries, advConfig.numChannels ) &&
+         channelData.SerializeInternal( stream, factory, advConfig.channel, advConfig.numChannels ) )
+    {
+        stream.Flush();
+        int packetBytes = stream.GetBytesProcessed();
+        channelData.Free( factory );                // release our write-side fragment data + message
+        if ( packetBytes > 0 )
+            receiver.ProcessPacket( NULL, 0, packet, packetBytes );
+    }
+    else
+    {
+        channelData.Free( factory );
+    }
+
+    while ( Message * m = receiver.ReceiveMessage( 0 ) )
+        factory.ReleaseMessage( m );
 }
 
 extern "C" int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )
@@ -117,15 +250,29 @@ extern "C" int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )
 
     Reader r = { data, size, 0 };
 
+    // The fault allocator is declared first so it outlives (and its leak check runs after) the
+    // factories and connections built on top of it.
+    FaultAllocator allocator;
+
     ConnectionConfig config;
     fuzz_make_config( r.u8(), config );
 
-    FuzzMessageFactory senderFactory( GetDefaultAllocator() );
-    FuzzMessageFactory receiverFactory( GetDefaultAllocator() );
+    FuzzMessageFactory senderFactory( allocator );
+    FuzzMessageFactory receiverFactory( allocator );
 
     double time = 100.0;
-    Connection sender( GetDefaultAllocator(), senderFactory, config, time );
-    Connection receiver( GetDefaultAllocator(), receiverFactory, config, time );
+    Connection sender( allocator, senderFactory, config, time );
+    Connection receiver( allocator, receiverFactory, config, time );
+
+    // A dedicated receiver + factory for adversarial block fragments, on a config whose
+    // maxBlockSize is not a multiple of blockFragmentSize (the overflow-prone geometry).
+    ConnectionConfig advConfig;
+    advConfig.numChannels = 1;
+    advConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+    advConfig.channel[0].maxBlockSize = 1100;
+    advConfig.channel[0].blockFragmentSize = 500;
+    FuzzMessageFactory advFactory( allocator );
+    Connection advReceiver( allocator, advFactory, advConfig, time );
 
     uint8_t packetData[8 * 1024];
     uint16_t sequence = 0;
@@ -134,6 +281,15 @@ extern "C" int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )
     for ( int op = 0; op < MAX_OPS && !r.done(); ++op )
     {
         uint8_t action = r.u8();
+
+        // Occasionally schedule an allocation failure a few allocations out (one-shot). Armed only
+        // here, inside the op loop, so it never disturbs the up-front pool allocations.
+        if ( action & 0x20 )
+            allocator.FailIn( 1 + ( r.u8() % 12 ) );
+
+        // Occasionally feed the dedicated receiver an adversarial block fragment.
+        if ( ( action & 0xC0 ) == 0xC0 )
+            inject_adversarial_fragment( advReceiver, advConfig, advFactory, r );
 
         if ( ( action & 3 ) != 0 )
         {
@@ -156,8 +312,10 @@ extern "C" int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )
                 Message * message = senderFactory.CreateMessage( type );
                 if ( message )
                 {
-                    fill_message( message, type, r, config, channel, senderFactory.GetAllocator() );
-                    sender.SendMessage( channel, message );
+                    if ( fill_message( message, type, r, config, channel, senderFactory.GetAllocator() ) )
+                        sender.SendMessage( channel, message );
+                    else
+                        senderFactory.ReleaseMessage( message );
                 }
             }
         }

--- a/include/yojimbo_allocator.h
+++ b/include/yojimbo_allocator.h
@@ -30,6 +30,7 @@
 
 #include <stdint.h>
 #include <new>
+#include <utility>
 #if YOJIMBO_DEBUG_MEMORY_LEAKS
 #include <map>
 #endif // YOJIMBO_DEBUG_MEMORY_LEAKS
@@ -48,8 +49,23 @@ namespace yojimbo
 
     class Allocator & GetDefaultAllocator();
 
+    /**
+        Helper behind YOJIMBO_NEW. Allocates storage for a T and placement-constructs it, but
+        only if the allocation succeeded — on failure it returns NULL instead of running the
+        constructor on a NULL pointer (undefined behavior, and a crash the moment the constructor
+        touches a member). Callers already NULL-check the result (e.g. MessageFactory::CreateMessage).
+     */
+    template <typename T, typename A, typename... Args>
+    T * yojimbo_new( A & allocator, const char * file, int line, Args &&... args )
+    {
+        void * memory = allocator.Allocate( sizeof( T ), file, line );
+        if ( !memory )
+            return NULL;
+        return new ( memory ) T( std::forward<Args>( args )... );
+    }
+
     /// Macro for creating a new object instance with a yojimbo allocator.
-    #define YOJIMBO_NEW( a, T, ... ) ( new ( (a).Allocate( sizeof(T), __FILE__, __LINE__ ) ) T(__VA_ARGS__) )
+    #define YOJIMBO_NEW( a, T, ... ) ( yojimbo::yojimbo_new<T>( (a), __FILE__, __LINE__, ##__VA_ARGS__ ) )
 
     /// Macro for deleting an object created with a yojimbo allocator.
     #define YOJIMBO_DELETE( a, T, p ) do { if (p) { (p)->~T(); (a).Free( p, __FILE__, __LINE__ ); p = NULL; } } while (0)

--- a/include/yojimbo_message.h
+++ b/include/yojimbo_message.h
@@ -556,7 +556,7 @@ namespace yojimbo
 #define YOJIMBO_DECLARE_MESSAGE_TYPE( message_type, message_class )                                                                     \
                                                                                                                                         \
                 case message_type:                                                                                                      \
-                    message = YOJIMBO_NEW( allocator, message_class, );                                                                 \
+                    message = YOJIMBO_NEW( allocator, message_class );                                                                  \
                     if ( !message )                                                                                                     \
                         return NULL;                                                                                                    \
                     SetMessageType( message, message_type );                                                                            \

--- a/source/yojimbo_connection.cpp
+++ b/source/yojimbo_connection.cpp
@@ -38,7 +38,12 @@ namespace yojimbo
             Allocator & allocator = messageFactory->GetAllocator();
             channelEntry = (ChannelPacketData*) YOJIMBO_ALLOCATE( allocator, sizeof( ChannelPacketData ) * numEntries );
             if ( channelEntry == NULL )
+            {
+                // On the read path numChannelEntries was already set from the wire before this
+                // call; reset it so the destructor doesn't iterate a NULL channelEntry array.
+                numChannelEntries = 0;
                 return false;
+            }
             for ( int i = 0; i < numEntries; ++i )
             {
                 channelEntry[i].Initialize();

--- a/test.cpp
+++ b/test.cpp
@@ -1891,6 +1891,62 @@ void test_connection_generate_packet_channel_data_alloc_failure()
     check( allocator.GetOutstanding() == 0 );   // no leak across teardown
 }
 
+void test_message_factory_create_message_alloc_failure()
+{
+    // Regression: YOJIMBO_NEW used to run the constructor on a NULL pointer when the allocation
+    // failed (undefined behavior / crash) before CreateMessage's NULL check. CreateMessage must
+    // return NULL cleanly on allocator exhaustion and flag the factory.
+    ArmableAllocator allocator;
+    {
+        TestMessageFactory factory( allocator );
+        allocator.Arm( 0 );     // fail the next allocation (the message object)
+        Message * message = factory.CreateMessage( TEST_MESSAGE );
+        allocator.Disarm();
+        check( message == NULL );
+        check( factory.GetErrorLevel() == MESSAGE_FACTORY_ERROR_FAILED_TO_ALLOCATE_MESSAGE );
+    }
+    check( allocator.GetOutstanding() == 0 );
+}
+
+void test_connection_process_packet_channel_data_alloc_failure()
+{
+    // Regression: on the read path, if AllocateChannelData failed, numChannelEntries had already
+    // been read from the wire, so the ConnectionPacket destructor iterated a NULL channelEntry
+    // array (crash). Feed a valid packet to a receiver whose allocator fails the channel-data
+    // allocation, and verify the read fails cleanly without crashing or leaking.
+    ArmableAllocator senderAlloc;
+    ArmableAllocator receiverAlloc;
+    {
+        TestMessageFactory senderFactory( senderAlloc );
+        TestMessageFactory receiverFactory( receiverAlloc );
+
+        ConnectionConfig config;
+        config.numChannels = 1;
+        config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+
+        {
+            Connection sender( senderAlloc, senderFactory, config, 100.0 );
+            Connection receiver( receiverAlloc, receiverFactory, config, 100.0 );
+
+            Message * message = senderFactory.CreateMessage( TEST_MESSAGE );
+            check( message );
+            sender.SendMessage( 0, message );
+
+            uint8_t packetData[4096];
+            int packetBytes = 0;
+            check( sender.GeneratePacket( NULL, 0, packetData, sizeof( packetData ), packetBytes ) );
+            check( packetBytes > 0 );
+
+            receiverAlloc.Arm( 0 );     // fail the channel-data allocation in the connection-packet read
+            const bool ok = receiver.ProcessPacket( NULL, 0, packetData, packetBytes );
+            receiverAlloc.Disarm();
+            check( !ok );               // read fails cleanly rather than crashing in the destructor
+        }
+    }
+    check( senderAlloc.GetOutstanding() == 0 );
+    check( receiverAlloc.GetOutstanding() == 0 );
+}
+
 void test_client_server_messages()
 {
     const uint64_t clientId = 1;
@@ -3151,6 +3207,8 @@ int main( int argc, char ** argv )
         RUN_TEST( test_connection_reliable_message_alloc_failure );
         RUN_TEST( test_connection_unreliable_message_alloc_failure );
         RUN_TEST( test_connection_generate_packet_channel_data_alloc_failure );
+        RUN_TEST( test_message_factory_create_message_alloc_failure );
+        RUN_TEST( test_connection_process_packet_channel_data_alloc_failure );
 
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );


### PR DESCRIPTION
Extends the connection fuzzing to cover the two bug classes from this review pass, and fixes two more crashes the new fuzzing surfaced within seconds of running.

## Fuzzing additions (`fuzz_connection_structured`)

- **Allocation-failure injection.** A fault allocator, armed from the fuzz input (only *after* construction — the fixed pools are allocated up front and treated as infallible), drives every runtime allocation through a fail-on-Nth path. Combined with ASan and the message-factory leak check, this exercises the send/receive allocation-failure paths continuously.
- **Adversarial block fragments.** Builds a `ChannelPacketData` with fuzz-chosen, deliberately out-of-spec header fields (full-size final fragment, boundary `numFragments`/`fragmentId`) and serializes it through the library's *own* writer (so the wire format stays in sync — only the values are adversarial), feeding a dedicated receiver on a config whose `maxBlockSize` is not a multiple of `blockFragmentSize`. Targets the block-reassembly bounds check directly.
- `fuzz_config.h` gains two non-multiple-`maxBlockSize` geometries (configs 6/7), appended so existing corpus inputs still map to the same config.

## Fixes (both OOM-only crashes the fault fuzzing found)

- **`YOJIMBO_NEW` constructed on NULL.** It placement-constructed even when the allocation failed (UB / crash), before the caller's `if (!p) return NULL` — so `MessageFactory::CreateMessage` crashed under exhaustion instead of returning NULL. Now a variadic-template helper allocates first and only constructs on success. (Also dropped a trailing comma in `YOJIMBO_DECLARE_MESSAGE_TYPE`'s `YOJIMBO_NEW(...)` so the zero-arg case elides cleanly.)
- **`ConnectionPacket` read path.** When `AllocateChannelData` failed, `numChannelEntries` had already been read from the wire, so the destructor iterated a NULL `channelEntry` array. Now resets `numChannelEntries = 0` on failure.

## Testing

New regression tests `test_message_factory_create_message_alloc_failure` and `test_connection_process_packet_channel_data_alloc_failure`, both verified to **trap under UBSan against the pre-fix code** (`constructor call on null pointer`, `member call on null pointer` at connection.cpp:26) and to pass after. Full suite passes under ASan+UBSan and in CMake Debug + Release; the standalone fuzzer runs 500k iterations clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)