### PR TITLE
Fix NULL-client crash in Client::Connect / ConnectLoopback on socket failure

### DIFF
--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -87,6 +87,13 @@ namespace yojimbo
         CreateInternal();
         m_clientId = clientId;
         CreateClient( m_address );
+        if ( !m_client )
+        {
+            // Socket creation/bind failed (e.g. port in use, invalid bind address). Bail before
+            // calling into netcode, which dereferences the client pointer without checking.
+            Disconnect();
+            return;
+        }
         netcode_client_connect( m_client, connectToken );
         if ( netcode_client_state( m_client ) > NETCODE_CLIENT_STATE_DISCONNECTED )
         {
@@ -188,6 +195,12 @@ namespace yojimbo
         CreateInternal();
         m_clientId = clientId;
         CreateClient( m_address );
+        if ( !m_client )
+        {
+            // Socket creation/bind failed. Bail before netcode dereferences the client pointer.
+            Disconnect();
+            return;
+        }
         netcode_client_connect_loopback( m_client, clientIndex, maxClients );
         SetClientState( CLIENT_STATE_CONNECTED );
     }

--- a/test.cpp
+++ b/test.cpp
@@ -1947,6 +1947,31 @@ void test_connection_process_packet_channel_data_alloc_failure()
     check( receiverAlloc.GetOutstanding() == 0 );
 }
 
+void test_client_connect_socket_failure_no_crash()
+{
+    // Regression: Connect() and ConnectLoopback() called into netcode_client_connect() without
+    // checking that CreateClient() succeeded. When the socket can't be created - forced here with
+    // an unparseable bind address - m_client is NULL and netcode dereferences it (crash in
+    // release; assert trap in debug). Both must bail like InsecureConnect() already does.
+    ClientServerConfig config;
+
+    Address invalidAddress;                     // ADDRESS_NONE -> "NONE" -> netcode_client_create fails
+    check( !invalidAddress.IsValid() );
+
+    Client client( GetDefaultAllocator(), invalidAddress, config, adapter, 100.0 );
+
+    uint8_t connectToken[ConnectTokenBytes];
+    memset( connectToken, 0, sizeof( connectToken ) );
+
+    client.Connect( 1, connectToken );          // must not crash - CreateClient failed
+    check( !client.IsConnected() );
+
+    client.ConnectLoopback( 0, 1, 1 );          // must not crash either
+    check( !client.IsConnected() );
+
+    client.Disconnect();
+}
+
 void test_client_server_messages()
 {
     const uint64_t clientId = 1;
@@ -3210,6 +3235,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_message_factory_create_message_alloc_failure );
         RUN_TEST( test_connection_process_packet_channel_data_alloc_failure );
 
+        RUN_TEST( test_client_connect_socket_failure_no_crash );
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );
         RUN_TEST( test_client_server_message_failed_to_serialize_reliable_ordered );


### PR DESCRIPTION
## The bug

`Client::CreateClient()` leaves `m_client == NULL` when the netcode client can't be created — socket bind failure, port already in use, an invalid bind address, file-descriptor exhaustion, etc. `InsecureConnect()` checks for this (`if (!m_client) { Disconnect(); return; }`), but **`Connect()` and `ConnectLoopback()` did not** — they called `netcode_client_connect()` / `netcode_client_connect_loopback()` unconditionally.

netcode dereferences the client pointer immediately:

```c
void netcode_client_connect( struct netcode_client_t * client, uint8_t * connect_token )
{
    netcode_assert( client );
    netcode_assert( connect_token );
    netcode_client_disconnect( client );   // <-- NULL deref
    ...
```

So a failed client socket → assert trap in debug, **NULL-pointer segfault in release**. `Connect()` is the primary secure-connect entry point, making this an easily-hit crash for any app whose client socket fails to bind (a port already in use is enough).

## The fix

`Connect()` and `ConnectLoopback()` now bail out exactly like `InsecureConnect()` when `m_client` is NULL.

## Testing

New regression test `test_client_connect_socket_failure_no_crash` forces `CreateClient()` to fail via an unparseable bind address (`ADDRESS_NONE` → `"NONE"`, which `netcode_client_create` rejects) and calls both `Connect()` and `ConnectLoopback()`. Verified to **trap at `netcode_client_connect` against the pre-fix code** (`assert failed: ( client ), netcode.c:2832`) and to pass after. Full suite passes in CMake Debug and Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)