### PR TITLE
Fix NULL-client crash in Client::IsLoopback when disconnected

### DIFF
--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -216,7 +216,9 @@ namespace yojimbo
 
     bool Client::IsLoopback() const
     {
-        return netcode_client_loopback( m_client ) != 0;
+        // Safe to query in any state: when not connected there is no netcode client, so this is
+        // not a loopback client. netcode_client_loopback() would dereference a NULL m_client.
+        return m_client ? ( netcode_client_loopback( m_client ) != 0 ) : false;
     }
 
     void Client::ProcessLoopbackPacket( const uint8_t * packetData, int packetBytes, uint64_t packetSequence )

--- a/test.cpp
+++ b/test.cpp
@@ -1972,6 +1972,20 @@ void test_client_connect_socket_failure_no_crash()
     client.Disconnect();
 }
 
+void test_client_is_loopback_when_disconnected()
+{
+    // Regression: IsLoopback() called netcode_client_loopback(m_client) with no NULL guard, so a
+    // never-connected client (m_client == NULL) crashed. Like GetClientIndex(), it must be safe
+    // to query in any state and simply report false.
+    ClientServerConfig config;
+    Address clientAddress( "0.0.0.0", ClientPort );
+    Client client( GetDefaultAllocator(), clientAddress, config, adapter, 100.0 );
+
+    check( !client.IsLoopback() );              // must not crash; not connected -> not a loopback client
+    check( client.GetClientIndex() == -1 );
+    check( !client.IsConnected() );
+}
+
 void test_client_server_messages()
 {
     const uint64_t clientId = 1;
@@ -3236,6 +3250,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_connection_process_packet_channel_data_alloc_failure );
 
         RUN_TEST( test_client_connect_socket_failure_no_crash );
+        RUN_TEST( test_client_is_loopback_when_disconnected );
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );
         RUN_TEST( test_client_server_message_failed_to_serialize_reliable_ordered );


### PR DESCRIPTION
Follow-up to #287 (same bug class, found by auditing every `netcode_client_*` call in `client.cpp` for a missing `m_client` guard).

## The bug

`IsLoopback()` calls `netcode_client_loopback(m_client)` with no NULL check:

```cpp
bool Client::IsLoopback() const
{
    return netcode_client_loopback( m_client ) != 0;
}
```

`m_client` is NULL whenever the client isn't connected (before the first connect, or after disconnect), and netcode dereferences it immediately:

```c
int netcode_client_loopback( struct netcode_client_t * client )
{
    netcode_assert( client );
    return client->loopback;      // NULL deref
}
```

→ assert trap in debug, **NULL-pointer segfault in release**. Unlike `DisconnectLoopback()` / `ProcessLoopbackPacket()` (which document a "must already be a connected loopback client" precondition), `IsLoopback()` is a plain query with no precondition, so it must be safe to call in any state. `GetClientIndex()` immediately above it already guards this way (`m_client ? … : -1`); `IsLoopback()` now matches.

## Testing

`test_client_is_loopback_when_disconnected` queries `IsLoopback()` on a never-connected client — verified to trap at `netcode_client_loopback` (`netcode.c:3456`) against the pre-fix code and to pass after. Full suite passes in CMake Debug and Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)