### PR TITLE
Validate config at startup, document design assumptions, harden .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,21 +8,56 @@
 *.vcxproj.filters
 *.sln
 
-# CMake
+# CMake generated build files must never be committed (including in-source builds)
 /build/
 /build-*/
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
 CTestTestfile.cmake
+CPackConfig.cmake
+CPackSourceConfig.cmake
+install_manifest.txt
+compile_commands.json
+Testing/
+_deps/
+.cmake/
 # CMake generates the top-level Makefile for in-source builds; never commit it.
 /Makefile
+# Ninja generator (in-source builds)
+build.ninja
+.ninja_deps
+.ninja_log
 
-# Build artifacts: compiled objects and static libraries must never be committed.
+# Build artifacts: compiled objects, libraries, executables and debug symbols
+# must never be committed.
 *.a
 *.o
 *.obj
 *.lib
+*.so
+*.so.*
+*.dylib
+*.dll
+*.exe
+*.out
+*.pdb
+*.ilk
+*.exp
+*.dSYM/
+
+# Locally built fuzz targets and libFuzzer artifacts (see fuzz/README.md; the
+# committed seed corpus lives in fuzz/corpus/, the working corpus in /corpus/)
+/fuzz_reliable
+/fuzz_netcode
+/fuzz_netcode_connect_token
+/fuzz_connection
+/fuzz_connection_structured
+/corpus/
+crash-*
+oom-*
+timeout-*
+leak-*
 
 # Misc
 *.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,176 @@
+# CLAUDE.md — Audit of yojimbo
+
+*An honest code audit written by Claude (July 2026), covering the yojimbo library proper
+(`include/`, `source/`), its vendored dependencies (`netcode/`, `reliable/`, `serialize/`,
+`sodium/`, `tlsf/`), tests, fuzzing, CI, and documentation.*
+
+## Orientation
+
+yojimbo is a C++ client/server network library for real-time multiplayer games. It layers
+cleanly: **yojimbo** (messages, channels, connection, allocators) sits on **reliable**
+(acks, packet fragmentation), **netcode** (encrypted UDP, connect-token authentication),
+and a pruned **libsodium** (crypto), with **serialize** (bitpacker) and **tlsf**
+(per-client heaps) alongside. Each dependency is vendored as an amalgamated one- or
+two-file library maintained by the same author. The yojimbo layer itself is ~9,300 lines
+of source plus well-documented headers — small enough to hold in your head, which is a
+feature.
+
+## Design contract (per the author)
+
+These are deliberate design decisions, not defects — reviews and changes should work
+within them:
+
+- **Asserts enforce programmer contracts.** Correct usage and configuration are validated
+  by asserts in debug builds; release builds pay zero overhead because the programmer is
+  expected to have validated their integration in debug before shipping. Any added
+  validation must follow this pattern (debug-only, fails loudly, compiles away).
+- **The config must be identical on client and server** or they won't work. Each side can
+  only validate locally; keeping the two sides in sync is the integrator's
+  responsibility.
+- **Single-threaded by design.** All client/server/message APIs are called from one
+  thread.
+- **Designed for client/server games with ~100 players or less** — the memory model,
+  `MaxClients = 64`, and per-client heap sizing all assume that scale.
+- **Log level semantics:** `ERROR` is an error, `INFO` is infrequent but important
+  ("client connected"), `DEBUG` is too frequent for info, and per-packet spam goes below
+  that. `LOG_LEVEL_NONE` is not a severity — it's a glorified printf for emitting data to
+  library users without log-level filtering interfering (e.g. the assert handler's
+  output).
+
+## Verdict
+
+This is a mature, genuinely well-engineered library, and the README's claim of
+"stable and production ready" is credible. Ten years of history show in the right ways:
+the hard-won invariants are written down where they matter (the sequence-buffer
+wraparound war story, the attacker-controlled-fragment bounds check), the error paths are
+handled rather than hoped away, and the recent hardening pass — fuzzers over every
+untrusted parser, sanitizers and a sanitized soak test in CI, allocation-failure
+injection tests — puts it well above the norm for open-source game networking. My honest
+overall opinion: I would trust this library in production. The criticisms below are real
+but they are footguns and polish, not rot.
+
+## What's genuinely good
+
+- **Security posture.** Encryption and authentication are on by default, not opt-in. The
+  connect-token model pushes unauthenticated-traffic rejection down into netcode before
+  any per-client state is allocated. The untrusted read path is disciplined: every
+  wire-read value is range-bounded by the serializer, validation happens *before* the
+  memcpy (see the over-long-final-fragment check in
+  `ReliableOrderedChannel::ProcessPacketFragment`), and malformed input degrades to a
+  channel error level and a disconnect — never an assert, never trust. Debug asserts are
+  deliberately kept off the read path so a hostile peer can't crash a debug server.
+- **The fuzzing setup is exemplary.** Five libFuzzer targets cover each parsing layer,
+  including the post-decrypt layers that naive fuzzing can't reach (the decrypted
+  connect-token parser gets its own target because the AEAD boundary blocks mutation; the
+  stateful connection target threads multiple packets through one live `Connection` so
+  block reassembly is reachable; the structured target drives the real write path so the
+  receiver never bails early). CI runs them per-PR, a nightly runs them long with a
+  persistent corpus and dictionaries, and `fuzz/README.md` documents actual bugs found —
+  with regression tests in `test.cpp`. That is evidence of a working process, not
+  security theater.
+- **Memory architecture.** Everything allocates through a pluggable `Allocator`;
+  the server silos each client into its own TLSF heap, so one client exhausting its
+  budget cannot starve another or the global heap — the right containment model for a
+  game server. Allocation failure is handled deliberately on essentially every path, with
+  ownership reasoning written at the site (who holds the reference, what must be freed).
+  Debug builds track leaks for both memory and messages.
+- **The serialization design.** One templated serialize function per message, compiled
+  three ways (read/write/measure), with packet budgeting driven by the measure stream.
+  It's elegant, it's fast, and the unified path makes read/write mismatches structurally
+  harder to write.
+- **Asserts as the contract-enforcement mechanism.** The library's explicit design
+  contract: asserts enforce correct usage and configuration in debug builds, and release
+  builds pay zero overhead because the programmer has already validated their integration
+  by running it in debug. The assert placement makes that contract actually work — config
+  invariants (power-of-two buffer sizes, channel counts) assert in constructors, so every
+  debug run validates the config at startup; usage contracts deep in the stack are
+  asserted where they're exercised (e.g. `reliable.c` asserts the fragment count fits
+  `max_fragments` at send time); API misuse paths additionally degrade gracefully in
+  release (`yojimbo_assert(CanSendMessage())` followed by a handled error). Meanwhile
+  asserts are deliberately kept *off* the untrusted network read path, so the full-trust
+  rule for programmer inputs is never confused with the zero-trust rule for wire data.
+  This is the classic game-engine contract, applied consistently.
+- **Tests and CI.** 37 functional tests including adversarial cases (empty packets,
+  fragment overflow, over-budget packets, receive-queue overflow, allocation-failure
+  injection), Linux/macOS/Windows builds, ASan+UBSan+LSan, a separate MSan job with a
+  written rationale for its build flags, and a sanitized 20k-iteration soak run per PR.
+- **Documentation.** Header comment density is exceptional, `USAGE.md` is a real
+  integration walkthrough rather than API listing, and `SECURITY.md` is clear about
+  scope, reporting, and the vendored-sodium liability. Most commercial codebases don't
+  document this well.
+
+## Honest criticisms
+
+Ordered by how much I think they matter. (Two items from the first draft of this audit —
+"config validation is assert-only" and "`maxPacketFragments` goes stale" — were revised
+after the author clarified the assert design contract: debug-only validation is the
+intended mechanism, not a defect. What survived is captured in the note below and the
+list that follows.)
+
+*Note on config validation:* the one genuine gap the original criticism found was that
+`maxPacketFragments` is derived from `maxPacketSize` inside the `ClientServerConfig`
+constructor, so raising `maxPacketSize` afterwards (the documented config pattern)
+silently leaves it too small — the debug assert for that case fired three layers down in
+`reliable.c`, at send time, only when a large enough packet was actually generated, and
+nothing pointed at the config field. `soak.cpp` itself had this latent bug. This is now
+closed within the contract: `ClientServerConfig::Validate()`
+(`source/yojimbo_config.cpp`) runs at `Server::Start` and on every client connect path,
+asserts each config invariant at startup with a message naming the field and the fix, and
+compiles away entirely in release.
+
+1. **Disconnect diagnostics are thin for production use.** Channel errors collapse into
+   one enum, trigger a disconnect, and the reason is only visible as an ERROR-level log
+   line at the moment it happens. A game shipping at scale wants to know *why* clients
+   disconnect (which channel, which error, counters over time) programmatically —
+   `GetNetworkInfo` covers transport stats but there's no error/disconnect-cause
+   telemetry surface. This is the gap I'd feel first operating a real game on it.
+
+2. **The single-threaded, ≤100-player contract is under-signposted.** Both are deliberate
+   design decisions (see the design contract above), and the author is comfortable with
+   them being surfaced — the criticism is only that the codebase barely states them: one
+   line in `yojimbo_allocator.h` is the sole thread-safety statement. Contracts enforced
+   by programmer responsibility only work when they're written down where integrators
+   will read them; a prominent paragraph in README/USAGE would do it, because violating
+   the threading contract produces rare refcount races in production, not a clean
+   failure.
+
+3. **Manual message refcounting is easy to misuse.** Create/Send transfers ownership;
+   Receive obligates a Release; the compiler enforces none of it. This is consistent with
+   the library's contract style, and the debug leak checker is its enforcement mechanism
+   — though `exit(1)` from the factory destructor is hostile if the library is embedded
+   in an editor or tool. This is the part of the API where integrators will make their
+   first mistake.
+
+4. **`alloca` sized by config in packet and tick paths.** With default configs the sizes
+   are trivial, but `Client::AdvanceTime` puts ~12 bytes × `maxSimulatorPackets` (48KB at
+   the default 4096) on the stack per tick when the simulator is active, and a user who
+   cranks `maxMessagesPerPacket` or `maxSimulatorPackets` converts a config choice into a
+   silent stack-overflow risk. Fixed member buffers or the channel allocator would be
+   sturdier.
+
+5. **The C++ dialect is dated — deliberately, but with a couple of leaks.** C++03 idioms
+   (NULL, private copy constructors instead of `=delete`, no `override`, `std::map` in
+   debug trackers) are a fair trade for portability into engine codebases with exceptions
+   and RTTI off. Two things do leak out of that choice, though:
+   `#pragma warning(disable: 4244)` in `yojimbo_config.h` suppresses narrowing warnings
+   in *user* translation units that include yojimbo headers, and the `#undef SendMessage`
+   in the public headers silently deletes the Win32 macro for users who include
+   `windows.h` first. Both deserve at least a documentation note.
+
+6. **Vendored-crypto maintenance burden.** The pruned libsodium subset means upstream
+   CVEs must be tracked and re-vendored by hand. `SECURITY.md` acknowledges this honestly
+   and `-DYOJIMBO_SYSTEM_SODIUM=ON` exists as an escape hatch, which is the right
+   mitigation — but it remains a standing liability inherent to the amalgamation
+   approach, and it's the one place where the single-maintainer model concentrates risk.
+
+## Bottom line
+
+The architecture is sound, the security engineering is unusually serious for the genre,
+and the code reads like it's been maintained by someone who has debugged it at 90% packet
+loss — because it has. The design contract is coherent: zero trust for anything off the
+wire, full trust plus debug-time assert enforcement for the programmer's own inputs, and
+zero overhead in release. With startup config validation now in place, the remaining asks
+I'd weight most are disconnect-cause telemetry and writing the threading/scale contract
+into the front-page docs. If I were choosing a C++ client/server layer for a competitive
+multiplayer game today, this would be on my shortlist, and the source being small and
+readable enough to audit in an afternoon is a large part of why.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ It has the following features:
 
 yojimbo is stable and production ready.
 
+## Design Assumptions
+
+yojimbo is **single-threaded**. Call all client and server functions from the same thread. If you want to run networking on its own thread, that works fine — just make sure every yojimbo call happens on that one thread.
+
+yojimbo is designed for **client/server games with 100 players or less**.
+
+The client and server must use the **same configuration**. Make sure the `ClientServerConfig`, channels and message factory are identical on both sides, or the client and server won't work together. In debug builds, each side validates its own configuration at startup and asserts if it's invalid — keeping the two sides in sync is your responsibility.
+
 ## Source Code
 
 You can get the latest source code by cloning it from github:

--- a/include/yojimbo_config.h
+++ b/include/yojimbo_config.h
@@ -158,6 +158,17 @@ namespace yojimbo
             // which counts fragments with ceil).
             return ( maxBlockSize + blockFragmentSize - 1 ) / blockFragmentSize;
         }
+
+        /**
+            Validate this channel configuration.
+            Asserts (debug builds only, zero overhead in release) on invariants the channel implementations rely on,
+            so an invalid channel config fails loudly at startup rather than corrupting channel state at runtime.
+            Called for each channel by ConnectionConfig::Validate.
+            @param channelIndex The index of this channel in the connection config. Used for error reporting.
+            @param maxPacketSize The maximum packet size from the connection config (bytes).
+         */
+
+        void Validate( int channelIndex, int maxPacketSize ) const;
     };
 
     /**
@@ -178,6 +189,16 @@ namespace yojimbo
             maxPacketSize = 8 * 1024;
             channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
         }
+
+        /**
+            Validate this connection configuration.
+            Asserts (debug builds only, zero overhead in release) on invariants the connection and channels rely on,
+            so an invalid config fails loudly at startup rather than corrupting state at runtime.
+            IMPORTANT: The connection config must be identical on the client and the server. This validates each side
+            locally — keeping the two sides in sync is your responsibility.
+         */
+
+        void Validate() const;
     };
 
     /**
@@ -220,6 +241,18 @@ namespace yojimbo
             receivedPacketsBufferSize = 256;
             rttSmoothingFactor = 0.0025f;
         }
+
+        /**
+            Validate this client/server configuration.
+            Asserts (debug builds only, zero overhead in release) on invariants the client and server rely on,
+            so an invalid config fails loudly at startup rather than misbehaving at runtime.
+            Called automatically by Server::Start and when the client connects. You can also call it directly.
+            IMPORTANT: If you increase maxPacketSize after construction, you must also update maxPacketFragments,
+            because it is derived from maxPacketSize inside the ClientServerConfig constructor. This is one of the
+            things validated here.
+         */
+
+        void Validate() const;
     };
 }
 

--- a/soak.cpp
+++ b/soak.cpp
@@ -26,6 +26,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 
 const int MaxPacketSize = 16 * 1024;
 const int MaxSnapshotSize = 8 * 1024;
@@ -45,6 +46,10 @@ int SoakMain( int iterations )
 {
     ClientServerConfig config;
     config.maxPacketSize = MaxPacketSize;
+    // maxPacketFragments was derived from the default maxPacketSize in the ClientServerConfig
+    // constructor. We just doubled maxPacketSize, so recompute it or packets larger than
+    // packetFragmentSize * maxPacketFragments can't be fragmented (config.Validate() catches this).
+    config.maxPacketFragments = (int) ceil( config.maxPacketSize / (double) config.packetFragmentSize );
     config.clientMemory = 100 * 1024 * 1024;
     config.serverGlobalMemory = 10 * 1024 * 1024;
     config.serverPerClientMemory = 100 * 1024 * 1024;

--- a/source/yojimbo_base_client.cpp
+++ b/source/yojimbo_base_client.cpp
@@ -137,6 +137,8 @@ namespace yojimbo
         yojimbo_assert( m_clientAllocator == NULL );
         yojimbo_assert( m_messageFactory == NULL );
 
+        m_config.Validate();
+
         m_clientMemory = (uint8_t*) YOJIMBO_ALLOCATE( *m_allocator, m_config.clientMemory );
         m_clientAllocator = m_adapter->CreateAllocator( *m_allocator, m_clientMemory, m_config.clientMemory );
         m_messageFactory = m_adapter->CreateMessageFactory( *m_clientAllocator );

--- a/source/yojimbo_base_server.cpp
+++ b/source/yojimbo_base_server.cpp
@@ -47,6 +47,8 @@ namespace yojimbo
     {
         yojimbo_assert( maxClients <= MaxClients );
 
+        m_config.Validate();
+
         Stop();
 
         m_running = true;

--- a/source/yojimbo_config.cpp
+++ b/source/yojimbo_config.cpp
@@ -1,0 +1,176 @@
+/*
+    Yojimbo Client/Server Network Library.
+
+    Copyright © 2016 - 2026, Más Bandwidth LLC.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+           in the documentation and/or other materials provided with the distribution.
+
+        3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived
+           from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+    USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "yojimbo_config.h"
+#include "yojimbo_platform.h"
+
+#include <math.h>
+
+namespace yojimbo
+{
+#ifdef YOJIMBO_DEBUG
+
+    // Print what is wrong with the config (with the offending values), then assert. Debug builds
+    // only: config validation follows the library-wide contract that asserts enforce correct usage
+    // in debug and the programmer has already validated their integration before shipping release.
+    #define YOJIMBO_CONFIG_CHECK( condition, ... )                                                  \
+        do                                                                                          \
+        {                                                                                           \
+            if ( !( condition ) )                                                                   \
+            {                                                                                       \
+                yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, __VA_ARGS__ );                             \
+                yojimbo_assert( condition );                                                        \
+            }                                                                                       \
+        } while ( 0 )
+
+    void ChannelConfig::Validate( int channelIndex, int maxPacketSize ) const
+    {
+        YOJIMBO_CONFIG_CHECK( messageSendQueueSize > 0,
+            "error: invalid config: channel %d messageSendQueueSize (%d) must be > 0\n", channelIndex, messageSendQueueSize );
+
+        YOJIMBO_CONFIG_CHECK( messageReceiveQueueSize > 0,
+            "error: invalid config: channel %d messageReceiveQueueSize (%d) must be > 0\n", channelIndex, messageReceiveQueueSize );
+
+        YOJIMBO_CONFIG_CHECK( maxMessagesPerPacket > 0,
+            "error: invalid config: channel %d maxMessagesPerPacket (%d) must be > 0\n", channelIndex, maxMessagesPerPacket );
+
+        if ( !disableBlocks )
+        {
+            YOJIMBO_CONFIG_CHECK( maxBlockSize > 0,
+                "error: invalid config: channel %d maxBlockSize (%d) must be > 0\n", channelIndex, maxBlockSize );
+        }
+
+        if ( type == CHANNEL_TYPE_RELIABLE_ORDERED )
+        {
+            // The reliable-ordered channel stores its state in sequence buffers indexed by
+            // sequence % size, which only works when the size divides 65536 (ie. a power of two).
+            // Any other size aliases sequence numbers and corrupts channel state.
+
+            YOJIMBO_CONFIG_CHECK( sentPacketBufferSize > 0,
+                "error: invalid config: channel %d sentPacketBufferSize (%d) must be > 0\n", channelIndex, sentPacketBufferSize );
+
+            YOJIMBO_CONFIG_CHECK( ( 65536 % sentPacketBufferSize ) == 0,
+                "error: invalid config: channel %d sentPacketBufferSize (%d) must be a power of two\n", channelIndex, sentPacketBufferSize );
+
+            YOJIMBO_CONFIG_CHECK( ( 65536 % messageSendQueueSize ) == 0,
+                "error: invalid config: channel %d messageSendQueueSize (%d) must be a power of two\n", channelIndex, messageSendQueueSize );
+
+            YOJIMBO_CONFIG_CHECK( ( 65536 % messageReceiveQueueSize ) == 0,
+                "error: invalid config: channel %d messageReceiveQueueSize (%d) must be a power of two\n", channelIndex, messageReceiveQueueSize );
+
+            if ( !disableBlocks )
+            {
+                YOJIMBO_CONFIG_CHECK( blockFragmentSize > 0,
+                    "error: invalid config: channel %d blockFragmentSize (%d) must be > 0\n", channelIndex, blockFragmentSize );
+
+                // A block fragment must fit inside a packet, or the channel stalls forever trying
+                // to send the block (see ReliableOrderedChannel::GetPacketData).
+                YOJIMBO_CONFIG_CHECK( blockFragmentSize <= maxPacketSize,
+                    "error: invalid config: channel %d blockFragmentSize (%d) must be <= maxPacketSize (%d)\n", channelIndex, blockFragmentSize, maxPacketSize );
+
+                // Fragment id 0xFFFF is reserved as a sentinel (see GetFragmentToSend).
+                YOJIMBO_CONFIG_CHECK( GetMaxFragmentsPerBlock() <= 65535,
+                    "error: invalid config: channel %d maxBlockSize (%d) / blockFragmentSize (%d) gives too many fragments per block (max 65535)\n", channelIndex, maxBlockSize, blockFragmentSize );
+            }
+        }
+    }
+
+    void ConnectionConfig::Validate() const
+    {
+        YOJIMBO_CONFIG_CHECK( numChannels >= 1 && numChannels <= MaxChannels,
+            "error: invalid config: numChannels (%d) must be in [1,%d]\n", numChannels, MaxChannels );
+
+        YOJIMBO_CONFIG_CHECK( maxPacketSize > 0,
+            "error: invalid config: maxPacketSize (%d) must be > 0\n", maxPacketSize );
+
+        for ( int i = 0; i < numChannels; ++i )
+        {
+            channel[i].Validate( i, maxPacketSize );
+        }
+    }
+
+    void ClientServerConfig::Validate() const
+    {
+        ConnectionConfig::Validate();
+
+        YOJIMBO_CONFIG_CHECK( clientMemory > 0,
+            "error: invalid config: clientMemory (%d) must be > 0\n", clientMemory );
+
+        YOJIMBO_CONFIG_CHECK( serverGlobalMemory > 0,
+            "error: invalid config: serverGlobalMemory (%d) must be > 0\n", serverGlobalMemory );
+
+        YOJIMBO_CONFIG_CHECK( serverPerClientMemory > 0,
+            "error: invalid config: serverPerClientMemory (%d) must be > 0\n", serverPerClientMemory );
+
+        if ( networkSimulator )
+        {
+            YOJIMBO_CONFIG_CHECK( maxSimulatorPackets > 0,
+                "error: invalid config: maxSimulatorPackets (%d) must be > 0\n", maxSimulatorPackets );
+        }
+
+        YOJIMBO_CONFIG_CHECK( packetFragmentSize > 0,
+            "error: invalid config: packetFragmentSize (%d) must be > 0\n", packetFragmentSize );
+
+        YOJIMBO_CONFIG_CHECK( fragmentPacketsAbove > 0,
+            "error: invalid config: fragmentPacketsAbove (%d) must be > 0\n", fragmentPacketsAbove );
+
+        // maxPacketFragments is derived from maxPacketSize inside the ClientServerConfig
+        // constructor, which runs *before* your code adjusts any fields. If you increase
+        // maxPacketSize you must update maxPacketFragments too, otherwise packets larger than
+        // packetFragmentSize * maxPacketFragments cannot be fragmented and are dropped.
+        const int neededPacketFragments = (int) ceil( maxPacketSize / (double) packetFragmentSize );
+
+        YOJIMBO_CONFIG_CHECK( maxPacketFragments >= neededPacketFragments,
+            "error: invalid config: maxPacketFragments (%d) is too small for maxPacketSize (%d) with packetFragmentSize (%d). It must be at least %d.\n"
+            "maxPacketFragments is computed in the ClientServerConfig constructor, so if you increase maxPacketSize afterwards, update maxPacketFragments as well\n",
+            maxPacketFragments, maxPacketSize, packetFragmentSize, neededPacketFragments );
+
+        // The reliable endpoint encodes (num fragments - 1) as a uint8_t and asserts max_fragments <= 256.
+        YOJIMBO_CONFIG_CHECK( maxPacketFragments <= 256,
+            "error: invalid config: maxPacketFragments (%d) must be <= 256\n", maxPacketFragments );
+
+        YOJIMBO_CONFIG_CHECK( packetReassemblyBufferSize > 0,
+            "error: invalid config: packetReassemblyBufferSize (%d) must be > 0\n", packetReassemblyBufferSize );
+
+        YOJIMBO_CONFIG_CHECK( ackedPacketsBufferSize > 0,
+            "error: invalid config: ackedPacketsBufferSize (%d) must be > 0\n", ackedPacketsBufferSize );
+
+        YOJIMBO_CONFIG_CHECK( receivedPacketsBufferSize > 0,
+            "error: invalid config: receivedPacketsBufferSize (%d) must be > 0\n", receivedPacketsBufferSize );
+    }
+
+#else // #ifdef YOJIMBO_DEBUG
+
+    void ChannelConfig::Validate( int channelIndex, int maxPacketSize ) const
+    {
+        (void) channelIndex;
+        (void) maxPacketSize;
+    }
+
+    void ConnectionConfig::Validate() const {}
+
+    void ClientServerConfig::Validate() const {}
+
+#endif // #ifdef YOJIMBO_DEBUG
+}


### PR DESCRIPTION
## Summary

- **Config validation at startup (debug builds only, zero release overhead).** New `ClientServerConfig::Validate()` / `ConnectionConfig::Validate()` / `ChannelConfig::Validate()` in `source/yojimbo_config.cpp`, called from `BaseServer::Start` and every client connect path. Each invariant asserts with an ERROR-level message naming the field, the offending values, and the required value. Checks include: power-of-two queue/buffer sizes for reliable channels, block fragment size fits in a packet, fragments per block ≤ 65535, `numChannels` in range, memory sizes positive, and `maxPacketFragments >= ceil(maxPacketSize / packetFragmentSize)`.
- **Fix latent stale `maxPacketFragments` in soak.cpp.** `maxPacketFragments` is derived from `maxPacketSize` inside the `ClientServerConfig` constructor, so raising `maxPacketSize` afterwards left it too small (8 fragments for a 16KB max packet). Recomputed after the config is adjusted; the new validation catches this class of mistake at startup instead of a `reliable.c` assert at send time.
- **README: document design assumptions.** Single-threaded, designed for client/server games with 100 players or less, and client/server configuration must be identical.
- **.gitignore: never commit binaries or CMake generated build files.** Adds shared libraries/executables/debug symbols, remaining CMake generated files, Ninja in-source build files, locally built fuzz targets, and libFuzzer crash artifacts. The committed seed corpus under `fuzz/corpus/` stays tracked; no currently tracked file is affected.
- **Add CLAUDE.md** with a code audit and the author-stated design contract (assert philosophy, log level semantics, identical config, threading/scale assumptions).

## Test plan

- [x] `./bin/test` passes in Debug and Release on macOS arm64
- [x] `./bin/soak 2000` runs clean with the corrected soak config
- [x] Reproducer with stale `maxPacketFragments` fails loudly at `Server::Start` in debug: prints the offending values and required minimum, then asserts
- [x] Release build compiles warning-free; `Validate()` bodies compile away (`#ifdef YOJIMBO_DEBUG`)
- [x] `git ls-files -i -c` confirms no tracked file is shadowed by the new .gitignore rules
- [ ] CI matrix (Linux/macOS/Windows, sanitizers, MSan, fuzz, soak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)