### PR TITLE
Add per-client slot disconnect reason to the server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,12 +118,14 @@ closed within the contract: `ClientServerConfig::Validate()`
 asserts each config invariant at startup with a message naming the field and the fix, and
 compiles away entirely in release.
 
-1. **Disconnect diagnostics are thin for production use.** Channel errors collapse into
-   one enum, trigger a disconnect, and the reason is only visible as an ERROR-level log
-   line at the moment it happens. A game shipping at scale wants to know *why* clients
-   disconnect (which channel, which error, counters over time) programmatically —
-   `GetNetworkInfo` covers transport stats but there's no error/disconnect-cause
-   telemetry surface. This is the gap I'd feel first operating a real game on it.
+1. **Disconnect diagnostics are thin for production use.** *(Server side addressed:
+   `Server::GetClientDisconnectReason(clientIndex)` returns a per-slot
+   `ServerClientDisconnectReason` — kicked, transport disconnect/timeout, serialize
+   failure, desync, out of memory, etc. — recorded before
+   `Adapter::OnServerClientDisconnected` fires so it can be queried from the callback.)*
+   The client side still compresses the detailed netcode states (connection denied, token
+   expired, timed out) into a single `CLIENT_STATE_ERROR`, so a game cannot tell the
+   player "server is full" versus "network error" without querying netcode directly.
 
 2. **The single-threaded, ≤100-player contract is under-signposted.** Both are deliberate
    design decisions (see the design contract above), and the author is comfortable with

--- a/include/yojimbo_base_server.h
+++ b/include/yojimbo_base_server.h
@@ -87,7 +87,19 @@ namespace yojimbo
 
         void GetNetworkInfo( int clientIndex, NetworkInfo & info ) const;
 
+        /**
+            Get the reason the client in this slot was last disconnected.
+            Valid while the server is running. Recorded before Adapter::OnServerClientDisconnected is called,
+            so you can query it from inside that callback. See ServerClientDisconnectReason for the values.
+            @param clientIndex The index of the client slot in [0,maxClients-1].
+            @returns The disconnect reason (a ServerClientDisconnectReason value). YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE if no client has disconnected from this slot since the server started, or if a new client has since connected to it.
+         */
+
+        int GetClientDisconnectReason( int clientIndex ) const;
+
     protected:
+
+        void SetClientDisconnectReason( int clientIndex, int disconnectReason );
 
         uint8_t * GetPacketBuffer() { return m_packetBuffer; }
 
@@ -137,6 +149,7 @@ namespace yojimbo
         MessageFactory * m_clientMessageFactory[MaxClients];        ///< Array of per-client message factories. This silos message allocations per-client slot.
         Connection * m_clientConnection[MaxClients];                ///< Array of per-client connection classes. This is how messages are exchanged with clients.
         reliable_endpoint_t * m_clientEndpoint[MaxClients];         ///< Array of per-client reliable endpoints.
+        int m_clientDisconnectReason[MaxClients];                   ///< Per-client slot reason the last client in that slot was disconnected (ServerClientDisconnectReason). Reset to none at server start, and when a new client connects to the slot.
         NetworkSimulator * m_networkSimulator;                      ///< The network simulator used to simulate packet loss, latency, jitter etc. Optional.
         uint8_t * m_packetBuffer;                                   ///< Buffer used when writing packets.
     };

--- a/include/yojimbo_connection.h
+++ b/include/yojimbo_connection.h
@@ -77,6 +77,15 @@ namespace yojimbo
 
         ConnectionErrorLevel GetErrorLevel() { return m_errorLevel; }
 
+        /**
+            Get the error level of a channel on this connection.
+            Use this to find out which channel error drove the connection into CONNECTION_ERROR_CHANNEL.
+            @param channelIndex The channel index in [0,numChannels-1].
+            @returns The channel error level.
+         */
+
+        ChannelErrorLevel GetChannelErrorLevel( int channelIndex ) const;
+
     private:
 
         Allocator * m_allocator;                                ///< Allocator passed in to the connection constructor.

--- a/include/yojimbo_server.h
+++ b/include/yojimbo_server.h
@@ -34,6 +34,56 @@ struct netcode_server_t;
 namespace yojimbo
 {
     /**
+        The reason the client in a server client slot was last disconnected.
+
+        This lets you distinguish problems you need to act on (eg. serialize failures indicating a client/server protocol
+        mismatch, or per-client memory exhaustion indicating an undersized config) from normal network behavior (a client
+        cleanly disconnecting or timing out), and route that into your own logging, metrics and analytics.
+
+        Tracked per-client slot. All slots reset to YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE when the server starts,
+        and a slot resets back to NONE when a new client connects to it. The reason is recorded before
+        Adapter::OnServerClientDisconnected is called, so you can query it from inside that callback.
+
+        @see Server::GetClientDisconnectReason
+     */
+
+    enum ServerClientDisconnectReason
+    {
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE = 0,                   ///< No client has disconnected from this slot since the server started, or a new client has since connected to this slot.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DISCONNECTED,               ///< The client cleanly disconnected or timed out at the transport level.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED,                     ///< Server code called Server::DisconnectClient or Server::DisconnectAllClients for this client.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE,        ///< A message from this client failed to serialize read. Usually a client/server protocol version mismatch, or a bug in a message serialize function.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DESYNC,                     ///< A channel for this client desynced and cannot recover. See CHANNEL_ERROR_DESYNC.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_SEND_QUEUE_FULL,            ///< A channel send queue for this client filled up. See CHANNEL_ERROR_SEND_QUEUE_FULL.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_BLOCKS_DISABLED,            ///< This client sent block data on a channel that is configured with blocks disabled.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_MESSAGE_TOO_LARGE,          ///< A message sent to this client is too large to ever fit into a packet. See CHANNEL_ERROR_MESSAGE_TOO_LARGE.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY,              ///< The per-client memory budget for this client was exhausted. Consider increasing ClientServerConfig::serverPerClientMemory.
+        YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_READ_PACKET_FAILED,         ///< A connection packet from this client failed to deserialize.
+    };
+
+    /// Helper function to convert a server client disconnect reason to a user friendly string.
+
+    inline const char * GetServerClientDisconnectReasonString( int reason )
+    {
+        switch ( reason )
+        {
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE:                  return "none";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DISCONNECTED:          return "disconnected";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED:                return "kicked";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE:   return "failed to serialize";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DESYNC:                return "desync";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_SEND_QUEUE_FULL:       return "send queue full";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_BLOCKS_DISABLED:       return "blocks disabled";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_MESSAGE_TOO_LARGE:     return "message too large";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY:         return "out of memory";
+            case YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_READ_PACKET_FAILED:    return "read packet failed";
+            default:
+                yojimbo_assert( false );
+                return "(unknown)";
+        }
+    }
+
+    /**
         Server implementation.
      */
 

--- a/source/yojimbo_base_server.cpp
+++ b/source/yojimbo_base_server.cpp
@@ -4,6 +4,7 @@
 #include "yojimbo_connection.h"
 #include "yojimbo_network_info.h"
 #include "yojimbo_utils.h"
+#include "yojimbo_server.h"             // for the ServerClientDisconnectReason enum
 #include "reliable.h"
 
 namespace yojimbo
@@ -25,6 +26,7 @@ namespace yojimbo
             m_clientMessageFactory[i] = NULL;
             m_clientConnection[i] = NULL;
             m_clientEndpoint[i] = NULL;
+            m_clientDisconnectReason[i] = YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE;
         }
         m_networkSimulator = NULL;
         m_packetBuffer = NULL;
@@ -53,6 +55,11 @@ namespace yojimbo
 
         m_running = true;
         m_maxClients = maxClients;
+
+        for ( int i = 0; i < MaxClients; ++i )
+        {
+            m_clientDisconnectReason[i] = YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE;
+        }
 
         yojimbo_assert( !m_globalMemory );
         yojimbo_assert( !m_globalAllocator );
@@ -145,6 +152,45 @@ namespace yojimbo
         m_packetBuffer = NULL;
     }
 
+    // Map the error that drove a connection into an error state to the disconnect reason we
+    // record for the client slot. For channel errors, drill into the channels to find the one
+    // in error, because that is where the actionable detail lives (eg. serialize failure vs
+    // desync vs out of memory).
+    static int ClientDisconnectReasonForConnectionError( const Connection & connection, ConnectionErrorLevel errorLevel, int numChannels )
+    {
+        switch ( errorLevel )
+        {
+            case CONNECTION_ERROR_ALLOCATOR:            return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY;
+            case CONNECTION_ERROR_MESSAGE_FACTORY:      return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY;
+            case CONNECTION_ERROR_READ_PACKET_FAILED:   return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_READ_PACKET_FAILED;
+
+            case CONNECTION_ERROR_CHANNEL:
+            {
+                for ( int i = 0; i < numChannels; ++i )
+                {
+                    switch ( connection.GetChannelErrorLevel( i ) )
+                    {
+                        case CHANNEL_ERROR_DESYNC:                  return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DESYNC;
+                        case CHANNEL_ERROR_SEND_QUEUE_FULL:         return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_SEND_QUEUE_FULL;
+                        case CHANNEL_ERROR_BLOCKS_DISABLED:         return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_BLOCKS_DISABLED;
+                        case CHANNEL_ERROR_FAILED_TO_SERIALIZE:     return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE;
+                        case CHANNEL_ERROR_OUT_OF_MEMORY:           return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY;
+                        case CHANNEL_ERROR_MESSAGE_TOO_LARGE:       return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_MESSAGE_TOO_LARGE;
+                        case CHANNEL_ERROR_NONE:                    break;
+                    }
+                }
+            }
+            break;
+
+            case CONNECTION_ERROR_NONE:
+                break;
+        }
+
+        // A connection in an error state always matches one of the cases above; keep a sane
+        // value if that ever changes rather than reporting garbage.
+        return YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DISCONNECTED;
+    }
+
     void BaseServer::AdvanceTime( double time )
     {
         m_time = time;
@@ -153,9 +199,11 @@ namespace yojimbo
             for ( int i = 0; i < m_maxClients; ++i )
             {
                 m_clientConnection[i]->AdvanceTime( time );
-                if ( m_clientConnection[i]->GetErrorLevel() != CONNECTION_ERROR_NONE )
+                const ConnectionErrorLevel connectionErrorLevel = m_clientConnection[i]->GetErrorLevel();
+                if ( connectionErrorLevel != CONNECTION_ERROR_NONE )
                 {
                     yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "client %d connection is in error state. disconnecting client\n", i );
+                    SetClientDisconnectReason( i, ClientDisconnectReasonForConnectionError( *m_clientConnection[i], connectionErrorLevel, m_config.numChannels ) );
                     DisconnectClient( i );
                     continue;
                 }
@@ -367,6 +415,20 @@ namespace yojimbo
         yojimbo_assert( pointer );
         Allocator * allocator = (Allocator*) context;
         YOJIMBO_FREE( *allocator, pointer );
+    }
+
+    int BaseServer::GetClientDisconnectReason( int clientIndex ) const
+    {
+        yojimbo_assert( clientIndex >= 0 );
+        yojimbo_assert( clientIndex < m_maxClients );
+        return m_clientDisconnectReason[clientIndex];
+    }
+
+    void BaseServer::SetClientDisconnectReason( int clientIndex, int disconnectReason )
+    {
+        yojimbo_assert( clientIndex >= 0 );
+        yojimbo_assert( clientIndex < m_maxClients );
+        m_clientDisconnectReason[clientIndex] = disconnectReason;
     }
 
     void BaseServer::ResetClient( int clientIndex )

--- a/source/yojimbo_connection.cpp
+++ b/source/yojimbo_connection.cpp
@@ -362,6 +362,13 @@ namespace yojimbo
         return true;
     }
 
+    ChannelErrorLevel Connection::GetChannelErrorLevel( int channelIndex ) const
+    {
+        yojimbo_assert( channelIndex >= 0 );
+        yojimbo_assert( channelIndex < m_connectionConfig.numChannels );
+        return m_channel[channelIndex]->GetErrorLevel();
+    }
+
     void Connection::ProcessAcks( const uint16_t * acks, int numAcks )
     {
         for ( int i = 0; i < numAcks; ++i )

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -96,6 +96,13 @@ namespace yojimbo
     void Server::DisconnectClient( int clientIndex )
     {
         yojimbo_assert( m_server );
+        // Record the kick, but only if no reason is set yet: when the disconnect comes from
+        // BaseServer::AdvanceTime, the specific connection error reason is already recorded
+        // and must not be overwritten with the generic "kicked".
+        if ( IsClientConnected( clientIndex ) && GetClientDisconnectReason( clientIndex ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE )
+        {
+            SetClientDisconnectReason( clientIndex, YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED );
+        }
         netcode_server_disconnect_client( m_server, clientIndex );
         ResetClient( clientIndex );
     }
@@ -103,8 +110,15 @@ namespace yojimbo
     void Server::DisconnectAllClients()
     {
         yojimbo_assert( m_server );
-        netcode_server_disconnect_all_clients( m_server );
         const int maxClients = GetMaxClients();
+        for ( int i = 0; i < maxClients; ++i )
+        {
+            if ( IsClientConnected( i ) && GetClientDisconnectReason( i ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE )
+            {
+                SetClientDisconnectReason( i, YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED );
+            }
+        }
+        netcode_server_disconnect_all_clients( m_server );
         for ( int i = 0; i < maxClients; ++i )
         {
             ResetClient( i );
@@ -243,6 +257,13 @@ namespace yojimbo
     {
         if ( connected == 0 )
         {
+            // If no reason was recorded before the transport-level disconnect (connection error,
+            // kick), the client cleanly disconnected or timed out. Record it before the adapter
+            // callback, so OnServerClientDisconnected can query the reason.
+            if ( GetClientDisconnectReason( clientIndex ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE )
+            {
+                SetClientDisconnectReason( clientIndex, YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DISCONNECTED );
+            }
             GetAdapter().OnServerClientDisconnected( clientIndex );
             reliable_endpoint_reset( GetClientEndpoint( clientIndex ) );
             GetClientConnection( clientIndex ).Reset();
@@ -254,6 +275,9 @@ namespace yojimbo
         }
         else
         {
+            // This slot now belongs to a new client: clear any disconnect reason left behind by
+            // the previous occupant of the slot.
+            SetClientDisconnectReason( clientIndex, YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE );
             GetAdapter().OnServerClientConnected( clientIndex );
         }
     }

--- a/test.cpp
+++ b/test.cpp
@@ -2346,6 +2346,204 @@ void test_client_server_message_failed_to_serialize_reliable_ordered()
     server.Stop();
 }
 
+void test_server_client_disconnect_reason()
+{
+    const uint64_t clientId = 1;
+
+    Address clientAddress( "0.0.0.0", ClientPort );
+    Address serverAddress( "127.0.0.1", ServerPort );
+
+    double time = 100.0;
+
+    ClientServerConfig config;
+
+    uint8_t privateKey[KeyBytes];
+    memset( privateKey, 0, KeyBytes );
+
+    Server server( GetDefaultAllocator(), privateKey, serverAddress, config, adapter, time );
+
+    server.Start( MaxClients );
+
+    // all client slots are cleared to none at server start
+
+    for ( int i = 0; i < MaxClients; ++i )
+    {
+        check( server.GetClientDisconnectReason( i ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE );
+    }
+
+    Client client( GetDefaultAllocator(), clientAddress, config, adapter, time );
+
+    const int NumIterations = 10000;
+
+    // connect a client. while it is connected the reason stays none
+
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        if ( !client.IsConnecting() && client.IsConnected() && server.GetNumConnectedClients() == 1 )
+            break;
+    }
+
+    check( client.IsConnected() );
+    check( server.IsClientConnected( 0 ) );
+    check( server.GetClientDisconnectReason( 0 ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE );
+
+    // kick the client. the reason is recorded immediately, before the adapter callback fires
+
+    server.DisconnectClient( 0 );
+
+    check( server.GetClientDisconnectReason( 0 ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( !client.IsConnected() )
+            break;
+    }
+
+    check( !client.IsConnected() );
+    check( server.GetClientDisconnectReason( 0 ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED );
+
+    // reconnect. a new client connecting to the slot clears the reason back to none
+
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        if ( !client.IsConnecting() && client.IsConnected() && server.GetNumConnectedClients() == 1 )
+            break;
+    }
+
+    check( client.IsConnected() );
+    check( server.IsClientConnected( 0 ) );
+    check( server.GetClientDisconnectReason( 0 ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE );
+
+    // clean client-side disconnect is recorded as a transport-level disconnect
+
+    client.Disconnect();
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( server.GetNumConnectedClients() == 0 )
+            break;
+    }
+
+    check( server.GetNumConnectedClients() == 0 );
+    check( server.GetClientDisconnectReason( 0 ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DISCONNECTED );
+
+    // restarting the server clears all slots back to none
+
+    server.Stop();
+
+    server.Start( MaxClients );
+
+    for ( int i = 0; i < MaxClients; ++i )
+    {
+        check( server.GetClientDisconnectReason( i ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE );
+    }
+
+    server.Stop();
+}
+
+void test_server_client_disconnect_reason_failed_to_serialize()
+{
+    const uint64_t clientId = 1;
+
+    Address clientAddress( "0.0.0.0", ClientPort );
+    Address serverAddress( "127.0.0.1", ServerPort );
+
+    double time = 100.0;
+
+    ClientServerConfig config;
+    config.maxPacketSize = 1100;
+    config.numChannels = 1;
+    config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+    config.channel[0].maxBlockSize = 1024;
+    config.channel[0].blockFragmentSize = 200;
+
+    uint8_t privateKey[KeyBytes];
+    memset( privateKey, 0, KeyBytes );
+
+    Server server( GetDefaultAllocator(), privateKey, serverAddress, config, adapter, time );
+
+    server.Start( MaxClients );
+
+    Client client( GetDefaultAllocator(), clientAddress, config, adapter, time );
+
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
+    const int NumIterations = 10000;
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        if ( !client.IsConnecting() && client.IsConnected() && server.GetNumConnectedClients() == 1 )
+            break;
+    }
+
+    check( !client.IsConnecting() );
+    check( client.IsConnected() );
+    check( server.GetNumConnectedClients() == 1 );
+
+    // send a message that fails to serialize on read. the server disconnects the client
+    // and records the specific channel error as the disconnect reason
+
+    Message * message = client.CreateMessage( TEST_SERIALIZE_FAIL_ON_READ_MESSAGE );
+    check( message );
+    client.SendMessage( 0, message );
+
+    for ( int i = 0; i < 256; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( !client.IsConnected() && server.GetNumConnectedClients() == 0 )
+            break;
+    }
+
+    check( !client.IsConnected() && server.GetNumConnectedClients() == 0 );
+    check( server.GetClientDisconnectReason( 0 ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE );
+
+    client.Disconnect();
+
+    server.Stop();
+}
+
 void test_client_server_message_failed_to_serialize_unreliable_unordered()
 {
     const uint64_t clientId = 1;
@@ -3254,6 +3452,8 @@ int main( int argc, char ** argv )
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );
         RUN_TEST( test_client_server_message_failed_to_serialize_reliable_ordered );
+        RUN_TEST( test_server_client_disconnect_reason );
+        RUN_TEST( test_server_client_disconnect_reason_failed_to_serialize );
         RUN_TEST( test_client_server_message_failed_to_serialize_unreliable_unordered );
         RUN_TEST( test_client_server_message_exhaust_stream_allocator );
         RUN_TEST( test_client_server_message_receive_queue_overflow );


### PR DESCRIPTION
## Summary

- New enum `ServerClientDisconnectReason` (`yojimbo_server.h`) with `YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_*` values, and new function `int GetClientDisconnectReason( int clientIndex )` on the server. Existing functions unchanged.
- Distinguishes: `KICKED` (server called `DisconnectClient` / `DisconnectAllClients`), `DISCONNECTED` (transport-level: clean disconnect or timeout), and the specific connection error causes — `FAILED_TO_SERIALIZE` (protocol mismatch), `DESYNC`, `SEND_QUEUE_FULL`, `BLOCKS_DISABLED`, `MESSAGE_TOO_LARGE`, `OUT_OF_MEMORY` (channel / allocator / message factory), `READ_PACKET_FAILED`.
- Tracked per-client slot: cleared to `..._NONE` at server start and when a new client connects to the slot. First reason wins — the connection-error path records the specific cause before the kick/transport handling runs, so it is never overwritten by the generic reason.
- Recorded **before** `Adapter::OnServerClientDisconnected` fires, so the reason can be queried from inside that callback and routed into game-side logging/metrics/analytics.
- Adds `Connection::GetChannelErrorLevel( channelIndex )` to expose which channel error drove `CONNECTION_ERROR_CHANNEL`.
- Includes `GetServerClientDisconnectReasonString()` helper, matching `GetChannelErrorString` style.

## Test plan

- [x] New test `test_server_client_disconnect_reason`: all slots `NONE` at start → `KICKED` recorded immediately on kick → cleared to `NONE` when a new client connects to the slot → `DISCONNECTED` on clean client-side disconnect → all slots cleared on server restart
- [x] New test `test_server_client_disconnect_reason_failed_to_serialize`: message that fails serialize read disconnects the client with reason `FAILED_TO_SERIALIZE`
- [x] Full suite passes in Debug and Release on macOS arm64, both builds warning-free
- [ ] CI matrix (Linux/macOS/Windows, sanitizers, MSan, fuzz, soak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)