### PR TITLE
Add disconnect reason to the client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,14 +118,16 @@ closed within the contract: `ClientServerConfig::Validate()`
 asserts each config invariant at startup with a message naming the field and the fix, and
 compiles away entirely in release.
 
-1. **Disconnect diagnostics are thin for production use.** *(Server side addressed:
+1. **Disconnect diagnostics** — *addressed on both sides.* Server:
    `Server::GetClientDisconnectReason(clientIndex)` returns a per-slot
-   `ServerClientDisconnectReason` — kicked, transport disconnect/timeout, serialize
-   failure, desync, out of memory, etc. — recorded before
-   `Adapter::OnServerClientDisconnected` fires so it can be queried from the callback.)*
-   The client side still compresses the detailed netcode states (connection denied, token
-   expired, timed out) into a single `CLIENT_STATE_ERROR`, so a game cannot tell the
-   player "server is full" versus "network error" without querying netcode directly.
+   `ServerClientDisconnectReason` (kicked, transport disconnect/timeout, serialize
+   failure, desync, out of memory, …), recorded before
+   `Adapter::OnServerClientDisconnected` fires so it can be queried from the callback.
+   Client: `Client::GetDisconnectReason()` returns a `ClientDisconnectReason` that
+   preserves the detailed netcode failure states (connection denied, connect token
+   expired/invalid, request/response/connection timed out, disconnected by server) plus
+   the same connection-error causes, so the game can tell the player "server is full"
+   versus "update your client" versus "network error".
 
 2. **The single-threaded, ≤100-player contract is under-signposted.** Both are deliberate
    design decisions (see the design contract above), and the author is comfortable with

--- a/include/yojimbo_base_client.h
+++ b/include/yojimbo_base_client.h
@@ -102,7 +102,18 @@ namespace yojimbo
 
         void GetNetworkInfo( NetworkInfo & info ) const;
 
+        /**
+            Get the reason this client was last disconnected.
+            See ClientDisconnectReason for the values. Cleared back to YOJIMBO_CLIENT_DISCONNECT_REASON_NONE
+            when a new connect attempt starts.
+            @returns The disconnect reason (a ClientDisconnectReason value). YOJIMBO_CLIENT_DISCONNECT_REASON_NONE if no disconnect has happened yet.
+         */
+
+        int GetDisconnectReason() const { return m_disconnectReason; }
+
     protected:
+
+        void SetDisconnectReason( int disconnectReason ) { m_disconnectReason = disconnectReason; }
 
         uint8_t * GetPacketBuffer() { return m_packetBuffer; }
 
@@ -156,6 +167,7 @@ namespace yojimbo
         NetworkSimulator * m_networkSimulator;                              ///< The network simulator used to simulate packet loss, latency, jitter etc. Optional.
         ClientState m_clientState;                                          ///< The current client state. See ClientInterface::GetClientState
         int m_clientIndex;                                                  ///< The client slot index on the server [0,maxClients-1]. -1 if not connected.
+        int m_disconnectReason;                                             ///< The reason this client was last disconnected (ClientDisconnectReason). Cleared back to none when a new connect attempt starts.
         double m_time;                                                      ///< The current client time. See ClientInterface::AdvanceTime
         uint8_t * m_packetBuffer;                                           ///< Buffer used to read and write packets.
 

--- a/include/yojimbo_client.h
+++ b/include/yojimbo_client.h
@@ -34,6 +34,67 @@ struct netcode_client_t;
 namespace yojimbo
 {
     /**
+        The reason this client was last disconnected.
+
+        This lets you distinguish what to show the player and what to do next: a denied connection (eg. server full),
+        an expired or invalid connect token (eg. matchmaking took too long, or a client/server version mismatch),
+        a timeout, or a protocol error such as a message that failed to serialize.
+
+        Cleared to YOJIMBO_CLIENT_DISCONNECT_REASON_NONE when a new connect attempt starts. The first reason recorded
+        for a disconnect wins, so a specific error is never overwritten by the generic disconnect that follows it.
+
+        @see BaseClient::GetDisconnectReason
+     */
+
+    enum ClientDisconnectReason
+    {
+        YOJIMBO_CLIENT_DISCONNECT_REASON_NONE = 0,                          ///< No disconnect has happened yet (or a new connect attempt is in progress).
+        YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED,                      ///< You called Client::Disconnect. A deliberate local disconnect.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED_BY_SERVER,            ///< The server disconnected us. The server was stopped, or it kicked this client.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_DENIED,                 ///< The server denied the connection request. For example, the server is full.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT,      ///< No response from the server to our connection request. Server not running, unreachable, or wrong address.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_RESPONSE_TIMED_OUT,     ///< No response from the server to our challenge response while establishing the connection.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_TIMED_OUT,              ///< The established connection timed out. We stopped hearing from the server.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_INVALID_CONNECT_TOKEN,             ///< The connect token is invalid, or could not be generated.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED,             ///< The connect token expired before we could connect. Request a fresh one from the matchmaker and retry.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE,               ///< A message from the server failed to serialize read. Usually a client/server protocol version mismatch, or a bug in a message serialize function.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_DESYNC,                            ///< A channel desynced and cannot recover. See CHANNEL_ERROR_DESYNC.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_SEND_QUEUE_FULL,                   ///< A channel send queue filled up. See CHANNEL_ERROR_SEND_QUEUE_FULL.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_BLOCKS_DISABLED,                   ///< The server sent block data on a channel that is configured with blocks disabled.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_MESSAGE_TOO_LARGE,                 ///< Tried to send a message too large to ever fit into a packet. See CHANNEL_ERROR_MESSAGE_TOO_LARGE.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY,                     ///< The client memory budget was exhausted. Consider increasing ClientServerConfig::clientMemory.
+        YOJIMBO_CLIENT_DISCONNECT_REASON_READ_PACKET_FAILED,                ///< A connection packet from the server failed to deserialize.
+    };
+
+    /// Helper function to convert a client disconnect reason to a user friendly string.
+
+    inline const char * GetClientDisconnectReasonString( int reason )
+    {
+        switch ( reason )
+        {
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_NONE:                             return "none";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED:                     return "disconnected";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED_BY_SERVER:           return "disconnected by server";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_DENIED:                return "connection denied";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT:     return "connection request timed out";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_RESPONSE_TIMED_OUT:    return "connection response timed out";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_TIMED_OUT:             return "connection timed out";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_INVALID_CONNECT_TOKEN:            return "invalid connect token";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED:            return "connect token expired";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE:              return "failed to serialize";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_DESYNC:                           return "desync";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_SEND_QUEUE_FULL:                  return "send queue full";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_BLOCKS_DISABLED:                  return "blocks disabled";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_MESSAGE_TOO_LARGE:                return "message too large";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY:                    return "out of memory";
+            case YOJIMBO_CLIENT_DISCONNECT_REASON_READ_PACKET_FAILED:               return "read packet failed";
+            default:
+                yojimbo_assert( false );
+                return "(unknown)";
+        }
+    }
+
+    /**
         Client implementation
      */
 

--- a/source/yojimbo_base_client.cpp
+++ b/source/yojimbo_base_client.cpp
@@ -28,6 +28,7 @@
 #include "yojimbo_network_simulator.h"
 #include "yojimbo_adapter.h"
 #include "yojimbo_utils.h"
+#include "yojimbo_client.h"             // for the ClientDisconnectReason enum
 #include "reliable.h"
 
 namespace yojimbo
@@ -46,6 +47,7 @@ namespace yojimbo
         m_networkSimulator = NULL;
         m_clientState = CLIENT_STATE_DISCONNECTED;
         m_clientIndex = -1;
+        m_disconnectReason = YOJIMBO_CLIENT_DISCONNECT_REASON_NONE;
         m_packetBuffer = (uint8_t*) YOJIMBO_ALLOCATE( allocator, config.maxPacketSize );
     }
 
@@ -63,15 +65,56 @@ namespace yojimbo
         Reset();
     }
 
+    // Map the error that drove the connection into an error state to the disconnect reason we
+    // record for this client. For channel errors, drill into the channels to find the one in
+    // error, because that is where the actionable detail lives (eg. serialize failure vs desync
+    // vs out of memory).
+    static int ClientDisconnectReasonForConnectionError( const Connection & connection, ConnectionErrorLevel errorLevel, int numChannels )
+    {
+        switch ( errorLevel )
+        {
+            case CONNECTION_ERROR_ALLOCATOR:            return YOJIMBO_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY;
+            case CONNECTION_ERROR_MESSAGE_FACTORY:      return YOJIMBO_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY;
+            case CONNECTION_ERROR_READ_PACKET_FAILED:   return YOJIMBO_CLIENT_DISCONNECT_REASON_READ_PACKET_FAILED;
+
+            case CONNECTION_ERROR_CHANNEL:
+            {
+                for ( int i = 0; i < numChannels; ++i )
+                {
+                    switch ( connection.GetChannelErrorLevel( i ) )
+                    {
+                        case CHANNEL_ERROR_DESYNC:                  return YOJIMBO_CLIENT_DISCONNECT_REASON_DESYNC;
+                        case CHANNEL_ERROR_SEND_QUEUE_FULL:         return YOJIMBO_CLIENT_DISCONNECT_REASON_SEND_QUEUE_FULL;
+                        case CHANNEL_ERROR_BLOCKS_DISABLED:         return YOJIMBO_CLIENT_DISCONNECT_REASON_BLOCKS_DISABLED;
+                        case CHANNEL_ERROR_FAILED_TO_SERIALIZE:     return YOJIMBO_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE;
+                        case CHANNEL_ERROR_OUT_OF_MEMORY:           return YOJIMBO_CLIENT_DISCONNECT_REASON_OUT_OF_MEMORY;
+                        case CHANNEL_ERROR_MESSAGE_TOO_LARGE:       return YOJIMBO_CLIENT_DISCONNECT_REASON_MESSAGE_TOO_LARGE;
+                        case CHANNEL_ERROR_NONE:                    break;
+                    }
+                }
+            }
+            break;
+
+            case CONNECTION_ERROR_NONE:
+                break;
+        }
+
+        // A connection in an error state always matches one of the cases above; keep a sane
+        // value if that ever changes rather than reporting garbage.
+        return YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED;
+    }
+
     void BaseClient::AdvanceTime( double time )
     {
         m_time = time;
         if ( m_endpoint )
         {
             m_connection->AdvanceTime( time );
-            if ( m_connection->GetErrorLevel() != CONNECTION_ERROR_NONE )
+            const ConnectionErrorLevel connectionErrorLevel = m_connection->GetErrorLevel();
+            if ( connectionErrorLevel != CONNECTION_ERROR_NONE )
             {
                 yojimbo_printf( YOJIMBO_LOG_LEVEL_DEBUG, "connection error. disconnecting client\n" );
+                SetDisconnectReason( ClientDisconnectReasonForConnectionError( *m_connection, connectionErrorLevel, m_config.numChannels ) );
                 Disconnect();
                 return;
             }

--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -7,7 +7,23 @@
 
 namespace yojimbo
 {
-    Client::Client( Allocator & allocator, const Address & address, const ClientServerConfig & config, Adapter & adapter, double time ) 
+    // Map a netcode client error state to the disconnect reason we record for this client.
+    // This is where "server is full" vs "update your client" vs "network problem" comes from.
+    static int ClientDisconnectReasonForNetcodeState( int netcodeState )
+    {
+        switch ( netcodeState )
+        {
+            case NETCODE_CLIENT_STATE_CONNECT_TOKEN_EXPIRED:            return YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED;
+            case NETCODE_CLIENT_STATE_INVALID_CONNECT_TOKEN:            return YOJIMBO_CLIENT_DISCONNECT_REASON_INVALID_CONNECT_TOKEN;
+            case NETCODE_CLIENT_STATE_CONNECTION_TIMED_OUT:             return YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_TIMED_OUT;
+            case NETCODE_CLIENT_STATE_CONNECTION_RESPONSE_TIMED_OUT:    return YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_RESPONSE_TIMED_OUT;
+            case NETCODE_CLIENT_STATE_CONNECTION_REQUEST_TIMED_OUT:     return YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT;
+            case NETCODE_CLIENT_STATE_CONNECTION_DENIED:                return YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_DENIED;
+            default:                                                    return YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED_BY_SERVER;
+        }
+    }
+
+    Client::Client( Allocator & allocator, const Address & address, const ClientServerConfig & config, Adapter & adapter, double time )
         : BaseClient( allocator, config, adapter, time ), m_config( config ), m_address( address )
     {
         m_clientId = 0;
@@ -33,6 +49,7 @@ namespace yojimbo
         yojimbo_assert( numServerAddresses <= NETCODE_MAX_SERVERS_PER_CONNECT );
         Disconnect();
         CreateInternal();
+        SetDisconnectReason( YOJIMBO_CLIENT_DISCONNECT_REASON_NONE );       // new connect attempt: clear the reason from any previous disconnect
         m_clientId = clientId;
         CreateClient( m_address );
         if ( !m_client )
@@ -44,6 +61,7 @@ namespace yojimbo
         if ( !GenerateInsecureConnectToken( connectToken, privateKey, clientId, serverAddresses, numServerAddresses ) )
         {
             yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to generate insecure connect token\n" );
+            SetDisconnectReason( YOJIMBO_CLIENT_DISCONNECT_REASON_INVALID_CONNECT_TOKEN );
             SetClientState( CLIENT_STATE_ERROR );
             return;
         }
@@ -85,6 +103,7 @@ namespace yojimbo
         yojimbo_assert( connectToken );
         Disconnect();
         CreateInternal();
+        SetDisconnectReason( YOJIMBO_CLIENT_DISCONNECT_REASON_NONE );       // new connect attempt: clear the reason from any previous disconnect
         m_clientId = clientId;
         CreateClient( m_address );
         if ( !m_client )
@@ -101,12 +120,21 @@ namespace yojimbo
         }
         else
         {
+            // The connect failed immediately, eg. an invalid connect token.
+            SetDisconnectReason( ClientDisconnectReasonForNetcodeState( netcode_client_state( m_client ) ) );
             Disconnect();
         }
     }
 
     void Client::Disconnect()
     {
+        // Record a deliberate local disconnect, but only if no more specific reason was already
+        // recorded (connection error, netcode error state) — the first reason recorded wins.
+        // Checked before BaseClient::Disconnect below, because that resets the client state.
+        if ( ( IsConnecting() || IsConnected() ) && GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE )
+        {
+            SetDisconnectReason( YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED );
+        }
         BaseClient::Disconnect();
         DestroyClient();
         DestroyInternal();
@@ -153,11 +181,23 @@ namespace yojimbo
             const int state = netcode_client_state( m_client );
             if ( state < NETCODE_CLIENT_STATE_DISCONNECTED )
             {
+                // Record why netcode failed (denied, token expired/invalid, timed out) before the
+                // disconnect, so the game can tell the player what actually happened.
+                if ( GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE )
+                {
+                    SetDisconnectReason( ClientDisconnectReasonForNetcodeState( state ) );
+                }
                 Disconnect();
                 SetClientState( CLIENT_STATE_ERROR );
             }
             else if ( state == NETCODE_CLIENT_STATE_DISCONNECTED )
             {
+                // netcode dropped to disconnected while we thought we were connecting/connected:
+                // the server disconnected us (server stopped, or kicked this client).
+                if ( GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE )
+                {
+                    SetDisconnectReason( YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED_BY_SERVER );
+                }
                 Disconnect();
                 SetClientState( CLIENT_STATE_DISCONNECTED );
             }
@@ -193,6 +233,7 @@ namespace yojimbo
     {
         Disconnect();
         CreateInternal();
+        SetDisconnectReason( YOJIMBO_CLIENT_DISCONNECT_REASON_NONE );       // new connect attempt: clear the reason from any previous disconnect
         m_clientId = clientId;
         CreateClient( m_address );
         if ( !m_client )
@@ -207,6 +248,12 @@ namespace yojimbo
 
     void Client::DisconnectLoopback()
     {
+        // Same recording rule as Client::Disconnect: a deliberate local disconnect, unless a more
+        // specific reason was already recorded.
+        if ( ( IsConnecting() || IsConnected() ) && GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE )
+        {
+            SetDisconnectReason( YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED );
+        }
         netcode_client_disconnect_loopback( m_client );
         BaseClient::Disconnect();
         DestroyClient();

--- a/test.cpp
+++ b/test.cpp
@@ -2544,6 +2544,213 @@ void test_server_client_disconnect_reason_failed_to_serialize()
     server.Stop();
 }
 
+void test_client_disconnect_reason()
+{
+    const uint64_t clientId = 1;
+
+    Address clientAddress( "0.0.0.0", ClientPort );
+    Address serverAddress( "127.0.0.1", ServerPort );
+
+    double time = 100.0;
+
+    ClientServerConfig config;
+
+    uint8_t privateKey[KeyBytes];
+    memset( privateKey, 0, KeyBytes );
+
+    Server server( GetDefaultAllocator(), privateKey, serverAddress, config, adapter, time );
+
+    server.Start( MaxClients );
+
+    Client client( GetDefaultAllocator(), clientAddress, config, adapter, time );
+
+    // no disconnect has happened yet
+
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE );
+
+    const int NumIterations = 10000;
+
+    // connect. while connected the reason stays none
+
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        if ( !client.IsConnecting() && client.IsConnected() && server.GetNumConnectedClients() == 1 )
+            break;
+    }
+
+    check( client.IsConnected() );
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE );
+
+    // deliberate local disconnect is recorded immediately
+
+    client.Disconnect();
+
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( server.GetNumConnectedClients() == 0 )
+            break;
+    }
+
+    check( server.GetNumConnectedClients() == 0 );
+
+    // reconnect. a new connect attempt clears the reason back to none
+
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        if ( !client.IsConnecting() && client.IsConnected() && server.GetNumConnectedClients() == 1 )
+            break;
+    }
+
+    check( client.IsConnected() );
+
+    // when the server kicks us, the client records disconnected by server
+
+    server.DisconnectClient( 0 );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( !client.IsConnected() )
+            break;
+    }
+
+    check( !client.IsConnected() );
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED_BY_SERVER );
+
+    // connecting to a server that isn't there fails with connect token expired: the insecure
+    // connect token uses config.timeout for both its expiry and its timeout, and netcode checks
+    // token expiry before the connection request timeout, so with equal timers expiry always
+    // wins. (secure connect tokens from a matchmaker have expiry >> timeout, and get
+    // connection request timed out instead.)
+
+    server.Stop();
+
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+
+        PumpClientServerUpdate( time, clients, 1, NULL, 0 );
+
+        if ( client.ConnectionFailed() )
+            break;
+    }
+
+    check( client.ConnectionFailed() );
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED );
+
+    client.Disconnect();
+}
+
+void test_client_disconnect_reason_failed_to_serialize()
+{
+    const uint64_t clientId = 1;
+
+    Address clientAddress( "0.0.0.0", ClientPort );
+    Address serverAddress( "127.0.0.1", ServerPort );
+
+    double time = 100.0;
+
+    ClientServerConfig config;
+    config.maxPacketSize = 1100;
+    config.numChannels = 1;
+    config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+    config.channel[0].maxBlockSize = 1024;
+    config.channel[0].blockFragmentSize = 200;
+
+    uint8_t privateKey[KeyBytes];
+    memset( privateKey, 0, KeyBytes );
+
+    Server server( GetDefaultAllocator(), privateKey, serverAddress, config, adapter, time );
+
+    server.Start( MaxClients );
+
+    Client client( GetDefaultAllocator(), clientAddress, config, adapter, time );
+
+    client.InsecureConnect( privateKey, clientId, serverAddress );
+
+    const int NumIterations = 10000;
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        if ( !client.IsConnecting() && client.IsConnected() && server.GetNumConnectedClients() == 1 )
+            break;
+    }
+
+    check( !client.IsConnecting() );
+    check( client.IsConnected() );
+    check( server.GetNumConnectedClients() == 1 );
+
+    // send a message from the server that fails to serialize on read. the client disconnects
+    // itself and records the specific channel error as its disconnect reason
+
+    Message * message = server.CreateMessage( 0, TEST_SERIALIZE_FAIL_ON_READ_MESSAGE );
+    check( message );
+    server.SendMessage( 0, 0, message );
+
+    for ( int i = 0; i < 256; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( !client.IsConnected() )
+            break;
+    }
+
+    check( !client.IsConnected() );
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_FAILED_TO_SERIALIZE );
+
+    client.Disconnect();
+
+    server.Stop();
+}
+
 void test_client_server_message_failed_to_serialize_unreliable_unordered()
 {
     const uint64_t clientId = 1;
@@ -3454,6 +3661,8 @@ int main( int argc, char ** argv )
         RUN_TEST( test_client_server_message_failed_to_serialize_reliable_ordered );
         RUN_TEST( test_server_client_disconnect_reason );
         RUN_TEST( test_server_client_disconnect_reason_failed_to_serialize );
+        RUN_TEST( test_client_disconnect_reason );
+        RUN_TEST( test_client_disconnect_reason_failed_to_serialize );
         RUN_TEST( test_client_server_message_failed_to_serialize_unreliable_unordered );
         RUN_TEST( test_client_server_message_exhaust_stream_allocator );
         RUN_TEST( test_client_server_message_receive_queue_overflow );


### PR DESCRIPTION
## Summary

Client-side counterpart to #290.

- New enum `ClientDisconnectReason` (`yojimbo_client.h`) with `YOJIMBO_CLIENT_DISCONNECT_REASON_*` values, and new function `int GetDisconnectReason() const`. Existing functions unchanged.
- Preserves the detailed netcode failure states that were previously compressed into `CLIENT_STATE_ERROR`: `CONNECTION_DENIED` (eg. server full), `CONNECT_TOKEN_EXPIRED`, `INVALID_CONNECT_TOKEN`, `CONNECTION_REQUEST_TIMED_OUT`, `CONNECTION_RESPONSE_TIMED_OUT`, `CONNECTION_TIMED_OUT` — so the game can tell the player "server is full" vs "update your client" vs "network error".
- Distinguishes `DISCONNECTED` (you called `Disconnect` — deliberate, local) from `DISCONNECTED_BY_SERVER` (server stopped or kicked us).
- Maps connection errors to the same causes as the server side: `FAILED_TO_SERIALIZE`, `DESYNC`, `SEND_QUEUE_FULL`, `BLOCKS_DISABLED`, `MESSAGE_TOO_LARGE`, `OUT_OF_MEMORY`, `READ_PACKET_FAILED`.
- Cleared to `..._NONE` when a new connect attempt starts; first reason recorded for a disconnect wins, so a specific error is never overwritten by the generic disconnect that follows it.
- Includes `GetClientDisconnectReasonString()` helper.

One behavior worth knowing (documented in the test): an **insecure** connect to an unreachable server reports `CONNECT_TOKEN_EXPIRED` rather than `CONNECTION_REQUEST_TIMED_OUT`, because the insecure connect token uses `config.timeout` for both its expiry and its timeout, and netcode checks expiry first (`netcode.c` client update). Secure tokens from a matchmaker have expiry ≫ timeout and report the request timeout.

## Test plan

- [x] New test `test_client_disconnect_reason`: `NONE` before any disconnect → `DISCONNECTED` recorded immediately on local `Disconnect()` → cleared to `NONE` on reconnect → `DISCONNECTED_BY_SERVER` when kicked by the server → `CONNECT_TOKEN_EXPIRED` on insecure connect to a stopped server
- [x] New test `test_client_disconnect_reason_failed_to_serialize`: server→client message that fails serialize read disconnects the client with reason `FAILED_TO_SERIALIZE`
- [x] Full suite passes in Debug and Release on macOS arm64, both builds warning-free
- [ ] CI matrix (Linux/macOS/Windows, sanitizers, MSan, fuzz, soak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)