### PR TITLE
Make insecure connect tokens expire like matcher tokens

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -253,7 +253,7 @@ if (m_client.IsDisconnected() || m_client.ConnectionFailed()) {
 }
 ```
 
-The reason is cleared back to `YOJIMBO_CLIENT_DISCONNECT_REASON_NONE` whenever a new connect attempt starts. One quirk worth knowing during development: an *insecure* connect to a server that isn't running reports `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED` rather than a connection request timeout, because the insecure connect token uses the same value for its expiry and its timeout, and the expiry check runs first. Secure connect tokens issued by a matchmaker have a much longer expiry and report `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT` as you'd expect.
+The reason is cleared back to `YOJIMBO_CLIENT_DISCONNECT_REASON_NONE` whenever a new connect attempt starts. Connecting to a server that isn't running reports `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT` after the connection timeout, for both secure and insecure connects. `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED` means the connect token's expiry passed before the client could connect — for example, the player sat on a menu too long after matchmaking — and the fix is to request a fresh token and retry.
 
 For testing purposes, let's also send a `TestMessage` when the player presses a key:
 

--- a/include/yojimbo_constants.h
+++ b/include/yojimbo_constants.h
@@ -37,6 +37,8 @@ namespace yojimbo
 
     const int ConnectTokenBytes = 2048;                             ///< Size of the encrypted connect token data return from the matchmaker. Must equal size of NETCODE_CONNECT_TOKEN_BYTE (2048).
 
+    const int InsecureConnectTokenExpirySeconds = 60;               ///< Expiry for insecure connect tokens (seconds). Kept well above the connection timeout so a failed insecure connect reports "connection request timed out" like a secure connect token from a matchmaker would, rather than hitting token expiry first.
+
     const int ConservativeMessageHeaderBits = 32;                   ///< Conservative number of bits per-message header.
     
     const int ConservativeFragmentHeaderBits = 64;                  ///< Conservative number of bits per-fragment header.

--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -2,6 +2,7 @@
 #include "yojimbo_connection.h"
 #include "yojimbo_network_simulator.h"
 #include "yojimbo_adapter.h"
+#include "yojimbo_utils.h"
 #include "netcode.h"
 #include "reliable.h"
 
@@ -86,15 +87,21 @@ namespace yojimbo
         uint8_t userData[256];
         memset( &userData, 0, sizeof(userData) );
 
-        return netcode_generate_connect_token( numServerAddresses, 
-                                               serverAddressStringPointers, 
-                                               serverAddressStringPointers, 
+        // Give the insecure connect token an expiry well above the connection timeout, so a
+        // failed insecure connect reports "connection request timed out" just like a secure
+        // connect token from a matchmaker would. With expiry == timeout, netcode checks token
+        // expiry first and every failed connect reports "connect token expired" instead.
+        const int expireSeconds = yojimbo_max( InsecureConnectTokenExpirySeconds, m_config.timeout * 2 );
+
+        return netcode_generate_connect_token( numServerAddresses,
+                                               serverAddressStringPointers,
+                                               serverAddressStringPointers,
+                                               expireSeconds,
                                                m_config.timeout,
-                                               m_config.timeout, 
-                                               clientId, 
-                                               m_config.protocolId, 
+                                               clientId,
+                                               m_config.protocolId,
                                                (uint8_t*)privateKey,
-                                               &userData[0], 
+                                               &userData[0],
                                                connectToken ) == NETCODE_OK;
     }
 

--- a/test.cpp
+++ b/test.cpp
@@ -2650,11 +2650,9 @@ void test_client_disconnect_reason()
     check( !client.IsConnected() );
     check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_DISCONNECTED_BY_SERVER );
 
-    // connecting to a server that isn't there fails with connect token expired: the insecure
-    // connect token uses config.timeout for both its expiry and its timeout, and netcode checks
-    // token expiry before the connection request timeout, so with equal timers expiry always
-    // wins. (secure connect tokens from a matchmaker have expiry >> timeout, and get
-    // connection request timed out instead.)
+    // connecting to a server that isn't there times out at the connection request stage.
+    // the insecure connect token expiry is deliberately much longer than the connection
+    // timeout, so this behaves the same way as a secure connect token from a matchmaker.
 
     server.Stop();
 
@@ -2673,7 +2671,7 @@ void test_client_disconnect_reason()
     }
 
     check( client.ConnectionFailed() );
-    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED );
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT );
 
     client.Disconnect();
 }


### PR DESCRIPTION
## Summary

Insecure connect tokens passed `config.timeout` for **both** `expire_seconds` and `timeout_seconds` to `netcode_generate_connect_token`, and netcode's client update checks token expiry before the connection request timeout. With equal timers, expiry always won: every failed insecure connect reported `CONNECT_TOKEN_EXPIRED` instead of `CONNECTION_REQUEST_TIMED_OUT`, unlike secure tokens from the matcher (whose expiry is much longer than the timeout).

- Push the insecure token expiry well past the connection timeout: `max( InsecureConnectTokenExpirySeconds (60), config.timeout * 2 )`, new constant in `yojimbo_constants.h`. The timeout stays at `config.timeout`.
- A failed insecure connect now reports `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT`, consistent with the secure path.
- `test_client_disconnect_reason` updated to expect the request timeout; the now-obsolete quirk note in USAGE.md replaced with the consistent behavior.

## Test plan

- [x] `test_client_disconnect_reason` passes with the new expectation
- [x] Ran the client sample against no server: prints `client disconnected: connection request timed out` (previously `connect token expired`)
- [x] Full suite passes; build warning-free
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)