### PR TITLE
Pre-release cleanups: leak check via assert, no config-sized allocas, loopback kick reason, Windows docs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -35,6 +35,19 @@ yojimbo directory:
 Open the generated `build\Yojimbo.sln` in Visual Studio if you prefer, or pass
 `--config Release` for an optimized build. The executables are written to `bin\`.
 
+### Windows header side effects
+
+Two things to be aware of when including yojimbo headers in your own Windows code:
+
+- The yojimbo headers `#undef SendMessage`, because `windows.h` defines it as a macro that
+  would otherwise mangle the `SendMessage` methods on the client and server. If your code
+  uses the Win32 API after including yojimbo, call `SendMessageA` / `SendMessageW`
+  explicitly instead of relying on the macro.
+- `yojimbo_config.h` defines `_CRT_SECURE_NO_WARNINGS` and disables MSVC warnings 4127
+  (conditional expression is constant) and 4244 (narrowing conversion) via `#pragma`.
+  These apply to any translation unit that includes yojimbo headers, so code in those
+  files won't get narrowing-conversion warnings even at `/W4`.
+
 ## Using the system libsodium instead of the bundled one
 
 To link the system-installed libsodium rather than the bundled subset, install it first:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,37 +129,36 @@ compiles away entirely in release.
    the same connection-error causes, so the game can tell the player "server is full"
    versus "update your client" versus "network error".
 
-2. **The single-threaded, ≤100-player contract is under-signposted.** Both are deliberate
-   design decisions (see the design contract above), and the author is comfortable with
-   them being surfaced — the criticism is only that the codebase barely states them: one
-   line in `yojimbo_allocator.h` is the sole thread-safety statement. Contracts enforced
-   by programmer responsibility only work when they're written down where integrators
-   will read them; a prominent paragraph in README/USAGE would do it, because violating
-   the threading contract produces rare refcount races in production, not a clean
-   failure.
+2. **The single-threaded, ≤100-player contract is under-signposted** — *addressed.* The
+   README now has a "Design Assumptions" section stating single-threaded operation, the
+   ~100-players-or-less target, and the identical-config requirement, and USAGE.md
+   explains config validation. (These are deliberate design decisions per the contract
+   above; the fix was writing them down where integrators read them.)
 
 3. **Manual message refcounting is easy to misuse.** Create/Send transfers ownership;
    Receive obligates a Release; the compiler enforces none of it. This is consistent with
    the library's contract style, and the debug leak checker is its enforcement mechanism
-   — though `exit(1)` from the factory destructor is hostile if the library is embedded
-   in an editor or tool. This is the part of the API where integrators will make their
-   first mistake.
+   — which now fails through `yojimbo_assert` (interceptable via
+   `yojimbo_set_assert_function`) rather than `exit(1)`, so editors and tools embedding
+   yojimbo can handle it. This remains the part of the API where integrators will make
+   their first mistake.
 
-4. **`alloca` sized by config in packet and tick paths.** With default configs the sizes
-   are trivial, but `Client::AdvanceTime` puts ~12 bytes × `maxSimulatorPackets` (48KB at
-   the default 4096) on the stack per tick when the simulator is active, and a user who
-   cranks `maxMessagesPerPacket` or `maxSimulatorPackets` converts a config choice into a
-   silent stack-overflow risk. Fixed member buffers or the channel allocator would be
-   sturdier.
+4. **`alloca` sized by config in packet and tick paths** — *largely addressed.* The
+   client/server simulator pumps now drain in fixed-size batches, and the channels own
+   scratch buffers for packet generation, so stack usage no longer scales with
+   `maxSimulatorPackets` or `maxMessagesPerPacket` on those paths. The remaining allocas
+   in `yojimbo_channel.cpp`'s message serialize functions are bounded by the
+   wire-validated message count (≤ `maxMessagesPerPacket`, ~6 bytes per message) and were
+   left because replacing them means threading heap cleanup through many early-return
+   paths in template code.
 
-5. **The C++ dialect is dated — deliberately, but with a couple of leaks.** C++03 idioms
-   (NULL, private copy constructors instead of `=delete`, no `override`, `std::map` in
-   debug trackers) are a fair trade for portability into engine codebases with exceptions
-   and RTTI off. Two things do leak out of that choice, though:
-   `#pragma warning(disable: 4244)` in `yojimbo_config.h` suppresses narrowing warnings
-   in *user* translation units that include yojimbo headers, and the `#undef SendMessage`
-   in the public headers silently deletes the Win32 macro for users who include
-   `windows.h` first. Both deserve at least a documentation note.
+5. **The C++ dialect is dated — deliberately, and now documented.** C++03 idioms (NULL,
+   private copy constructors instead of `=delete`, no `override`, `std::map` in debug
+   trackers) are a fair trade for portability into engine codebases with exceptions and
+   RTTI off. The two side effects that leak into user translation units — the
+   `#undef SendMessage` and the MSVC warning pragmas / `_CRT_SECURE_NO_WARNINGS` in
+   `yojimbo_config.h` — are now documented in BUILDING.md ("Windows header side
+   effects").
 
 6. **Vendored-crypto maintenance burden.** The pruned libsodium subset means upstream
    CVEs must be tracked and re-vendored by hand. `SECURITY.md` acknowledges this honestly
@@ -173,8 +172,10 @@ The architecture is sound, the security engineering is unusually serious for the
 and the code reads like it's been maintained by someone who has debugged it at 90% packet
 loss — because it has. The design contract is coherent: zero trust for anything off the
 wire, full trust plus debug-time assert enforcement for the programmer's own inputs, and
-zero overhead in release. With startup config validation now in place, the remaining asks
-I'd weight most are disconnect-cause telemetry and writing the threading/scale contract
-into the front-page docs. If I were choosing a C++ client/server layer for a competitive
+zero overhead in release. Every ask I weighted highly in the original audit has since
+been addressed: startup config validation, disconnect-cause telemetry on both client and
+server (including the timed-out vs clean-disconnect split, via netcode v1.3.2), and the
+threading/scale contract in the front-page docs. What remains is minor and recorded in
+the criticisms above. If I were choosing a C++ client/server layer for a competitive
 multiplayer game today, this would be on my shortlist, and the source being small and
 readable enough to audit in an afternoon is a large part of why.

--- a/include/yojimbo_message.h
+++ b/include/yojimbo_message.h
@@ -380,7 +380,10 @@ namespace yojimbo
                     Message * message = (Message*) i->first;
                     yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "leaked message %p (type %d, refcount %d)\n", message, message->GetType(), message->GetRefCount() );
                 }
-                exit(1);
+                // Fail through the assert handler rather than exit(1), so programs embedding
+                // yojimbo (editors, tools) can intercept via yojimbo_set_assert_function.
+                // Same idiom as the memory leak check in Allocator::~Allocator.
+                yojimbo_assert( false && "Message leaks detected, see log" );
             }
             #endif // #if YOJIMBO_DEBUG_MESSAGE_LEAKS
         }

--- a/include/yojimbo_reliable_ordered_channel.h
+++ b/include/yojimbo_reliable_ordered_channel.h
@@ -368,6 +368,7 @@ namespace yojimbo
         SequenceBuffer<MessageSendQueueEntry> * m_messageSendQueue;                     ///< Message send queue.
         SequenceBuffer<MessageReceiveQueueEntry> * m_messageReceiveQueue;               ///< Message receive queue.
         uint16_t * m_sentPacketMessageIds;                                              ///< Array of n message ids per sent connection packet. Allows the maximum number of messages per-packet to be allocated dynamically.
+        uint16_t * m_packetMessageIds;                                                  ///< Scratch space for the message ids gathered for the packet currently being generated (maxMessagesPerPacket entries). Owned by the channel so stack usage doesn't scale with the config.
         SendBlockData * m_sendBlock;                                                    ///< Data about the block being currently sent.
         ReceiveBlockData * m_receiveBlock;                                              ///< Data about the block being currently received.
 

--- a/include/yojimbo_unreliable_unordered_channel.h
+++ b/include/yojimbo_unreliable_unordered_channel.h
@@ -80,6 +80,7 @@ namespace yojimbo
 
         Queue<Message*> * m_messageSendQueue;                   ///< Message send queue.
         Queue<Message*> * m_messageReceiveQueue;                ///< Message receive queue.
+        Message ** m_packetMessages;                            ///< Scratch space for the messages gathered for the packet currently being generated (maxMessagesPerPacket entries). Owned by the channel so stack usage doesn't scale with the config.
 
     private:
 

--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -219,13 +219,22 @@ namespace yojimbo
             NetworkSimulator * networkSimulator = GetNetworkSimulator();
             if ( networkSimulator && networkSimulator->IsActive() )
             {
-                uint8_t ** packetData = (uint8_t**) alloca( sizeof( uint8_t*) * m_config.maxSimulatorPackets );
-                int * packetBytes = (int*) alloca( sizeof(int) * m_config.maxSimulatorPackets );
-                int numPackets = networkSimulator->ReceivePackets( m_config.maxSimulatorPackets, packetData, packetBytes, NULL );
-                for ( int i = 0; i < numPackets; ++i )
+                // Drain the simulator in fixed size batches, so stack usage here doesn't scale
+                // with maxSimulatorPackets. Each batch scans the simulator ring again, but the
+                // simulator is a development tool, not a production path.
+                const int MaxBatchPackets = 64;
+                uint8_t * packetData[MaxBatchPackets];
+                int packetBytes[MaxBatchPackets];
+                while ( true )
                 {
-                    netcode_client_send_packet( m_client, (uint8_t*) packetData[i], packetBytes[i] );
-                    YOJIMBO_FREE( networkSimulator->GetAllocator(), packetData[i] );
+                    const int numPackets = networkSimulator->ReceivePackets( MaxBatchPackets, packetData, packetBytes, NULL );
+                    if ( numPackets == 0 )
+                        break;
+                    for ( int i = 0; i < numPackets; ++i )
+                    {
+                        netcode_client_send_packet( m_client, packetData[i], packetBytes[i] );
+                        YOJIMBO_FREE( networkSimulator->GetAllocator(), packetData[i] );
+                    }
                 }
             }
         }

--- a/source/yojimbo_reliable_ordered_channel.cpp
+++ b/source/yojimbo_reliable_ordered_channel.cpp
@@ -40,6 +40,7 @@ namespace yojimbo
         m_messageSendQueue = YOJIMBO_NEW( *m_allocator, SequenceBuffer<MessageSendQueueEntry>, *m_allocator, m_config.messageSendQueueSize );
         m_messageReceiveQueue = YOJIMBO_NEW( *m_allocator, SequenceBuffer<MessageReceiveQueueEntry>, *m_allocator, m_config.messageReceiveQueueSize );
         m_sentPacketMessageIds = (uint16_t*) YOJIMBO_ALLOCATE( *m_allocator, sizeof( uint16_t ) * m_config.maxMessagesPerPacket * m_config.sentPacketBufferSize );
+        m_packetMessageIds = (uint16_t*) YOJIMBO_ALLOCATE( *m_allocator, sizeof( uint16_t ) * m_config.maxMessagesPerPacket );
 
         if ( !config.disableBlocks )
         {
@@ -66,6 +67,7 @@ namespace yojimbo
         YOJIMBO_DELETE( *m_allocator, SequenceBuffer<MessageReceiveQueueEntry>, m_messageReceiveQueue );
         
         YOJIMBO_FREE( *m_allocator, m_sentPacketMessageIds );
+        YOJIMBO_FREE( *m_allocator, m_packetMessageIds );
 
         m_sentPacketMessageIds = NULL;
     }
@@ -247,7 +249,7 @@ namespace yojimbo
         else
         {
             int numMessageIds = 0;
-            uint16_t * messageIds = (uint16_t*) alloca( m_config.maxMessagesPerPacket * sizeof( uint16_t ) );
+            uint16_t * messageIds = m_packetMessageIds;
             const int messageBits = GetMessagesToSend( messageIds, numMessageIds, availableBits, context );
 
             if ( numMessageIds > 0 )

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -230,6 +230,12 @@ namespace yojimbo
 
     void Server::DisconnectLoopbackClient( int clientIndex )
     {
+        // Same recording rule as DisconnectClient: disconnecting a loopback client is a kick,
+        // and must not overwrite a more specific reason recorded before the disconnect.
+        if ( IsClientConnected( clientIndex ) && GetClientDisconnectReason( clientIndex ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE )
+        {
+            SetClientDisconnectReason( clientIndex, YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED );
+        }
         netcode_server_disconnect_loopback_client( m_server, clientIndex );
     }
 

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -177,14 +177,23 @@ namespace yojimbo
         NetworkSimulator * networkSimulator = GetNetworkSimulator();
         if ( networkSimulator && networkSimulator->IsActive() )
         {
-            uint8_t ** packetData = (uint8_t**) alloca( sizeof( uint8_t*) * m_config.maxSimulatorPackets );
-            int * packetBytes = (int*) alloca( sizeof(int) * m_config.maxSimulatorPackets );
-            int * to = (int*) alloca( sizeof(int) * m_config.maxSimulatorPackets );
-            int numPackets = networkSimulator->ReceivePackets( m_config.maxSimulatorPackets, packetData, packetBytes, to );
-            for ( int i = 0; i < numPackets; ++i )
+            // Drain the simulator in fixed size batches, so stack usage here doesn't scale
+            // with maxSimulatorPackets. Each batch scans the simulator ring again, but the
+            // simulator is a development tool, not a production path.
+            const int MaxBatchPackets = 64;
+            uint8_t * packetData[MaxBatchPackets];
+            int packetBytes[MaxBatchPackets];
+            int to[MaxBatchPackets];
+            while ( true )
             {
-                netcode_server_send_packet( m_server, to[i], (uint8_t*) packetData[i], packetBytes[i] );
-                YOJIMBO_FREE( networkSimulator->GetAllocator(), packetData[i] );
+                const int numPackets = networkSimulator->ReceivePackets( MaxBatchPackets, packetData, packetBytes, to );
+                if ( numPackets == 0 )
+                    break;
+                for ( int i = 0; i < numPackets; ++i )
+                {
+                    netcode_server_send_packet( m_server, to[i], packetData[i], packetBytes[i] );
+                    YOJIMBO_FREE( networkSimulator->GetAllocator(), packetData[i] );
+                }
             }
         }
     }

--- a/source/yojimbo_unreliable_unordered_channel.cpp
+++ b/source/yojimbo_unreliable_unordered_channel.cpp
@@ -43,6 +43,7 @@ namespace yojimbo
         yojimbo_assert( config.type == CHANNEL_TYPE_UNRELIABLE_UNORDERED );
         m_messageSendQueue = YOJIMBO_NEW( *m_allocator, Queue<Message*>, *m_allocator, m_config.messageSendQueueSize );
         m_messageReceiveQueue = YOJIMBO_NEW( *m_allocator, Queue<Message*>, *m_allocator, m_config.messageReceiveQueueSize );
+        m_packetMessages = (Message**) YOJIMBO_ALLOCATE( *m_allocator, sizeof( Message* ) * m_config.maxMessagesPerPacket );
         Reset();
     }
 
@@ -51,6 +52,7 @@ namespace yojimbo
         Reset();
         YOJIMBO_DELETE( *m_allocator, Queue<Message*>, m_messageSendQueue );
         YOJIMBO_DELETE( *m_allocator, Queue<Message*>, m_messageReceiveQueue );
+        YOJIMBO_FREE( *m_allocator, m_packetMessages );
     }
 
     void UnreliableUnorderedChannel::Reset()
@@ -154,7 +156,7 @@ namespace yojimbo
 
         int usedBits = ConservativeMessageHeaderBits;
         int numMessages = 0;
-        Message ** messages = (Message**) alloca( sizeof( Message* ) * m_config.maxMessagesPerPacket );
+        Message ** messages = m_packetMessages;
 
         while ( true )
         {


### PR DESCRIPTION
## Summary

Four small cleanups from the audit, batched ahead of the 1.3.0 release:

1. **Message leak check fails through the assert handler.** `MessageFactory`'s destructor called `exit(1)` on leaked messages, which kills the process with no way to intercept when yojimbo is embedded in an editor or tool. It now prints the leaks and fails via `yojimbo_assert`, so embedders can intercept with `yojimbo_set_assert_function` — the same idiom as the memory leak check in `Allocator::~Allocator`. Debug-only path; release behavior unchanged.
2. **No more config-sized allocas in packet and tick paths.** The client/server simulator pumps drained through allocas sized by `maxSimulatorPackets` (~48KB of stack per tick at defaults); they now drain in fixed 64-packet batches. Both channels gathered messages for the packet being generated through allocas sized by `maxMessagesPerPacket`; each channel now owns a scratch buffer allocated once in its constructor. The remaining allocas in the message serialize functions are bounded by the wire-validated message count and deliberately left (replacing them threads heap cleanup through many early-return paths in template code) — noted in the commit message.
3. **Loopback kick records `KICKED`.** `Server::DisconnectLoopbackClient` now records `YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_KICKED`, consistent with `DisconnectClient`; previously it fell through to the transport default and reported `DISCONNECTED`.
4. **BUILDING.md documents the Windows header side effects**: the `#undef SendMessage` and the `_CRT_SECURE_NO_WARNINGS` / MSVC warning 4127/4244 pragmas that apply to including translation units.

Also updates the CLAUDE.md audit to mark these items addressed.

## Test plan

- [x] Full suite passes in Debug and Release on macOS arm64, builds warning-free
- [x] `soak 3000` runs clean (exercises the channel scratch-buffer changes under load)
- [x] Loopback sample runs clean (connect, disconnect, stop)
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)