### PR TITLE
Remove the remaining config-sized allocas from message serialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,9 +148,9 @@ compiles away entirely in release.
    does not use modern C++ features, and changing the API would break the interface its
    users have come to expect — interface stability is the point. The debug leak checker
    is the contract's enforcement mechanism (it fails through `yojimbo_assert`,
-   interceptable via `yojimbo_set_assert_function`), and USAGE.md's examples show the
-   ownership pattern. Review future changes against this contract; do not propose
-   RAII/smart-pointer wrappers.
+   interceptable via `yojimbo_set_assert_function`), and USAGE.md states the message
+   ownership rules explicitly. Review future changes against this contract; do not
+   propose RAII/smart-pointer wrappers.
 
 4. **`alloca` sized by config in packet and tick paths** — *addressed.* The
    client/server simulator pumps drain in fixed-size batches, the channels own scratch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,13 @@ but they are footguns and polish, not rot.
   integration walkthrough rather than API listing, and `SECURITY.md` is clear about
   scope, reporting, and the vendored-sodium liability. Most commercial codebases don't
   document this well.
+- **Interface stability as a feature.** The library is over ten years old and
+  deliberately keeps the C++ dialect it was written in and the API its users have come
+  to expect — no interface churn chasing language fashion. That is exactly what you want
+  from a networking layer a shipped game depends on: yojimbo is a stable, mature library
+  that values compatibility, for serious people to get things done with. (The two header
+  side effects that reach user translation units on Windows — the `#undef SendMessage`
+  and the MSVC warning pragmas — are documented in BUILDING.md.)
 
 ## Honest criticisms
 
@@ -135,36 +142,32 @@ compiles away entirely in release.
    explains config validation. (These are deliberate design decisions per the contract
    above; the fix was writing them down where integrators read them.)
 
-3. **Manual message refcounting is easy to misuse.** Create/Send transfers ownership;
-   Receive obligates a Release; the compiler enforces none of it. This is consistent with
-   the library's contract style, and the debug leak checker is its enforcement mechanism
-   — which now fails through `yojimbo_assert` (interceptable via
-   `yojimbo_set_assert_function`) rather than `exit(1)`, so editors and tools embedding
-   yojimbo can handle it. This remains the part of the API where integrators will make
-   their first mistake.
+3. **Manual message refcounting — as designed, no change will be considered.**
+   Create/Send transfers ownership; Receive obligates a Release; the compiler enforces
+   none of it. The author's position: this library is over ten years old, deliberately
+   does not use modern C++ features, and changing the API would break the interface its
+   users have come to expect — interface stability is the point. The debug leak checker
+   is the contract's enforcement mechanism (it fails through `yojimbo_assert`,
+   interceptable via `yojimbo_set_assert_function`), and USAGE.md's examples show the
+   ownership pattern. Review future changes against this contract; do not propose
+   RAII/smart-pointer wrappers.
 
-4. **`alloca` sized by config in packet and tick paths** — *largely addressed.* The
-   client/server simulator pumps now drain in fixed-size batches, and the channels own
-   scratch buffers for packet generation, so stack usage no longer scales with
-   `maxSimulatorPackets` or `maxMessagesPerPacket` on those paths. The remaining allocas
-   in `yojimbo_channel.cpp`'s message serialize functions are bounded by the
-   wire-validated message count (≤ `maxMessagesPerPacket`, ~6 bytes per message) and were
-   left because replacing them means threading heap cleanup through many early-return
-   paths in template code.
+4. **`alloca` sized by config in packet and tick paths** — *addressed.* The
+   client/server simulator pumps drain in fixed-size batches, the channels own scratch
+   buffers for packet generation, and the message serialize functions in
+   `yojimbo_channel.cpp` allocate their type/id scratch from the message factory
+   allocator (an outer function owns the allocation and single free; the serialize body
+   with its early returns lives in a separate inner function). Stack usage no longer
+   scales with any config value.
 
-5. **The C++ dialect is dated — deliberately, and now documented.** C++03 idioms (NULL,
-   private copy constructors instead of `=delete`, no `override`, `std::map` in debug
-   trackers) are a fair trade for portability into engine codebases with exceptions and
-   RTTI off. The two side effects that leak into user translation units — the
-   `#undef SendMessage` and the MSVC warning pragmas / `_CRT_SECURE_NO_WARNINGS` in
-   `yojimbo_config.h` — are now documented in BUILDING.md ("Windows header side
-   effects").
-
-6. **Vendored-crypto maintenance burden.** The pruned libsodium subset means upstream
-   CVEs must be tracked and re-vendored by hand. `SECURITY.md` acknowledges this honestly
-   and `-DYOJIMBO_SYSTEM_SODIUM=ON` exists as an escape hatch, which is the right
-   mitigation — but it remains a standing liability inherent to the amalgamation
-   approach, and it's the one place where the single-maintainer model concentrates risk.
+5. **Vendored-crypto maintenance.** Inherent to the amalgamation approach, but managed
+   rather than ad hoc: the process for generating and validating the pruned libsodium
+   subset is documented in the **netcode repository** under `sodium/NOTES.md`
+   (intentionally not duplicated into this repo — yojimbo's copy follows netcode's),
+   netcode's nightly CI opens a tracking issue when upstream libsodium publishes a new
+   release, `SECURITY.md` states the policy, and `-DYOJIMBO_SYSTEM_SODIUM=ON` is the
+   escape hatch for anyone who prefers the system library. What remains is that
+   re-vendoring is a manual — though documented and repeatable — step.
 
 ## Bottom line
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -215,6 +215,17 @@ void GameServer::ProcessTestMessage(int clientIndex, TestMessage* message) {
 }
 ```
 
+Now that we're creating, sending, receiving and releasing messages, this is the place to state the **message ownership rules** explicitly. Messages are reference counted and always come from the message factory — never create one with `new` and never delete one directly:
+
+- `CreateMessage` returns a message that **you own**. Check the returned pointer — it is NULL if the message factory is out of memory.
+- `SendMessage` **takes ownership** of the message. After sending, the message belongs to yojimbo: don't touch it, and don't release it.
+- If you create a message and then decide not to send it, release it with `ReleaseMessage`, or it will leak.
+- `ReceiveMessage` returns a message that **you own**. Process it, then call `ReleaseMessage`. Don't use the pointer after releasing it.
+- On the server, messages belong to a **per-client** message factory. Create a message with the same client index you will send it to, and release received messages with the client index you received them from. A message created for one client cannot be sent to another.
+- A block allocated with `AllocateBlock` is owned by the message once you call `AttachBlockToMessage`, and is freed when the message is destroyed. If you allocate a block and never attach it, free it with `FreeBlock`.
+
+In debug builds the message factory checks for leaked messages when the client or server shuts down, prints each leaked message, and fails an assert — so ownership mistakes are caught during development.
+
 Let's leave the server aside for a moment and take a look at the client. You need a `Client` and the same `ClientServerConfig` and `Adapter` as the server. In this example, the game is divided into "screens" and the screen handling the online game is called `OnlineGameScreen`. It looks like this:
 
 ```cpp

--- a/source/yojimbo_channel.cpp
+++ b/source/yojimbo_channel.cpp
@@ -76,95 +76,212 @@ namespace yojimbo
         initialized = 0;
     }
 
-    template <typename Stream> bool SerializeOrderedMessages( Stream & stream, 
-                                                              MessageFactory & messageFactory, 
-                                                              int & numMessages, 
-                                                              Message ** & messages, 
-                                                              int maxMessagesPerPacket )
+    template <typename Stream> bool SerializeOrderedMessagesInternal( Stream & stream,
+                                                                      MessageFactory & messageFactory,
+                                                                      int & numMessages,
+                                                                      Message ** & messages,
+                                                                      int * messageTypes,
+                                                                      uint16_t * messageIds )
     {
         const int maxMessageType = messageFactory.GetNumTypes() - 1;
 
+        memset( messageTypes, 0, sizeof( int ) * numMessages );
+        memset( messageIds, 0, sizeof( uint16_t ) * numMessages );
+
+        if ( Stream::IsWriting )
+        {
+            yojimbo_assert( messages );
+
+            for ( int i = 0; i < numMessages; ++i )
+            {
+                yojimbo_assert( messages[i] );
+                messageTypes[i] = messages[i]->GetType();
+                messageIds[i] = messages[i]->GetId();
+            }
+        }
+        else
+        {
+            Allocator & allocator = messageFactory.GetAllocator();
+
+            messages = (Message**) YOJIMBO_ALLOCATE( allocator, sizeof( Message* ) * numMessages );
+
+            if ( !messages )
+            {
+                // Out of memory. Leave the arm empty (numMessages = 0) so ChannelPacketData::Free
+                // stays safe, then fail the read; the channel treats this as a serialize failure.
+                numMessages = 0;
+                yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate messages (SerializeOrderedMessages)\n" );
+                return false;
+            }
+
+            for ( int i = 0; i < numMessages; ++i )
+            {
+                messages[i] = NULL;
+            }
+        }
+
+        serialize_bits( stream, messageIds[0], 16 );
+
+        for ( int i = 1; i < numMessages; ++i )
+            serialize_sequence_relative( stream, messageIds[i-1], messageIds[i] );
+
+        for ( int i = 0; i < numMessages; ++i )
+        {
+            if ( maxMessageType > 0 )
+            {
+                serialize_int( stream, messageTypes[i], 0, maxMessageType );
+            }
+            else
+            {
+                messageTypes[i] = 0;
+            }
+
+            if ( Stream::IsReading )
+            {
+                messages[i] = messageFactory.CreateMessage( messageTypes[i] );
+
+                if ( !messages[i] )
+                {
+                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to create message of type %d (SerializeOrderedMessages)\n", messageTypes[i] );
+                    return false;
+                }
+
+                messages[i]->SetId( messageIds[i] );
+            }
+
+            yojimbo_assert( messages[i] );
+
+            if ( !messages[i]->SerializeInternal( stream ) )
+            {
+                yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to serialize message of type %d (SerializeOrderedMessages)\n", messageTypes[i] );
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    template <typename Stream> bool SerializeOrderedMessages( Stream & stream,
+                                                              MessageFactory & messageFactory,
+                                                              int & numMessages,
+                                                              Message ** & messages,
+                                                              int maxMessagesPerPacket )
+    {
         bool hasMessages = Stream::IsWriting && numMessages != 0;
 
         serialize_bool( stream, hasMessages );
 
-        if ( hasMessages )
+        if ( !hasMessages )
+            return true;
+
+        serialize_int( stream, numMessages, 1, maxMessagesPerPacket );
+
+        // One heap block for the message type and id scratch arrays, so stack usage doesn't
+        // scale with maxMessagesPerPacket. The serialize body lives in a separate function so
+        // all its early returns (including the ones hidden inside serialize_* macros) funnel
+        // through the single free below.
+        Allocator & allocator = messageFactory.GetAllocator();
+
+        uint8_t * scratch = (uint8_t*) YOJIMBO_ALLOCATE( allocator, ( sizeof( int ) + sizeof( uint16_t ) ) * numMessages );
+
+        if ( !scratch )
         {
-            serialize_int( stream, numMessages, 1, maxMessagesPerPacket );
-
-            int * messageTypes = (int*) alloca( sizeof( int ) * numMessages );
-
-            uint16_t * messageIds = (uint16_t*) alloca( sizeof( uint16_t ) * numMessages );
-
-            memset( messageTypes, 0, sizeof( int ) * numMessages );
-            memset( messageIds, 0, sizeof( uint16_t ) * numMessages );
-
-            if ( Stream::IsWriting )
+            if ( Stream::IsReading )
             {
-                yojimbo_assert( messages );
-
-                for ( int i = 0; i < numMessages; ++i )
-                {
-                    yojimbo_assert( messages[i] );
-                    messageTypes[i] = messages[i]->GetType();
-                    messageIds[i] = messages[i]->GetId();
-                }
+                // Leave the arm empty (numMessages = 0) so ChannelPacketData::Free stays safe.
+                // On write the messages remain owned by the packet data, so leave them alone.
+                numMessages = 0;
             }
-            else
-            {
-                Allocator & allocator = messageFactory.GetAllocator();
+            yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate serialize scratch (SerializeOrderedMessages)\n" );
+            return false;
+        }
 
-                messages = (Message**) YOJIMBO_ALLOCATE( allocator, sizeof( Message* ) * numMessages );
+        int * messageTypes = (int*) scratch;
+        uint16_t * messageIds = (uint16_t*) ( scratch + sizeof( int ) * numMessages );
 
-                if ( !messages )
-                {
-                    // Out of memory. Leave the arm empty (numMessages = 0) so ChannelPacketData::Free
-                    // stays safe, then fail the read; the channel treats this as a serialize failure.
-                    numMessages = 0;
-                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate messages (SerializeOrderedMessages)\n" );
-                    return false;
-                }
+        const bool result = SerializeOrderedMessagesInternal( stream, messageFactory, numMessages, messages, messageTypes, messageIds );
 
-                for ( int i = 0; i < numMessages; ++i )
-                {
-                    messages[i] = NULL;
-                }
-            }
+        YOJIMBO_FREE( allocator, scratch );
 
-            serialize_bits( stream, messageIds[0], 16 );
+        return result;
+    }
 
-            for ( int i = 1; i < numMessages; ++i )
-                serialize_sequence_relative( stream, messageIds[i-1], messageIds[i] );
+    template <typename Stream> bool SerializeUnorderedMessagesInternal( Stream & stream,
+                                                                        MessageFactory & messageFactory,
+                                                                        int & numMessages,
+                                                                        Message ** & messages,
+                                                                        int maxBlockSize,
+                                                                        int * messageTypes )
+    {
+        const int maxMessageType = messageFactory.GetNumTypes() - 1;
+
+        memset( messageTypes, 0, sizeof( int ) * numMessages );
+
+        if ( Stream::IsWriting )
+        {
+            yojimbo_assert( messages );
 
             for ( int i = 0; i < numMessages; ++i )
             {
-                if ( maxMessageType > 0 )
-                {
-                    serialize_int( stream, messageTypes[i], 0, maxMessageType );
-                }
-                else
-                {
-                    messageTypes[i] = 0;
-                }
-
-                if ( Stream::IsReading )
-                {
-                    messages[i] = messageFactory.CreateMessage( messageTypes[i] );
-
-                    if ( !messages[i] )
-                    {
-                        yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to create message of type %d (SerializeOrderedMessages)\n", messageTypes[i] );
-                        return false;
-                    }
-
-                    messages[i]->SetId( messageIds[i] );
-                }
-
                 yojimbo_assert( messages[i] );
+                messageTypes[i] = messages[i]->GetType();
+            }
+        }
+        else
+        {
+            Allocator & allocator = messageFactory.GetAllocator();
 
-                if ( !messages[i]->SerializeInternal( stream ) )
+            messages = (Message**) YOJIMBO_ALLOCATE( allocator, sizeof( Message* ) * numMessages );
+
+            if ( !messages )
+            {
+                // Out of memory. Leave the arm empty (numMessages = 0) so ChannelPacketData::Free
+                // stays safe, then fail the read; the channel treats this as a serialize failure.
+                numMessages = 0;
+                yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate messages (SerializeUnorderedMessages)\n" );
+                return false;
+            }
+
+            for ( int i = 0; i < numMessages; ++i )
+                messages[i] = NULL;
+        }
+
+        for ( int i = 0; i < numMessages; ++i )
+        {
+            if ( maxMessageType > 0 )
+            {
+                serialize_int( stream, messageTypes[i], 0, maxMessageType );
+            }
+            else
+            {
+                messageTypes[i] = 0;
+            }
+
+            if ( Stream::IsReading )
+            {
+                messages[i] = messageFactory.CreateMessage( messageTypes[i] );
+
+                if ( !messages[i] )
                 {
-                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to serialize message of type %d (SerializeOrderedMessages)\n", messageTypes[i] );
+                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to create message type %d (SerializeUnorderedMessages)\n", messageTypes[i] );
+                    return false;
+                }
+            }
+
+            yojimbo_assert( messages[i] );
+
+            if ( !messages[i]->SerializeInternal( stream ) )
+            {
+                yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to serialize message type %d (SerializeUnorderedMessages)\n", messageTypes[i] );
+                return false;
+            }
+
+            if ( messages[i]->IsBlockMessage() )
+            {
+                BlockMessage * blockMessage = (BlockMessage*) messages[i];
+                if ( !SerializeMessageBlock( stream, messageFactory, blockMessage, maxBlockSize ) )
+                {
+                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to serialize message block (SerializeUnorderedMessages)\n" );
                     return false;
                 }
             }
@@ -173,99 +290,47 @@ namespace yojimbo
         return true;
     }
 
-    template <typename Stream> bool SerializeUnorderedMessages( Stream & stream, 
-                                                                MessageFactory & messageFactory, 
-                                                                int & numMessages, 
-                                                                Message ** & messages, 
-                                                                int maxMessagesPerPacket, 
+    template <typename Stream> bool SerializeUnorderedMessages( Stream & stream,
+                                                                MessageFactory & messageFactory,
+                                                                int & numMessages,
+                                                                Message ** & messages,
+                                                                int maxMessagesPerPacket,
                                                                 int maxBlockSize )
     {
-        const int maxMessageType = messageFactory.GetNumTypes() - 1;
-
         bool hasMessages = Stream::IsWriting && numMessages != 0;
 
         serialize_bool( stream, hasMessages );
 
-        if ( hasMessages )
+        if ( !hasMessages )
+            return true;
+
+        serialize_int( stream, numMessages, 1, maxMessagesPerPacket );
+
+        // Heap scratch for the message types, so stack usage doesn't scale with
+        // maxMessagesPerPacket. The serialize body lives in a separate function so all its
+        // early returns (including the ones hidden inside serialize_* macros) funnel through
+        // the single free below.
+        Allocator & allocator = messageFactory.GetAllocator();
+
+        int * messageTypes = (int*) YOJIMBO_ALLOCATE( allocator, sizeof( int ) * numMessages );
+
+        if ( !messageTypes )
         {
-            serialize_int( stream, numMessages, 1, maxMessagesPerPacket );
-
-            int * messageTypes = (int*) alloca( sizeof( int ) * numMessages );
-
-            memset( messageTypes, 0, sizeof( int ) * numMessages );
-
-            if ( Stream::IsWriting )
+            if ( Stream::IsReading )
             {
-                yojimbo_assert( messages );
-
-                for ( int i = 0; i < numMessages; ++i )
-                {
-                    yojimbo_assert( messages[i] );
-                    messageTypes[i] = messages[i]->GetType();
-                }
+                // Leave the arm empty (numMessages = 0) so ChannelPacketData::Free stays safe.
+                // On write the messages remain owned by the packet data, so leave them alone.
+                numMessages = 0;
             }
-            else
-            {
-                Allocator & allocator = messageFactory.GetAllocator();
-
-                messages = (Message**) YOJIMBO_ALLOCATE( allocator, sizeof( Message* ) * numMessages );
-
-                if ( !messages )
-                {
-                    // Out of memory. Leave the arm empty (numMessages = 0) so ChannelPacketData::Free
-                    // stays safe, then fail the read; the channel treats this as a serialize failure.
-                    numMessages = 0;
-                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate messages (SerializeUnorderedMessages)\n" );
-                    return false;
-                }
-
-                for ( int i = 0; i < numMessages; ++i )
-                    messages[i] = NULL;
-            }
-
-            for ( int i = 0; i < numMessages; ++i )
-            {
-                if ( maxMessageType > 0 )
-                {
-                    serialize_int( stream, messageTypes[i], 0, maxMessageType );
-                }
-                else
-                {
-                    messageTypes[i] = 0;
-                }
-
-                if ( Stream::IsReading )
-                {
-                    messages[i] = messageFactory.CreateMessage( messageTypes[i] );
-
-                    if ( !messages[i] )
-                    {
-                        yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to create message type %d (SerializeUnorderedMessages)\n", messageTypes[i] );
-                        return false;
-                    }
-                }
-
-                yojimbo_assert( messages[i] );
-
-                if ( !messages[i]->SerializeInternal( stream ) )
-                {
-                    yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to serialize message type %d (SerializeUnorderedMessages)\n", messageTypes[i] );
-                    return false;
-                }
-
-                if ( messages[i]->IsBlockMessage() )
-                {
-                    BlockMessage * blockMessage = (BlockMessage*) messages[i];
-                    if ( !SerializeMessageBlock( stream, messageFactory, blockMessage, maxBlockSize ) )
-                    {
-                        yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to serialize message block (SerializeUnorderedMessages)\n" );
-                        return false;
-                    }
-                }
-            }
+            yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate serialize scratch (SerializeUnorderedMessages)\n" );
+            return false;
         }
 
-        return true;
+        const bool result = SerializeUnorderedMessagesInternal( stream, messageFactory, numMessages, messages, maxBlockSize, messageTypes );
+
+        YOJIMBO_FREE( allocator, messageTypes );
+
+        return result;
     }
 
     template <typename Stream> bool SerializeBlockFragment( Stream & stream, 


### PR DESCRIPTION
## Summary

Closes out the last open item from the CLAUDE.md audit ahead of the release. `SerializeOrderedMessages` and `SerializeUnorderedMessages` allocated their message type/id scratch with `alloca` sized by the message count — the last place where stack usage scaled with a config value (`maxMessagesPerPacket`).

- Each function is split in two: the **outer** function serializes the message count, allocates one scratch block from the message factory allocator, calls the inner function, and frees unconditionally. The **inner** function holds the serialize body with all its early returns (including the ones hidden inside `serialize_*` macros), so cleanup has a single point and can't be missed. No RAII, no caller-visible changes — the outer signatures are unchanged.
- On scratch allocation failure, the read path leaves the arm empty (`numMessages = 0`) so `ChannelPacketData::Free` stays safe — and the write path deliberately leaves `numMessages`/`messages` untouched, since on write the messages are owned by the packet data and zeroing the count would leak their acquired references.
- Also updates CLAUDE.md with the author's design rulings: manual refcounting and the C++ dialect are as designed (dialect moves from criticisms to strengths — interface stability is a feature), and vendored crypto is a documented, managed process (netcode `sodium/NOTES.md` + netcode's nightly upstream tracking).

## Test plan

- [x] Full suite passes in Debug and Release on macOS arm64, builds warning-free
- [x] `soak 3000` runs clean
- [x] `fuzz_connection` (read path — these exact functions) standalone under ASan+UBSan: corpus replay + 300k random inputs, clean
- [x] `fuzz_connection_structured` (write path) standalone under ASan+UBSan: corpus replay + 150k scripted runs, clean
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)