### PR TITLE
Add system-deps build for package managers (homebrew preparation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,21 +85,24 @@ jobs:
           set -euo pipefail
           sudo apt-get update && sudo apt-get install -y libsodium-dev
           PREFIX="$HOME/deps"
-          mkdir -p "$PREFIX/include" "$PREFIX/lib"
+          # Clone outside the workspace: the yojimbo checkout already has serialize/,
+          # reliable/ and netcode/ directories (the vendored copies).
+          DEPS_SRC="$HOME/deps-src"
+          mkdir -p "$PREFIX/include" "$PREFIX/lib" "$DEPS_SRC"
           # serialize: header-only
-          git clone --depth 1 --branch v1.3.1 https://github.com/mas-bandwidth/serialize.git
-          cp serialize/serialize.h "$PREFIX/include/"
+          git clone --depth 1 --branch v1.3.1 https://github.com/mas-bandwidth/serialize.git "$DEPS_SRC/serialize"
+          cp "$DEPS_SRC/serialize/serialize.h" "$PREFIX/include/"
           # reliable: build the library from source
-          git clone --depth 1 --branch v1.3.0 https://github.com/mas-bandwidth/reliable.git
-          cc -O2 -c reliable/reliable.c -Ireliable -o reliable.o
-          ar rcs "$PREFIX/lib/libreliable.a" reliable.o
-          cp reliable/reliable.h "$PREFIX/include/"
+          git clone --depth 1 --branch v1.3.0 https://github.com/mas-bandwidth/reliable.git "$DEPS_SRC/reliable"
+          cc -O2 -c "$DEPS_SRC/reliable/reliable.c" -I"$DEPS_SRC/reliable" -o "$DEPS_SRC/reliable.o"
+          ar rcs "$PREFIX/lib/libreliable.a" "$DEPS_SRC/reliable.o"
+          cp "$DEPS_SRC/reliable/reliable.h" "$PREFIX/include/"
           # netcode: has cmake install rules (built against the system libsodium, as a
           # package manager would)
-          git clone --depth 1 --branch v1.3.2 https://github.com/mas-bandwidth/netcode.git
-          cmake -B netcode-build -S netcode -DCMAKE_BUILD_TYPE=Release -DNETCODE_SYSTEM_SODIUM=ON -DCMAKE_INSTALL_PREFIX="$PREFIX"
-          cmake --build netcode-build -j
-          cmake --install netcode-build
+          git clone --depth 1 --branch v1.3.2 https://github.com/mas-bandwidth/netcode.git "$DEPS_SRC/netcode"
+          cmake -B "$DEPS_SRC/netcode-build" -S "$DEPS_SRC/netcode" -DCMAKE_BUILD_TYPE=Release -DNETCODE_SYSTEM_SODIUM=ON -DCMAKE_INSTALL_PREFIX="$PREFIX"
+          cmake --build "$DEPS_SRC/netcode-build" -j
+          cmake --install "$DEPS_SRC/netcode-build"
       - name: Build & test yojimbo against the installed dependencies
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Debug -DYOJIMBO_SYSTEM_DEPS=ON -DCMAKE_PREFIX_PATH="$HOME/deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,46 @@ jobs:
           cmake --build build -j
           ./bin/test
 
+  system-deps:
+    name: build & test (linux, --system-deps)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      # Simulates the package-manager environment (e.g. homebrew): serialize, reliable and
+      # netcode installed into a prefix from their own releases, then yojimbo built against
+      # them with -DYOJIMBO_SYSTEM_DEPS=ON instead of the vendored copies. Versions pinned
+      # to match the vendored ones.
+      - name: Install serialize, reliable and netcode into a prefix
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y libsodium-dev
+          PREFIX="$HOME/deps"
+          mkdir -p "$PREFIX/include" "$PREFIX/lib"
+          # serialize: header-only
+          git clone --depth 1 --branch v1.3.1 https://github.com/mas-bandwidth/serialize.git
+          cp serialize/serialize.h "$PREFIX/include/"
+          # reliable: build the library from source
+          git clone --depth 1 --branch v1.3.0 https://github.com/mas-bandwidth/reliable.git
+          cc -O2 -c reliable/reliable.c -Ireliable -o reliable.o
+          ar rcs "$PREFIX/lib/libreliable.a" reliable.o
+          cp reliable/reliable.h "$PREFIX/include/"
+          # netcode: has cmake install rules (built against the system libsodium, as a
+          # package manager would)
+          git clone --depth 1 --branch v1.3.2 https://github.com/mas-bandwidth/netcode.git
+          cmake -B netcode-build -S netcode -DCMAKE_BUILD_TYPE=Release -DNETCODE_SYSTEM_SODIUM=ON -DCMAKE_INSTALL_PREFIX="$PREFIX"
+          cmake --build netcode-build -j
+          cmake --install netcode-build
+      - name: Build & test yojimbo against the installed dependencies
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DYOJIMBO_SYSTEM_DEPS=ON -DCMAKE_PREFIX_PATH="$HOME/deps"
+          cmake --build build -j
+          ./bin/test
+      - name: Install yojimbo and verify the layout
+        run: |
+          cmake --install build --prefix "$HOME/yojimbo-install"
+          test -f "$HOME/yojimbo-install/include/yojimbo.h"
+          test -f "$HOME/yojimbo-install/lib/libyojimbo.a"
+
   sanitizers:
     name: sanitizers (linux, ASan+UBSan+LSan)
     runs-on: ubuntu-24.04

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,6 +60,23 @@ then configure with `-DYOJIMBO_SYSTEM_SODIUM=ON`:
     cmake -B build -DYOJIMBO_SYSTEM_SODIUM=ON
     cmake --build build -j
 
+## Building against system-installed dependencies
+
+By default the build uses the vendored copies of serialize, reliable and netcode. For
+package managers (e.g. homebrew), configure with `-DYOJIMBO_SYSTEM_DEPS=ON` to build
+against system-installed copies of all three instead. They must be installed where CMake
+can find them — pass `-DCMAKE_PREFIX_PATH=/path/to/prefix` for a custom location. In this
+configuration the bundled libsodium isn't used at all (the system netcode supplies its own
+crypto), and `cmake --install` installs the yojimbo headers and library:
+
+    cmake -B build -DYOJIMBO_SYSTEM_DEPS=ON
+    cmake --build build -j
+    ./bin/test
+    cmake --install build
+
+Note that the test suite skips the embedded netcode and reliable self-test sections in
+this configuration — system libraries are built without their test hooks.
+
 cheers
 
  - Glenn

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,22 @@
 #
 # Static libraries: sodium-builtin (unless -DYOJIMBO_SYSTEM_SODIUM=ON), netcode, reliable,
 # tlsf, yojimbo. Executables: client, server, loopback, soak, test — all written to bin/.
+#
+# For package managers (e.g. homebrew): -DYOJIMBO_SYSTEM_DEPS=ON builds against
+# system-installed serialize, reliable and netcode instead of the vendored copies, and
+# `cmake --install` installs the yojimbo headers and library.
 
 cmake_minimum_required(VERSION 3.16)
-project(Yojimbo LANGUAGES C CXX)
+project(Yojimbo VERSION 1.5.0 LANGUAGES C CXX)
 
 option(YOJIMBO_SYSTEM_SODIUM
     "Link the system-installed libsodium instead of the bundled subset in sodium/" OFF)
+
+option(YOJIMBO_SYSTEM_DEPS
+    "Build against system-installed serialize, reliable and netcode instead of the vendored copies" OFF)
+
+option(YOJIMBO_INSTALL
+    "Generate the install target (yojimbo headers and library)" ON)
 
 # Single-config generators (Make/Ninja) have no build type by default; match the old
 # `make config=debug` default of a debug build.
@@ -28,16 +38,6 @@ foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_SOURCE_DIR}/bin")
 endforeach()
 
-set(YOJIMBO_INCLUDE_DIRS
-    "${CMAKE_SOURCE_DIR}"
-    "${CMAKE_SOURCE_DIR}/include"
-    "${CMAKE_SOURCE_DIR}/sodium"
-    "${CMAKE_SOURCE_DIR}/tlsf"
-    "${CMAKE_SOURCE_DIR}/netcode"
-    "${CMAKE_SOURCE_DIR}/reliable"
-    "${CMAKE_SOURCE_DIR}/serialize"
-)
-
 # yojimbo/netcode/reliable/serialize each derive their _DEBUG vs _RELEASE mode from NDEBUG
 # (see the `#if !defined(..._DEBUG) && !defined(..._RELEASE)` blocks in their headers). CMake
 # already defines NDEBUG in Release and not in Debug, so the correct mode is selected
@@ -51,48 +51,131 @@ else()
     add_compile_options(-Wall -Wextra -ffast-math $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif()
 
-# --- libsodium backend --------------------------------------------------------------------
+if(YOJIMBO_SYSTEM_DEPS)
 
-if(YOJIMBO_SYSTEM_SODIUM)
-    find_library(YOJIMBO_SODIUM_LIB NAMES sodium REQUIRED
-        HINTS /opt/homebrew/lib /usr/local/lib /usr/lib)
-    message(STATUS "yojimbo: linking system libsodium: ${YOJIMBO_SODIUM_LIB}")
-    set(YOJIMBO_SODIUM ${YOJIMBO_SODIUM_LIB})
+    # --- system dependencies (e.g. homebrew) ------------------------------------------------
+    #
+    # Build against installed serialize (header-only), reliable and netcode instead of the
+    # vendored copies. This is the package-manager configuration: those libraries come from
+    # their own packages and receive their own updates. The system netcode supplies its own
+    # crypto, so the bundled libsodium is not used at all here (YOJIMBO_SYSTEM_SODIUM is
+    # moot). tlsf stays built-in — it is an implementation detail of yojimbo's per-client
+    # allocators, not a public dependency.
+
+    find_path(YOJIMBO_SERIALIZE_INCLUDE_DIR serialize.h REQUIRED)
+    find_path(YOJIMBO_NETCODE_INCLUDE_DIR netcode.h REQUIRED)
+    find_library(YOJIMBO_NETCODE_LIBRARY netcode REQUIRED)
+    find_path(YOJIMBO_RELIABLE_INCLUDE_DIR reliable.h REQUIRED)
+    find_library(YOJIMBO_RELIABLE_LIBRARY reliable REQUIRED)
+
+    # Needed at link time when the installed netcode is a static archive (a shared netcode
+    # already carries its crypto). Optional: absent is fine when netcode is shared.
+    find_library(YOJIMBO_SODIUM_LIBRARY sodium)
+
+    set(YOJIMBO_INCLUDE_DIRS
+        "${CMAKE_SOURCE_DIR}"
+        "${CMAKE_SOURCE_DIR}/include"
+        "${CMAKE_SOURCE_DIR}/tlsf"
+        "${YOJIMBO_SERIALIZE_INCLUDE_DIR}"
+        "${YOJIMBO_NETCODE_INCLUDE_DIR}"
+        "${YOJIMBO_RELIABLE_INCLUDE_DIR}"
+    )
+
 else()
-    # The bundled minimal libsodium (sodium/sodium.c). Warnings off — it is vendored,
-    # amalgamated upstream code.
-    add_library(sodium-builtin STATIC sodium/sodium.c)
-    target_include_directories(sodium-builtin PRIVATE ${YOJIMBO_INCLUDE_DIRS})
-    if(MSVC)
-        target_compile_options(sodium-builtin PRIVATE /w)
+
+    set(YOJIMBO_INCLUDE_DIRS
+        "${CMAKE_SOURCE_DIR}"
+        "${CMAKE_SOURCE_DIR}/include"
+        "${CMAKE_SOURCE_DIR}/sodium"
+        "${CMAKE_SOURCE_DIR}/tlsf"
+        "${CMAKE_SOURCE_DIR}/netcode"
+        "${CMAKE_SOURCE_DIR}/reliable"
+        "${CMAKE_SOURCE_DIR}/serialize"
+    )
+
+    # --- libsodium backend ----------------------------------------------------------------
+
+    if(YOJIMBO_SYSTEM_SODIUM)
+        find_library(YOJIMBO_SODIUM_LIB NAMES sodium REQUIRED
+            HINTS /opt/homebrew/lib /usr/local/lib /usr/lib)
+        message(STATUS "yojimbo: linking system libsodium: ${YOJIMBO_SODIUM_LIB}")
+        set(YOJIMBO_SODIUM ${YOJIMBO_SODIUM_LIB})
     else()
-        target_compile_options(sodium-builtin PRIVATE -w)
+        # The bundled minimal libsodium (sodium/sodium.c). Warnings off — it is vendored,
+        # amalgamated upstream code.
+        add_library(sodium-builtin STATIC sodium/sodium.c)
+        target_include_directories(sodium-builtin PRIVATE ${YOJIMBO_INCLUDE_DIRS})
+        set_target_properties(sodium-builtin PROPERTIES POSITION_INDEPENDENT_CODE ON)
+        if(MSVC)
+            target_compile_options(sodium-builtin PRIVATE /w)
+        else()
+            target_compile_options(sodium-builtin PRIVATE -w)
+        endif()
+        set(YOJIMBO_SODIUM sodium-builtin)
     endif()
-    set(YOJIMBO_SODIUM sodium-builtin)
+
+    # --- vendored C libraries ---------------------------------------------------------------
+
+    add_library(netcode STATIC netcode/netcode.c)
+    target_include_directories(netcode PRIVATE ${YOJIMBO_INCLUDE_DIRS})
+    target_compile_definitions(netcode PRIVATE NETCODE_ENABLE_TESTS=1)
+    set_target_properties(netcode PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(netcode PUBLIC ${YOJIMBO_SODIUM})
+
+    add_library(reliable STATIC reliable/reliable.c)
+    target_include_directories(reliable PRIVATE ${YOJIMBO_INCLUDE_DIRS})
+    target_compile_definitions(reliable PRIVATE RELIABLE_ENABLE_TESTS=1)
+    set_target_properties(reliable PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 endif()
 
-# --- vendored C libraries -----------------------------------------------------------------
-
-add_library(netcode STATIC netcode/netcode.c)
-target_include_directories(netcode PRIVATE ${YOJIMBO_INCLUDE_DIRS})
-target_compile_definitions(netcode PRIVATE NETCODE_ENABLE_TESTS=1)
-target_link_libraries(netcode PUBLIC ${YOJIMBO_SODIUM})
-
-add_library(reliable STATIC reliable/reliable.c)
-target_include_directories(reliable PRIVATE ${YOJIMBO_INCLUDE_DIRS})
-target_compile_definitions(reliable PRIVATE RELIABLE_ENABLE_TESTS=1)
-
 add_library(tlsf STATIC tlsf/tlsf.c)
-target_include_directories(tlsf PRIVATE ${YOJIMBO_INCLUDE_DIRS})
+target_include_directories(tlsf PRIVATE "${CMAKE_SOURCE_DIR}/tlsf")
+set_target_properties(tlsf PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # --- yojimbo library ----------------------------------------------------------------------
 
+# Static by default; -DBUILD_SHARED_LIBS=ON builds it shared (the built-in objects are
+# position independent, so they fold in either way).
+
 file(GLOB YOJIMBO_SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/source/*.cpp")
-add_library(yojimbo STATIC ${YOJIMBO_SOURCES})
+add_library(yojimbo ${YOJIMBO_SOURCES})
 target_include_directories(yojimbo PUBLIC ${YOJIMBO_INCLUDE_DIRS})
-target_link_libraries(yojimbo PUBLIC netcode reliable tlsf ${YOJIMBO_SODIUM})
+set_target_properties(yojimbo PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR})
+
+if(YOJIMBO_SYSTEM_DEPS)
+    target_link_libraries(yojimbo PUBLIC ${YOJIMBO_NETCODE_LIBRARY} ${YOJIMBO_RELIABLE_LIBRARY} tlsf)
+    if(YOJIMBO_SODIUM_LIBRARY)
+        target_link_libraries(yojimbo PUBLIC ${YOJIMBO_SODIUM_LIBRARY})
+    endif()
+    if(WIN32)
+        # The system netcode needs these; a plain find_library result can't carry them.
+        target_link_libraries(yojimbo PUBLIC ws2_32 iphlpapi)
+    endif()
+else()
+    target_link_libraries(yojimbo PUBLIC netcode reliable tlsf ${YOJIMBO_SODIUM})
+endif()
 if(NOT WIN32)
     target_link_libraries(yojimbo PUBLIC m)   # ceil/floor in the reliable-ordered channel etc.
+endif()
+
+# --- install ------------------------------------------------------------------------------
+
+# Installs the yojimbo headers and library. The installed headers include serialize.h (and
+# consumers may include netcode.h for netcode_address_t), so this is intended for
+# YOJIMBO_SYSTEM_DEPS builds where those headers come from their own packages into the same
+# prefix. The vendored copies are never installed — they belong to their own projects.
+
+if(YOJIMBO_INSTALL)
+    include(GNUInstallDirs)
+    install(TARGETS yojimbo
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    file(GLOB YOJIMBO_PUBLIC_HEADERS "${CMAKE_SOURCE_DIR}/include/*.h")
+    install(FILES ${YOJIMBO_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
 # --- sample programs and tests ------------------------------------------------------------
@@ -104,3 +187,9 @@ endforeach()
 
 # serialize is header-only; its self-tests are gated on this and called from test.cpp.
 target_compile_definitions(test PRIVATE SERIALIZE_ENABLE_TESTS=1)
+
+if(YOJIMBO_SYSTEM_DEPS)
+    # System netcode/reliable are built without their embedded test suites, so test.cpp
+    # skips the [netcode] and [reliable] sections in this configuration (see test.cpp).
+    target_compile_definitions(test PRIVATE YOJIMBO_SYSTEM_DEPS=1)
+endif()

--- a/test.cpp
+++ b/test.cpp
@@ -31,7 +31,9 @@
 
 #include "shared.h"
 #include "serialize.h"
+#ifndef YOJIMBO_SYSTEM_DEPS
 #include <sodium.h>
+#endif // #ifndef YOJIMBO_SYSTEM_DEPS
 
 using namespace yojimbo;
 
@@ -3505,12 +3507,16 @@ void test_client_server_messages_network_sim_leak()
     server.Stop();
 }
 
+#ifndef YOJIMBO_SYSTEM_DEPS
+
 void test_crypto_aead_vectors()
 {
     // Known-answer test for the two AEAD primitives netcode relies on. On Windows
     // this exercises the vendored libsodium in sodium/ (including its SSE2/SSSE3/AVX2
     // paths); on other platforms the system libsodium. Expected ciphertext was
     // generated from libsodium 1.0.20 reference output. Do not edit the arrays by hand.
+    // Not built with YOJIMBO_SYSTEM_DEPS: there the system netcode carries its own
+    // crypto, and sodium.h is not on the include path.
     static const uint8_t kat_key[32] = {
         0x40,0x41,0x42,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4a,0x4b,
         0x4c,0x4d,0x4e,0x4f,0x50,0x51,0x52,0x53,0x54,0x55,0x56,0x57,
@@ -3576,6 +3582,8 @@ void test_crypto_aead_vectors()
     check( crypto_aead_xchacha20poly1305_ietf_decrypt( m, &mlen, NULL, c, clen, kat_ad, sizeof( kat_ad ), kat_npub_xchacha, kat_key ) != 0 );
 }
 
+#endif // #ifndef YOJIMBO_SYSTEM_DEPS
+
 #define RUN_TEST( test_function )                                           \
     do                                                                      \
     {                                                                       \
@@ -3590,9 +3598,17 @@ void test_crypto_aead_vectors()
     }                                                                       \
     while (0)
 
+#ifndef YOJIMBO_SYSTEM_DEPS
+
+// The vendored netcode and reliable test suites are compiled into those libraries with
+// NETCODE_ENABLE_TESTS / RELIABLE_ENABLE_TESTS. System-installed libraries (eg. homebrew,
+// -DYOJIMBO_SYSTEM_DEPS=ON) are built without them, so these only exist in vendored builds.
+
 extern "C" void netcode_test();
 
 extern "C" void reliable_test();
+
+#endif // #ifndef YOJIMBO_SYSTEM_DEPS
 
 /*
 #ifndef SOAK
@@ -3641,6 +3657,8 @@ int main( int argc, char ** argv )
             ShutdownYojimbo();
         }
 
+#ifndef YOJIMBO_SYSTEM_DEPS
+
         {
             printf( "\n[netcode]\n\n" );
 
@@ -3661,9 +3679,13 @@ int main( int argc, char ** argv )
             ShutdownYojimbo();
         }
 
+#endif // #ifndef YOJIMBO_SYSTEM_DEPS
+
         printf( "\n[yojimbo]\n\n" );
 
+#ifndef YOJIMBO_SYSTEM_DEPS
         RUN_TEST( test_crypto_aead_vectors );
+#endif // #ifndef YOJIMBO_SYSTEM_DEPS
         RUN_TEST( test_queue );
         RUN_TEST( test_address );
         RUN_TEST( test_network_simulator_drains_all_slots );


### PR DESCRIPTION
## Summary

Prepares yojimbo for homebrew submission, per the plan: the homebrew build must depend on the homebrew formulas of serialize, reliable and netcode — never the vendored copies. (Actual submission remains gated on all three dependencies being accepted into homebrew-core first; a daily scheduled check watches for that.)

- **`-DYOJIMBO_SYSTEM_DEPS=ON`** builds against system-installed serialize (header-only), reliable and netcode instead of the vendored copies. The bundled libsodium isn't used at all in this configuration — the system netcode supplies its own crypto (libsodium is found and linked only if present, for the static-netcode case). tlsf stays built-in: it's an implementation detail of yojimbo's per-client allocators, not a public dependency.
- **Install rules** (`YOJIMBO_INSTALL`, default ON): `cmake --install` installs the yojimbo headers and library. Project gains `VERSION 1.5.0`; libraries build with PIC so `-DBUILD_SHARED_LIBS=ON` works.
- **test.cpp** skips the embedded `netcode_test()` / `reliable_test()` suites and the sodium AEAD known-answer test in system-deps builds (system libraries are built without test hooks; there's no vendored sodium to validate). Everything else in the suite runs.
- **New CI job** `system-deps`: installs serialize v1.3.1, reliable v1.3.0, netcode v1.3.2 into a prefix from their release tags (netcode built against the system libsodium, exactly as a package manager would), builds yojimbo against them, runs the tests, and verifies the installed layout.
- BUILDING.md documents the configuration.

The default vendored build is unchanged in behavior.

## Test plan

- [x] Default (vendored) config: builds warning-free, full suite passes including the [netcode], [reliable] and AEAD sections
- [x] System-deps config: staged a simulated package prefix locally (release-content serialize.h/reliable.h + built libreliable.a/libnetcode.a/libsodium.a), built warning-free, suite passes with vendored-only sections skipped
- [x] `cmake --install` verified: headers + `libyojimbo.a` in the expected layout
- [ ] CI matrix including the new `system-deps` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)