### PR TITLE
Fix for compiler message:

### DIFF
--- a/include/yojimbo_config.h
+++ b/include/yojimbo_config.h
@@ -66,6 +66,14 @@
 #define YOJIMBO_PLATFORM YOJIMBO_PLATFORM_UNIX
 #endif
 
+#if !defined(YOJIMBO_OVERRIDE)
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1700)
+#define YOJIMBO_OVERRIDE override
+#else
+#define YOJIMBO_OVERRIDE
+#endif // #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1700)
+#endif // #if !defined(YOJIMBO_OVERRIDE)
+
 #ifdef YOJIMBO_DEBUG
 
 #define YOJIMBO_DEBUG_MEMORY_LEAKS                  1

--- a/include/yojimbo_serialize.h
+++ b/include/yojimbo_serialize.h
@@ -173,10 +173,10 @@ namespace yojimbo
         See shared.h for examples of usage.
      */
 
-    #define YOJIMBO_VIRTUAL_SERIALIZE_FUNCTIONS()                                                               \
-        bool SerializeInternal( class yojimbo::ReadStream & stream ) override { return Serialize( stream ); };           \
-        bool SerializeInternal( class yojimbo::WriteStream & stream ) override { return Serialize( stream ); };          \
-        bool SerializeInternal( class yojimbo::MeasureStream & stream ) override { return Serialize( stream ); };
+    #define YOJIMBO_VIRTUAL_SERIALIZE_FUNCTIONS()                                                                         \
+        bool SerializeInternal( class yojimbo::ReadStream & stream ) YOJIMBO_OVERRIDE { return Serialize( stream ); };    \
+        bool SerializeInternal( class yojimbo::WriteStream & stream ) YOJIMBO_OVERRIDE { return Serialize( stream ); };   \
+        bool SerializeInternal( class yojimbo::MeasureStream & stream ) YOJIMBO_OVERRIDE { return Serialize( stream ); };
 }
 
 #endif // #ifndef YOJIMBO_SERIALIZE_H

--- a/include/yojimbo_serialize.h
+++ b/include/yojimbo_serialize.h
@@ -174,9 +174,9 @@ namespace yojimbo
      */
 
     #define YOJIMBO_VIRTUAL_SERIALIZE_FUNCTIONS()                                                               \
-        bool SerializeInternal( class yojimbo::ReadStream & stream ) { return Serialize( stream ); };           \
-        bool SerializeInternal( class yojimbo::WriteStream & stream ) { return Serialize( stream ); };          \
-        bool SerializeInternal( class yojimbo::MeasureStream & stream ) { return Serialize( stream ); };
+        bool SerializeInternal( class yojimbo::ReadStream & stream ) override { return Serialize( stream ); };           \
+        bool SerializeInternal( class yojimbo::WriteStream & stream ) override { return Serialize( stream ); };          \
+        bool SerializeInternal( class yojimbo::MeasureStream & stream ) override { return Serialize( stream ); };
 }
 
 #endif // #ifndef YOJIMBO_SERIALIZE_H


### PR DESCRIPTION
Fix for compiler message:
error: 'SerializeInternal' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  253 |     YOJIMBO_VIRTUAL_SERIALIZE_FUNCTIONS()