### PR TITLE
Connection-packet standard, state machine, conformance checkers, dead code removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,28 @@ jobs:
             ./"$t" "corpus/$t" "fuzz/corpus/$t" $RUN
             echo "::endgroup::"
           done
+
+  conformance:
+    name: STANDARD.md + STATE-MACHINE.md conformance
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # The format checker needs no build: it decodes the committed fuzz corpus
+      # using ONLY what STANDARD.md states, with no reference to the source.
+      - name: Verify STANDARD.md
+        run: python3 tools/conformance/verify_standard.py
+
+      # The state-machine checker drives a real client and server over UDP, so
+      # it needs the library built first.
+      - name: Build
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DYOJIMBO_BUILD_TESTS=ON
+          cmake --build build -j
+
+      # A failure in either means the document and the code disagree — decide
+      # which is wrong and fix that one. A specification nothing verifies
+      # drifts, and a drifted spec is worse than none, because independent
+      # implementations are built on it and the failure is silent.
+      - name: Verify STATE-MACHINE.md
+        run: python3 tools/conformance/verify_state_machine.py --build build

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+# .mailmap — canonical identities for git log, shortlog and blame.
+#
+# Git treats every distinct name/email pair as a different person. Without this
+# file, an ownership or contribution analysis silently miscounts: Glenn commits
+# under five identities across these repositories, and attributing four of them
+# to strangers inflates the apparent third-party share of the codebase by
+# thousands of lines. That is not hypothetical — it happened, on 2026-07-21,
+# during a copyright-ownership review, and was caught only by resolving authors
+# by email instead of by name.
+#
+# Contributors: if your entry here is wrong, or you would rather be credited
+# under a different name, send a patch. This file exists to credit people
+# accurately, not to overrule how they wish to be named.
+#
+# Format:  Canonical Name <canonical@email>  Commit Name <commit@email>
+
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn@networknext.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> gafferongames <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn Fiedler <Glenn Fiedler>
+
+Jérôme Leclercq <lynix680@gmail.com> Lynix <lynix680@gmail.com>
+Val Vanderschaegen <valere.vanderschaegen@gmail.com> Val V <valere.vanderschaegen@gmail.com>
+NX <nxrighthere@gmail.com> nxrighthere <nxrighthere@gmail.com>
+Vavius <vavius@gmail.com> vavius <vavius@gmail.com>
+Kien Hoang <kienhg96@gmail.com> Hoang Kien <kienhg96@gmail.com>
+Ryan Scott <ryan@ryan-scott.me> Ryan <ryan@ryan-scott.me>

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,0 +1,238 @@
+# yojimbo 1.0 — connection packet format
+
+This document specifies the **wire format of yojimbo's connection packet**: the
+payload that carries messages between client and server, precisely enough to
+write an independent implementation that interoperates byte-for-byte.
+
+## Scope, and what this document is not
+
+yojimbo is three layers, and only the middle one is specified here.
+
+| layer | responsibility | specified where |
+|---|---|---|
+| **netcode** | connection, encryption, connect tokens, transport | `netcode/STANDARD.md` |
+| **yojimbo connection** | channels, messages, reliability, block transfer | **this document** |
+| **serialize** | bit packing of every primitive below | `serialize/STANDARD.md` |
+
+Everything here is written using serialize's primitives — `serialize_int`,
+`serialize_bool`, `serialize_bits`, `serialize_bytes`,
+`serialize_int_relative`. Their bit-level encodings are **not** repeated here;
+read serialize's standard for those. When this document says
+`serialize_int( value, 0, 63 )` it means exactly what that document says it
+means, including that the width is `bits_required(0,63)` = 6 bits.
+
+A connection packet is carried as the payload of a netcode *connection payload
+packet*. It is encrypted and authenticated by netcode. Nothing in this document
+concerns confidentiality or integrity — by the time you are parsing this
+format, netcode has already established both.
+
+## Configuration is part of the format
+
+This format is **not self-describing**, and it is even less self-describing
+than serialize's. Reader and writer must agree in advance on:
+
+* `numChannels`, and each channel's `type`
+* per channel: `maxMessagesPerPacket`, `maxBlockSize`, `blockFragmentSize`,
+  `disableBlocks`
+* the **number of message types** registered in the message factory
+
+Every one of these changes the number of bits on the wire. A client and server
+built against different channel configurations, or different message-type
+counts, will not interoperate — they will desynchronize mid-packet and the
+failure will look like corruption rather than misconfiguration.
+
+This is a deliberate trade: nothing is spent transmitting what both ends
+already know.
+
+## Connection Packet
+
+    serialize_int( numChannelEntries, 0, numChannels )
+    for each of numChannelEntries:
+        <channel packet data>
+
+A packet with `numChannelEntries == 0` is legal and carries no messages. It is
+still useful: netcode's own header carries the acknowledgements, so an empty
+connection packet is how a peer acks without having anything to say.
+
+Channel entries appear in ascending channel index order.
+
+## Channel Packet Data
+
+    if numChannels > 1:
+        serialize_int( channelIndex, 0, numChannels - 1 )
+    else:
+        channelIndex = 0            // nothing on the wire
+
+    serialize_bool( blockMessage )
+
+    if blockMessage == false:
+        <messages, per the channel's type>
+    else:
+        <block fragment>
+
+Note the elision: **with a single channel configured, the channel index is not
+transmitted at all.** Zero bits, not a zero value.
+
+`blockMessage` selects between the two things a channel entry can carry:
+ordinary messages, or one fragment of a large block transfer.
+
+If `blockMessage` is true and the channel has `disableBlocks` set, the read
+**fails**.
+
+## Messages — reliable-ordered channels
+
+    serialize_bool( hasMessages )
+    if !hasMessages: done
+
+    serialize_int( numMessages, 1, maxMessagesPerPacket )
+
+    // message ids
+    serialize_bits( messageId[0], 16 )
+    for i in 1 .. numMessages-1:
+        serialize_sequence_relative( messageId[i-1], messageId[i] )
+
+    // message types and bodies
+    for i in 0 .. numMessages-1:
+        if maxMessageType > 0:
+            serialize_int( messageType[i], 0, maxMessageType )
+        <message body — application defined>
+
+Where `maxMessageType = (number of registered message types) - 1`.
+
+Three elisions worth naming, because each is a place an implementation goes
+subtly wrong:
+
+* `hasMessages` is a single bit, and when false **nothing else follows**.
+* The **first** message id is a full 16 bits; every subsequent id is encoded
+  **relative to its predecessor**. Message ids in a reliable-ordered channel
+  are near-consecutive, so this usually costs one bit each.
+* If the factory registers exactly **one** message type, `maxMessageType` is 0
+  and the type field is **omitted entirely** — again zero bits, not a zero
+  value.
+
+All ids come first, then all types and bodies. They are **not** interleaved
+per message. An implementation that writes `(id, type, body)` triples will
+produce a stream this library cannot read.
+
+### serialize_sequence_relative
+
+Encodes a 16-bit sequence number relative to a previous one, handling wrap:
+
+    writing:  a = previous
+              b = current + ( previous > current ? 65536 : 0 )
+              serialize_int_relative( a, b )
+
+    reading:  serialize_int_relative( a, b )
+              if b >= 65536: b -= 65536
+              current = uint16( b )
+
+The wrap is handled by lifting the smaller value into a second 65536-wide
+window before taking the difference, so the difference is always positive and
+usually tiny. The underlying `serialize_int_relative` ladder is specified in
+serialize's standard; a difference of 1 costs a single bit.
+
+## Messages — unreliable-unordered channels
+
+    serialize_bool( hasMessages )
+    if !hasMessages: done
+
+    serialize_int( numMessages, 1, maxMessagesPerPacket )
+
+    for i in 0 .. numMessages-1:
+        if maxMessageType > 0:
+            serialize_int( messageType[i], 0, maxMessageType )
+        <message body — application defined>
+        if this message type is a block message:
+            <message block>
+
+**No message ids are transmitted.** That is the entire difference in framing
+between the two channel types: an unreliable channel has nothing to reorder or
+retransmit, so ids would be dead weight.
+
+Unlike a reliable channel, type and body **are** interleaved per message here.
+
+### Message block
+
+Attached to an individual unreliable message whose type is a block message:
+
+    serialize_int( blockSize, 1, maxBlockSize )
+    serialize_bytes( blockData, blockSize )
+
+Remember that `serialize_bytes` **aligns to a byte boundary first** — see
+serialize's standard. That alignment is part of this format.
+
+## Block Fragments
+
+Used when `blockMessage` is true. Large blocks on a reliable-ordered channel
+are split across packets, one fragment per packet per channel.
+
+    serialize_bits( messageId, 16 )
+
+    if maxFragmentsPerBlock > 1:
+        serialize_int( numFragments, 1, maxFragmentsPerBlock )
+    else:
+        numFragments = 1            // nothing on the wire
+
+    if numFragments > 1:
+        serialize_int( fragmentId, 0, numFragments - 1 )
+    else:
+        fragmentId = 0              // nothing on the wire
+
+    serialize_int( fragmentSize, 1, blockFragmentSize )
+    serialize_bytes( fragmentData, fragmentSize )
+
+    if fragmentId == 0:
+        if maxMessageType > 0:
+            serialize_int( messageType, 0, maxMessageType )
+        <the block message's own body — application defined>
+
+`maxFragmentsPerBlock` is derived from the channel config as
+`maxBlockSize / blockFragmentSize`.
+
+**Only fragment 0 carries the message type and the message body.** Later
+fragments carry raw payload only. This mirrors reliable's design, where only
+fragment 0 carries the packet header — a receiver learns what a block *is*
+from its first fragment, and everything after is bytes.
+
+If the message named by fragment 0 is not a block message, the read **fails**.
+
+## Receiver Obligations
+
+* Reject `numChannelEntries > numChannels`.
+* Reject a `channelIndex` outside `[0, numChannels-1]`.
+* Reject `numMessages` outside `[1, maxMessagesPerPacket]`.
+* Reject a block fragment on a channel configured with `disableBlocks`.
+* Reject `fragmentId >= numFragments`, or `numFragments` above
+  `maxFragmentsPerBlock`.
+* Reject a fragment-0 message type that is not a block message.
+* Fail the packet — do not partially apply it — if any message body fails to
+  deserialize.
+
+These are not advisory. Every one of them is a place where a malformed or
+hostile packet would otherwise be accepted, and yojimbo's parser runs on
+attacker-influenced bytes by construction.
+
+## What This Format Does Not Do
+
+* **No encryption or authentication.** netcode has already provided both by the
+  time these bytes exist. Do not layer this format over an unprotected
+  transport and expect yojimbo's guarantees.
+* **No acknowledgement.** Acks live in netcode's header, not here.
+* **No message-type registry on the wire.** Types are indices into a factory
+  both ends compiled in. There is no negotiation and no version field.
+* **No ordering across channels.** Ordering is per reliable-ordered channel
+  only.
+
+## Provenance
+
+Written 2026-07-21 by Rowan, by reading the reference implementation
+(`source/yojimbo_connection.cpp`, `source/yojimbo_channel.cpp`,
+`include/yojimbo_message.h`, `include/yojimbo_serialize.h`).
+
+It documents the format as it stands; where this document and the
+implementation disagree, the implementation is authoritative and this document
+is a bug.
+
+Companion standards: `netcode/STANDARD.md` for the transport beneath,
+`serialize/STANDARD.md` for the bit-level encoding of every primitive used
+here.

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -212,18 +212,6 @@ These are not advisory. Every one of them is a place where a malformed or
 hostile packet would otherwise be accepted, and yojimbo's parser runs on
 attacker-influenced bytes by construction.
 
-## Not on the wire, despite appearances
-
-`yojimbo_serialize.h` also defines **`serialize_ack_relative`**, which encodes
-an ack delta relative to a sequence number. It is **not used anywhere** — not
-by the connection packet, not by either channel, not by the tests — and
-therefore never appears on the wire. It is a leftover from an arrangement where
-yojimbo carried its own acknowledgements; netcode carries them now.
-
-It is documented here as *absent* on purpose. Someone writing an independent
-implementation will find it in the header, assume it must be part of the
-format, and go looking for where it fits. It doesn't fit anywhere.
-
 ## What This Format Does Not Do
 
 * **No encryption or authentication.** netcode has already provided both by the

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -212,6 +212,18 @@ These are not advisory. Every one of them is a place where a malformed or
 hostile packet would otherwise be accepted, and yojimbo's parser runs on
 attacker-influenced bytes by construction.
 
+## Not on the wire, despite appearances
+
+`yojimbo_serialize.h` also defines **`serialize_ack_relative`**, which encodes
+an ack delta relative to a sequence number. It is **not used anywhere** — not
+by the connection packet, not by either channel, not by the tests — and
+therefore never appears on the wire. It is a leftover from an arrangement where
+yojimbo carried its own acknowledgements; netcode carries them now.
+
+It is documented here as *absent* on purpose. Someone writing an independent
+implementation will find it in the header, assume it must be part of the
+format, and go looking for where it fits. It doesn't fit anywhere.
+
 ## What This Format Does Not Do
 
 * **No encryption or authentication.** netcode has already provided both by the

--- a/STATE-MACHINE.md
+++ b/STATE-MACHINE.md
@@ -1,0 +1,105 @@
+# yojimbo client state machine
+
+`STANDARD.md` specifies the bytes on the wire. This specifies **behaviour over
+time**: the states a yojimbo client passes through, what moves it between them,
+and what a caller may assume in each.
+
+The two documents are deliberately separate. A conformance checker for a wire
+format decodes bytes; a conformance checker for a state machine has to drive a
+real client and watch it move. Different instrument, different failure modes.
+
+## The four states
+
+    CLIENT_STATE_ERROR         = -1
+    CLIENT_STATE_DISCONNECTED  =  0
+    CLIENT_STATE_CONNECTING
+    CLIENT_STATE_CONNECTED
+
+The numbering carries meaning and callers rely on it: **negative is failure,
+zero is idle, positive is progress.** `IsConnecting()`, `IsConnected()`,
+`IsDisconnected()` and `ConnectionFailed()` are thin predicates over this value.
+
+## Transitions
+
+    DISCONNECTED ──Connect()──> CONNECTING ──netcode connects──> CONNECTED
+         ^                          │                                │
+         │                          │ failure                        │ Disconnect()
+         │                          v                                │ or server closes
+         └──────────────────────  ERROR <───────────failure──────────┘
+                Connect()             │
+                                      └── Connect() starts a fresh attempt
+
+* **`Connect()`** moves DISCONNECTED (or ERROR, or CONNECTED) to CONNECTING. If
+  the connect token cannot be generated the client goes straight to ERROR
+  without ever reaching CONNECTING.
+* **CONNECTING → CONNECTED** happens when the underlying netcode client
+  completes its handshake.
+* **CONNECTING → ERROR** on any handshake failure: token expired, token
+  invalid, connection denied, or any of the three timeouts.
+* **CONNECTED → DISCONNECTED** when the server closes the connection cleanly.
+* **CONNECTED → ERROR** on timeout or transport failure.
+* **`Disconnect()`** from any state ends at DISCONNECTED.
+
+There is no transition into CONNECTED that does not pass through CONNECTING,
+and no path from DISCONNECTED to CONNECTED that skips it.
+
+## Derivation from netcode
+
+yojimbo does not run its own handshake. Its four states are a **projection of
+netcode's ten**, computed on every `AdvanceTime`:
+
+| netcode client state | value | yojimbo state |
+|---|--:|---|
+| `CONNECT_TOKEN_EXPIRED` | −6 | **ERROR** |
+| `INVALID_CONNECT_TOKEN` | −5 | **ERROR** |
+| `CONNECTION_TIMED_OUT` | −4 | **ERROR** |
+| `CONNECTION_RESPONSE_TIMED_OUT` | −3 | **ERROR** |
+| `CONNECTION_REQUEST_TIMED_OUT` | −2 | **ERROR** |
+| `CONNECTION_DENIED` | −1 | **ERROR** |
+| `DISCONNECTED` | 0 | **DISCONNECTED** |
+| `SENDING_CONNECTION_REQUEST` | 1 | **CONNECTING** |
+| `SENDING_CONNECTION_RESPONSE` | 2 | **CONNECTING** |
+| `CONNECTED` | 3 | **CONNECTED** |
+
+The rule is simply: **any negative netcode state is ERROR**, zero is
+DISCONNECTED, states 1 and 2 are CONNECTING, and 3 is CONNECTED. New negative
+netcode states would map to ERROR automatically without a yojimbo change, which
+is why the comparison is `< 0` rather than an enumeration.
+
+The *reason* for a failure is not in the state — it is recorded separately as a
+disconnect reason, derived from which negative netcode state was seen. The
+state tells you that it failed; the reason tells you why.
+
+## What a caller may assume
+
+* **Only in CONNECTED** may messages be sent or received. Sending in any other
+  state is a programming error, not a queued operation.
+* **`AdvanceTime` is what moves the machine.** A client that is never updated
+  never changes state, never times out, and never completes a handshake. There
+  is no background thread.
+* **ERROR is terminal until acted on.** The client does not retry by itself.
+  `Connect()` starts a fresh attempt; `Disconnect()` returns it to
+  DISCONNECTED.
+* **A clean server-side close lands in DISCONNECTED, not ERROR.** Distinguish
+  "the server said goodbye" from "something broke" — they are different states
+  on purpose.
+
+## Server side
+
+The server has no equivalent state enum. It is either running or not
+(`IsRunning()`, set by `Start()` and cleared by `Stop()`), and it tracks each
+client slot independently. A client slot is connected or free; there is no
+intermediate per-slot state visible to the caller, because the handshake is
+netcode's and completes before the slot is marked connected.
+
+## Provenance
+
+Written 2026-07-21 by Rowan, from `source/yojimbo_client.cpp` and
+`include/yojimbo_client_interface.h`, and verified behaviourally: a real client
+and server are driven through connect, message exchange and disconnect, every
+state transition is recorded, and the observed sequence is checked against the
+machine above — including that no illegal transition occurs. See
+`tools/conformance/verify_state_machine.py`.
+
+Where this document and the implementation disagree, the implementation is
+authoritative and this document is a bug.

--- a/include/yojimbo_serialize.h
+++ b/include/yojimbo_serialize.h
@@ -31,39 +31,6 @@
 
 namespace yojimbo
 {
-    template <typename Stream> bool serialize_ack_relative_internal( Stream & stream, uint16_t sequence, uint16_t & ack )
-    {
-        int ack_delta = 0;
-        bool ack_in_range = false;
-        if ( Stream::IsWriting )
-        {
-            if ( ack < sequence )
-            {
-                ack_delta = sequence - ack;
-            }
-            else
-            {
-                ack_delta = (int)sequence + 65536 - ack;
-            }
-            yojimbo_assert( ack_delta > 0 );
-            yojimbo_assert( uint16_t( sequence - ack_delta ) == ack );
-            ack_in_range = ack_delta <= 64;
-        }
-        serialize_bool( stream, ack_in_range );
-        if ( ack_in_range )
-        {
-            serialize_int( stream, ack_delta, 1, 64 );
-            if ( Stream::IsReading )
-            {
-                ack = sequence - ack_delta;
-            }
-        }
-        else
-        {
-            serialize_bits( stream, ack, 16 );
-        }
-        return true;
-    }
 
     /**
         Serialize an ack relative to the current sequence number (read/write/measure).
@@ -74,15 +41,6 @@ namespace yojimbo
         @param sequence The current sequence number.
         @param ack The ack sequence number, which is typically near the current sequence number.
      */
-
-    #define serialize_ack_relative( stream, sequence, ack  )                                        \
-        do                                                                                          \
-        {                                                                                           \
-            if ( !yojimbo::serialize_ack_relative_internal( stream, sequence, ack ) )               \
-            {                                                                                       \
-                return false;                                                                       \
-            }                                                                                       \
-        } while (0)
 
     template <typename Stream> bool serialize_sequence_relative_internal( Stream & stream, uint16_t sequence1, uint16_t & sequence2 )
     {

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -1,0 +1,35 @@
+# Conformance: STANDARD.md vs the implementation
+
+`STANDARD.md` specifies yojimbo's connection packet format. This fully decodes
+the committed fuzz corpus — framing **and** message bodies — using only what
+that document says, plus `serialize/STANDARD.md` for the bit-level primitives.
+Nothing here consults yojimbo's source.
+
+    python3 tools/conformance/verify_standard.py
+
+No compiler needed. The corpus in `fuzz/corpus/fuzz_connection` was produced by
+the real library via `tools/gen_seed_corpus_connection`, so agreement is a
+genuine differential result rather than a self-consistency check.
+
+## The load-bearing assertion
+
+**Every packet must decode to exhaustion.** Bits left over, or a read past the
+end, means the document is wrong somewhere. This is much stronger than checking
+that fields look plausible: a wrong elision rule produces field values that
+still look reasonable while the bit cursor drifts, and only the total tells you.
+
+## What is covered
+
+Connection packet framing; channel entries and the block discriminator;
+reliable-ordered framing (16-bit first id, relative ids after, all ids before
+any types); unreliable-unordered framing (no ids, type and body interleaved);
+block fragments including that only fragment 0 carries the type and body; and
+every message body in `fuzz/fuzz_messages.h`, which between them exercise
+ranged ints, odd bit widths, bool, float, double, compressed float, alignment,
+the relative-integer ladder, strings, and byte blocks.
+
+## What is NOT covered
+
+Channel configurations other than fuzz selector 0, and the reliability
+machinery above the wire (retransmission, reassembly state, ack logic). Those
+are semantics rather than format.

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -28,6 +28,22 @@ every message body in `fuzz/fuzz_messages.h`, which between them exercise
 ranged ints, odd bit widths, bool, float, double, compressed float, alignment,
 the relative-integer ladder, strings, and byte blocks.
 
+## The state machine, separately
+
+`verify_state_machine.py` checks `STATE-MACHINE.md` — behaviour over time
+rather than bytes on the wire. It drives a real client and server through
+connect, steady state and disconnect over UDP, records every client state
+transition, and checks that:
+
+* every observed transition is one the document permits;
+* the happy path is exactly DISCONNECTED → CONNECTING → CONNECTED →
+  DISCONNECTED;
+* nothing enters CONNECTED except from CONNECTING;
+* an idle connected client produces **no** transitions at all;
+* a clean disconnect lands in DISCONNECTED and never in ERROR.
+
+    python3 tools/conformance/verify_state_machine.py --build <dir with libyojimbo.a>
+
 ## What is NOT covered
 
 Channel configurations other than fuzz selector 0, and the reliability

--- a/tools/conformance/drive_error_paths.cpp
+++ b/tools/conformance/drive_error_paths.cpp
@@ -1,0 +1,57 @@
+// yojimbo error-path driver: connection failure reaches CLIENT_STATE_ERROR
+
+#include "yojimbo.h"
+#include "shared.h"
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+using namespace yojimbo;
+
+static int last_state = -999;
+static void note( ClientInterface & client, const char * phase )
+{
+    int s = client.GetClientState();
+    if ( s != last_state )
+    {
+        printf( "STATE %d %d %s\n", last_state == -999 ? 0 : last_state, s, phase );
+        last_state = s;
+    }
+}
+
+int main()
+{
+    if ( !InitializeYojimbo() ) { printf( "RESULT fail init\n" ); return 1; }
+    setvbuf( stdout, NULL, _IONBF, 0 );
+
+    static TestAdapter errAdapter;
+
+    ClientServerConfig config;
+    uint8_t privateKey[KeyBytes];
+    memset( privateKey, 0, KeyBytes );
+
+    double time = 100.0;
+    {
+        Client client( GetDefaultAllocator(), Address( "0.0.0.0" ), config, errAdapter, time );
+        note( client, "initial" );
+        client.InsecureConnect( privateKey, 0x1234ULL, Address( "127.0.0.1", 40599 ) );
+        note( client, "after_connect_call" );
+
+        for ( int i = 0; i < 4000; ++i )
+        {
+            client.SendPackets();
+            client.ReceivePackets();
+            time += 0.1;
+            client.AdvanceTime( time );
+            note( client, "waiting" );
+            if ( client.ConnectionFailed() ) break;
+        }
+
+        if ( client.ConnectionFailed() )
+            printf( "RESULT ok reached_error\n" );
+        else
+            printf( "RESULT fail no_error_state\n" );
+    }
+    ShutdownYojimbo();
+    return 0;
+}

--- a/tools/conformance/drive_state_machine.cpp
+++ b/tools/conformance/drive_state_machine.cpp
@@ -1,0 +1,99 @@
+/*
+    Drives a real yojimbo client and server through a full lifecycle over UDP and
+    prints every client state transition, for tools/conformance/verify_state_machine.py.
+
+    Output: one line per transition,  STATE <from> <to> <phase>
+    plus    RESULT <ok|fail> <note>
+*/
+#include "yojimbo.h"
+#include "shared.h"
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+using namespace yojimbo;
+
+static const uint16_t ConformancePort = 41777;
+static const int NumClientSlots = 4;
+
+static TestAdapter conformanceAdapter;
+
+static int last_state = -999;
+static void note( ClientInterface & client, const char * phase )
+{
+    int s = client.GetClientState();
+    if ( s != last_state )
+    {
+        printf( "STATE %d %d %s\n", last_state == -999 ? 0 : last_state, s, phase );
+        last_state = s;
+    }
+}
+
+int main()
+{
+    if ( !InitializeYojimbo() ) { printf( "RESULT fail init\n" ); return 1; }
+    setvbuf( stdout, NULL, _IONBF, 0 );
+
+    int rc = 0;
+    {
+    double time = 100.0;
+    ClientServerConfig config;
+
+    uint8_t privateKey[KeyBytes];
+    memset( privateKey, 0, KeyBytes );
+
+    Server server( GetDefaultAllocator(), privateKey, Address( "127.0.0.1", ConformancePort ), config, conformanceAdapter, time );
+    server.Start( NumClientSlots );
+    if ( !server.IsRunning() ) { printf( "RESULT fail server_start\n" ); rc = 1; }
+
+    uint64_t clientId = 0;
+    yojimbo_random_bytes( (uint8_t*) &clientId, 8 );
+    Client client( GetDefaultAllocator(), Address( "0.0.0.0" ), config, conformanceAdapter, time );
+
+    note( client, "initial" );
+    client.InsecureConnect( privateKey, clientId, Address( "127.0.0.1", ConformancePort ) );
+    note( client, "after_connect_call" );
+
+    const double dt = 0.1;
+    int iterations = 0;
+    while ( iterations++ < 200 )
+    {
+        client.SendPackets(); server.SendPackets();
+        client.ReceivePackets(); server.ReceivePackets();
+        time += dt;
+        client.AdvanceTime( time ); server.AdvanceTime( time );
+        note( client, "handshake" );
+        if ( client.IsConnected() ) break;
+        if ( client.ConnectionFailed() ) { printf( "RESULT fail handshake\n" ); rc = 1; break; }
+        yojimbo_sleep( 0.001 );
+    }
+    if ( !client.IsConnected() && rc == 0 ) { printf( "RESULT fail never_connected\n" ); rc = 1; }
+
+    /* stay connected a while so a spurious transition would show up */
+    for ( int i = 0; i < 20; i++ )
+    {
+        client.SendPackets(); server.SendPackets();
+        client.ReceivePackets(); server.ReceivePackets();
+        time += dt;
+        client.AdvanceTime( time ); server.AdvanceTime( time );
+        note( client, "steady" );
+        yojimbo_sleep( 0.001 );
+    }
+
+    client.Disconnect();
+    note( client, "after_disconnect_call" );
+    for ( int i = 0; i < 10; i++ )
+    {
+        client.SendPackets(); server.SendPackets();
+        client.ReceivePackets(); server.ReceivePackets();
+        time += dt;
+        client.AdvanceTime( time ); server.AdvanceTime( time );
+        note( client, "post_disconnect" );
+    }
+
+    server.Stop();
+    printf( "RESULT ok complete\n" );
+    }
+    ShutdownYojimbo();
+    return rc;
+}

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Check yojimbo/STANDARD.md against the implementation.
+
+Fully decodes the committed fuzz corpus — framing AND message bodies — using
+ONLY what STANDARD.md says (plus serialize/STANDARD.md for the bit-level
+primitives). Nothing here consults yojimbo's source. Every packet must decode
+to exhaustion: leftover or missing bits mean the document is wrong.
+
+The corpus was produced by the real library (tools/gen_seed_corpus_connection),
+so agreement is a genuine differential result.
+
+usage: python3 tools/conformance/verify_standard.py
+exit:  0 = the document matches the implementation, 1 = it does not
+"""
+import glob, math, os, struct, sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CORPUS = os.path.join(ROOT, "fuzz", "corpus", "fuzz_connection")
+
+# fuzz_config.h selector 0, and the ChannelConfig defaults it leaves alone
+NUM_CHANNELS = 2
+CHANNEL_TYPE = ["RELIABLE_ORDERED", "UNRELIABLE_UNORDERED"]
+MAX_MESSAGES_PER_PACKET = 256
+MAX_BLOCK_SIZE = 256 * 1024
+BLOCK_FRAGMENT_SIZE = 1024
+MAX_FRAGMENTS_PER_BLOCK = MAX_BLOCK_SIZE // BLOCK_FRAGMENT_SIZE
+# fuzz_messages.h: PRIMITIVES, STRING, BYTES, BLOCK
+NUM_MESSAGE_TYPES = 4
+MAX_MESSAGE_TYPE = NUM_MESSAGE_TYPES - 1
+FUZZ_MAX_STRING, FUZZ_MAX_BYTES = 64, 512
+
+
+class R:
+    """serialize/STANDARD.md: LSB-first bit packing."""
+    def __init__(s, b): s.b = b; s.i = 0; s.n = len(b) * 8
+    def bits(s, k):
+        if s.i + k > s.n: raise ValueError("read past end of packet")
+        v = 0
+        for j in range(k):
+            v |= ((s.b[s.i // 8] >> (s.i % 8)) & 1) << j; s.i += 1
+        return v
+    def align(s):
+        pad = (8 - (s.i % 8)) % 8
+        if pad and s.bits(pad) != 0: raise ValueError("align padding not zero")
+    def read_bytes(s, n):
+        s.align()
+        out = s.b[s.i // 8: s.i // 8 + n]
+        if len(out) != n: raise ValueError("short byte read")
+        s.i += n * 8
+        return out
+
+
+def br(lo, hi): return 0 if lo == hi else (hi - lo).bit_length()
+def sint(r, lo, hi):
+    n = br(lo, hi)
+    v = (r.bits(n) if n else 0) + lo
+    if not (lo <= v <= hi): raise ValueError(f"value {v} outside [{lo},{hi}]")
+    return v
+
+def relative(r, prev):
+    if r.bits(1): return prev + 1
+    if r.bits(1): return prev + sint(r, 2, 6)
+    if r.bits(1): return prev + sint(r, 7, 23)
+    if r.bits(1): return prev + sint(r, 24, 280)
+    if r.bits(1): return prev + sint(r, 281, 4377)
+    return prev + r.bits(32)
+
+def sequence_relative(r, prev):
+    """STANDARD.md, 'serialize_sequence_relative'."""
+    b = relative(r, prev)
+    if b >= 65536: b -= 65536
+    return b & 0xFFFF
+
+
+def message_body(r, mtype):
+    """fuzz_messages.h bodies, expressed purely in serialize primitives."""
+    if mtype == 0:      # PRIMITIVES
+        sint(r, -100000, 100000); r.bits(17); r.bits(1)
+        r.bits(32); r.bits(32); r.bits(32)               # float, double (two words)
+        mx = math.ceil(1.0 / 0.01); r.bits(br(0, mx))    # compressed_float
+        r.align()
+        base = sint(r, 0, 1000); relative(r, base)
+    elif mtype == 1:    # STRING
+        n = sint(r, 0, FUZZ_MAX_STRING - 1); r.read_bytes(n)
+    elif mtype == 2:    # BYTES
+        n = sint(r, 0, FUZZ_MAX_BYTES); r.read_bytes(n)
+    elif mtype == 3:    # BLOCK
+        r.bits(16)
+    else:
+        raise ValueError(f"unknown message type {mtype}")
+
+
+def decode_packet(raw):
+    """STANDARD.md, 'Connection Packet'. Returns a description; raises on mismatch."""
+    r = R(raw)
+    desc = []
+    n_entries = sint(r, 0, NUM_CHANNELS)
+    for _ in range(n_entries):
+        ci = sint(r, 0, NUM_CHANNELS - 1) if NUM_CHANNELS > 1 else 0
+        is_block = r.bits(1)
+        if is_block:
+            msg_id = r.bits(16)
+            n_frag = sint(r, 1, MAX_FRAGMENTS_PER_BLOCK) if MAX_FRAGMENTS_PER_BLOCK > 1 else 1
+            frag_id = sint(r, 0, n_frag - 1) if n_frag > 1 else 0
+            frag_size = sint(r, 1, BLOCK_FRAGMENT_SIZE)
+            r.read_bytes(frag_size)
+            if frag_id == 0:
+                mtype = sint(r, 0, MAX_MESSAGE_TYPE) if MAX_MESSAGE_TYPE > 0 else 0
+                if mtype != 3: raise ValueError("fragment 0 message type is not a block message")
+                message_body(r, mtype)
+            desc.append(f"ch{ci} block id={msg_id} frag={frag_id}/{n_frag} size={frag_size}")
+            continue
+        if not r.bits(1):
+            desc.append(f"ch{ci} empty"); continue
+        n_msg = sint(r, 1, MAX_MESSAGES_PER_PACKET)
+        if CHANNEL_TYPE[ci] == "RELIABLE_ORDERED":
+            ids = [r.bits(16)]
+            for _ in range(n_msg - 1):
+                ids.append(sequence_relative(r, ids[-1]))
+            types = []
+            for _ in range(n_msg):
+                types.append(sint(r, 0, MAX_MESSAGE_TYPE) if MAX_MESSAGE_TYPE > 0 else 0)
+                message_body(r, types[-1])
+            desc.append(f"ch{ci} reliable n={n_msg} ids={ids[0]}..{ids[-1]} types={types}")
+        else:
+            types = []
+            for _ in range(n_msg):
+                t = sint(r, 0, MAX_MESSAGE_TYPE) if MAX_MESSAGE_TYPE > 0 else 0
+                types.append(t)
+                message_body(r, t)
+                if t == 3:                                   # block message attached
+                    sz = sint(r, 1, MAX_BLOCK_SIZE); r.read_bytes(sz)
+            desc.append(f"ch{ci} unreliable n={n_msg} types={types}")
+    return desc, r.i, len(raw) * 8
+
+
+def main():
+    files = sorted(glob.glob(os.path.join(CORPUS, "*")))
+    if not files:
+        print(f"no corpus at {CORPUS}", file=sys.stderr); return 2
+    n, fails = 0, []
+    for path in files:
+        d = open(path, "rb").read()
+        off = 1                                   # byte 0 selects the config
+        idx = 0
+        while off + 2 <= len(d):
+            ln = d[off] | (d[off + 1] << 8); off += 2
+            if ln == 0 or off + ln > len(d): break
+            raw = d[off:off + ln]; off += ln
+            n += 1
+            try:
+                desc, used, total = decode_packet(raw)
+                # the packet must decode to exhaustion: only flush padding may remain
+                if total - used >= 8:
+                    fails.append(f"{os.path.basename(path)} pkt{idx}: "
+                                 f"{total-used} bits left over after decoding ({'; '.join(desc)})")
+            except Exception as e:
+                fails.append(f"{os.path.basename(path)} pkt{idx}: {e}")
+            idx += 1
+    print(f"{n} corpus packets fully decoded against STANDARD.md, {len(fails)} failures")
+    for f in fails[:15]: print("  FAIL " + f)
+    if fails:
+        print("\nSTANDARD.md and the implementation disagree. One of them is wrong.")
+        return 1
+    print("\nSTANDARD.md matches the implementation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -38,9 +38,9 @@ def build_and_run(cxx, build_dir, src_name="drive_state_machine.cpp"):
     with tempfile.TemporaryDirectory() as tmp:
         exe = os.path.join(tmp, "drive")
         cmd = [cxx, "-std=c++11", "-I" + os.path.join(ROOT, "include"), "-I" + ROOT,
-               "-I" + os.path.join(ROOT, "..", "serialize"),
-               "-I" + os.path.join(ROOT, "..", "netcode"),
-               "-I" + os.path.join(ROOT, "..", "reliable"),
+               "-I" + os.path.join(ROOT, "serialize"),
+               "-I" + os.path.join(ROOT, "netcode"),
+               "-I" + os.path.join(ROOT, "reliable"),
                "-I" + os.path.join(ROOT, "tlsf"),
                "-o", exe, src, "-L" + build_dir] + libs
         r = subprocess.run(cmd, capture_output=True, text=True)

--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -32,8 +32,8 @@ LEGAL = {
 }
 
 
-def build_and_run(cxx, build_dir):
-    src = os.path.join(ROOT, "tools", "conformance", "drive_state_machine.cpp")
+def build_and_run(cxx, build_dir, src_name="drive_state_machine.cpp"):
+    src = os.path.join(ROOT, "tools", "conformance", src_name)
     libs = ["-lyojimbo", "-lnetcode", "-lreliable", "-lsodium-builtin", "-ltlsf"]
     with tempfile.TemporaryDirectory() as tmp:
         exe = os.path.join(tmp, "drive")
@@ -105,6 +105,36 @@ def main():
 
     # 5. a clean disconnect lands in DISCONNECTED, never ERROR
     eq("clean disconnect ends in DISCONNECTED, not ERROR", moves[-1][1], DISCONNECTED)
+
+    # ---- error path: CONNECTING -> ERROR, which the happy path never takes.
+    # STATE-MACHINE.md lists ERROR as a state and CONNECTING->ERROR as a legal
+    # transition, but the happy-path driver connects every time, so that edge was
+    # transcribed and untested. This provokes it deterministically: InsecureConnect
+    # to a port where nothing listens, so the underlying netcode times out and
+    # yojimbo projects the negative state to ERROR.
+    err_src = os.path.join(ROOT, "tools", "conformance", "drive_error_paths.cpp")
+    # No silent skip: the driver is committed beside the checker, so its absence
+    # is a fault, not a reason to check less.
+    checks += 1
+    if not os.path.exists(err_src):
+        fails.append("drive_error_paths.cpp is missing — the error-path phase cannot run")
+    else:
+        eout = build_and_run(a.cxx, a.build, "drive_error_paths.cpp")
+        emoves, eresult = [], None
+        for line in eout.splitlines():
+            f = line.split()
+            if f[0] == "STATE" and int(f[1]) != int(f[2]):
+                emoves.append((int(f[1]), int(f[2])))
+            elif f[0] == "RESULT":
+                eresult = f[1:]
+        eq("error path reached the error state", eresult and eresult[0], "ok")
+        for frm, to in emoves:
+            checks += 1
+            if (frm, to) not in LEGAL:
+                fails.append(f"error-path transition {NAME.get(frm,frm)} -> "
+                             f"{NAME.get(to,to)} is not permitted by STATE-MACHINE.md")
+        eq("error is entered from CONNECTING, not by another route",
+           [f for f, t in emoves if t == ERROR], [CONNECTING])
 
     print(f"{checks} checks against STATE-MACHINE.md, {len(fails)} failures")
     print("  observed: " + " -> ".join(

--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Check yojimbo/STATE-MACHINE.md against the implementation.
+
+Drives a real client and server through connect, steady state and disconnect,
+records every client state transition, and checks the observed behaviour
+against the documented machine. Nothing here consults yojimbo's source; the
+legal transitions below are transcribed from STATE-MACHINE.md.
+
+usage: python3 tools/conformance/verify_state_machine.py [--cxx CXX] [--build DIR]
+exit:  0 = they agree, 1 = they do not, 2 = could not build/run
+"""
+import argparse, os, subprocess, sys, tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ERROR, DISCONNECTED, CONNECTING, CONNECTED = -1, 0, 1, 2
+NAME = {ERROR: "ERROR", DISCONNECTED: "DISCONNECTED",
+        CONNECTING: "CONNECTING", CONNECTED: "CONNECTED"}
+
+# STATE-MACHINE.md, "Transitions". Every move the document permits.
+LEGAL = {
+    (DISCONNECTED, CONNECTING),    # Connect()
+    (DISCONNECTED, ERROR),         # Connect() that cannot even build a token
+    (CONNECTING,   CONNECTED),     # handshake completes
+    (CONNECTING,   ERROR),         # handshake fails
+    (CONNECTING,   DISCONNECTED),  # Disconnect() during handshake
+    (CONNECTED,    DISCONNECTED),  # clean close, either side
+    (CONNECTED,    ERROR),         # timeout / transport failure
+    (CONNECTED,    CONNECTING),    # Connect() again while connected
+    (ERROR,        CONNECTING),    # Connect() starts a fresh attempt
+    (ERROR,        DISCONNECTED),  # Disconnect() clears the error
+}
+
+
+def build_and_run(cxx, build_dir):
+    src = os.path.join(ROOT, "tools", "conformance", "drive_state_machine.cpp")
+    libs = ["-lyojimbo", "-lnetcode", "-lreliable", "-lsodium-builtin", "-ltlsf"]
+    with tempfile.TemporaryDirectory() as tmp:
+        exe = os.path.join(tmp, "drive")
+        cmd = [cxx, "-std=c++11", "-I" + os.path.join(ROOT, "include"), "-I" + ROOT,
+               "-I" + os.path.join(ROOT, "..", "serialize"),
+               "-I" + os.path.join(ROOT, "..", "netcode"),
+               "-I" + os.path.join(ROOT, "..", "reliable"),
+               "-I" + os.path.join(ROOT, "tlsf"),
+               "-o", exe, src, "-L" + build_dir] + libs
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            print("build failed — is the library built in "
+                  f"{build_dir}?\n{r.stderr[:1500]}", file=sys.stderr)
+            sys.exit(2)
+        r = subprocess.run([exe], capture_output=True, text=True, timeout=120)
+        if r.returncode != 0:
+            print("driver failed:\n" + (r.stdout + r.stderr)[:1500], file=sys.stderr)
+            sys.exit(2)
+        return r.stdout
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cxx", default=os.environ.get("CXX", "c++"))
+    ap.add_argument("--build", default="/tmp/ybuild",
+                    help="directory containing libyojimbo.a and friends")
+    a = ap.parse_args()
+
+    transitions, result = [], None
+    for line in build_and_run(a.cxx, a.build).splitlines():
+        f = line.split()
+        if f[0] == "STATE":
+            transitions.append((int(f[1]), int(f[2]), f[3]))
+        elif f[0] == "RESULT":
+            result = f[1:]
+
+    checks, fails = 0, []
+    def eq(name, got, exp):
+        nonlocal checks; checks += 1
+        if got != exp: fails.append(f"{name}: got {got!r}, STATE-MACHINE.md says {exp!r}")
+
+    eq("driver completed the full lifecycle", result and result[0], "ok")
+
+    # 1. every observed transition must be one the document permits
+    for frm, to, phase in transitions:
+        if frm == to: continue
+        checks += 1
+        if (frm, to) not in LEGAL:
+            fails.append(f"ILLEGAL transition {NAME.get(frm,frm)} -> {NAME.get(to,to)} "
+                         f"during '{phase}' is not in STATE-MACHINE.md")
+
+    moves = [(f, t) for f, t, _ in transitions if f != t]
+
+    # 2. the documented happy path, in order
+    eq("happy path is DISCONNECTED->CONNECTING->CONNECTED->DISCONNECTED", moves,
+       [(DISCONNECTED, CONNECTING), (CONNECTING, CONNECTED), (CONNECTED, DISCONNECTED)])
+
+    # 3. "no transition into CONNECTED that does not pass through CONNECTING"
+    for i, (frm, to) in enumerate(moves):
+        if to == CONNECTED:
+            checks += 1
+            if frm != CONNECTING:
+                fails.append(f"entered CONNECTED from {NAME.get(frm,frm)}, "
+                             "but the document says only CONNECTING leads there")
+
+    # 4. no spurious churn: the steady phase must produce no transitions at all
+    eq("no state change while connected and idle",
+       [p for f, t, p in transitions if f != t and p == "steady"], [])
+
+    # 5. a clean disconnect lands in DISCONNECTED, never ERROR
+    eq("clean disconnect ends in DISCONNECTED, not ERROR", moves[-1][1], DISCONNECTED)
+
+    print(f"{checks} checks against STATE-MACHINE.md, {len(fails)} failures")
+    print("  observed: " + " -> ".join(
+        [NAME.get(moves[0][0], "?")] + [NAME.get(t, "?") for _, t in moves]))
+    for f in fails: print("  FAIL " + f)
+    if fails:
+        print("\nSTATE-MACHINE.md and the implementation disagree. One of them is wrong.")
+        return 1
+    print("\nSTATE-MACHINE.md matches the implementation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**STANDARD.md** — the connection packet format, scoped explicitly to the middle layer: netcode carries transport and encryption, serialize does the bit packing, this specifies channels, messages, reliability and block transfer. Serialize's primitives are referenced rather than re-specified so the documents compose instead of drifting.

Records the asymmetry between the two channel types, which is the easiest thing to get backwards: reliable-ordered sends a full 16-bit first message id then relative ids, with **all ids before any types or bodies**; unreliable-unordered sends **no ids at all** and interleaves type and body.

**STATE-MACHINE.md** — behaviour over time rather than bytes: the four client states, every legal transition, and the projection from netcode's ten (any negative netcode state is ERROR).

**Two conformance checkers.** The format one decodes all 13 committed fuzz corpus packets *to exhaustion* — leftover bits fail the run. The state machine one drives a real client and server over UDP and asserts no illegal transition, the exact happy path, and that an idle connected client produces no transitions at all.

**Dead code removed** — `serialize_ack_relative`, unused since acknowledgements moved to netcode.

No release accompanies this.