### PR TITLE
Make YOJIMBO_ENABLE_LOGGING overridable, matching netcode and reliable

### DIFF
--- a/include/yojimbo_config.h
+++ b/include/yojimbo_config.h
@@ -80,7 +80,14 @@
 
 #endif // #ifdef YOJIMBO_DEBUG
 
+// Logging is ON by default, matching netcode and reliable: a networking library
+// that goes silent in a release build is worse than one that costs a few
+// nanoseconds per call. Guarded so it can still be compiled out from the build
+// system (-DYOJIMBO_ENABLE_LOGGING=0) without editing this header, which is
+// what netcode.c and reliable.c already allow.
+#ifndef YOJIMBO_ENABLE_LOGGING
 #define YOJIMBO_ENABLE_LOGGING                      1
+#endif // #ifndef YOJIMBO_ENABLE_LOGGING
 
 namespace yojimbo
 {


### PR DESCRIPTION
netcode and reliable both `#ifndef`-guard their logging flag, so a build can compile logging out with `-D`. yojimbo used a bare `#define`, so `-DYOJIMBO_ENABLE_LOGGING=0` produced `warning: 'YOJIMBO_ENABLE_LOGGING' macro redefined` and the header won regardless.

**Default unchanged at 1**, deliberately — a networking library that goes silent in a release build is worse than one that costs a few nanoseconds per call.

Found while profiling. Worth recording why this did *not* become a default change: at `LOG_LEVEL_NONE` a disabled log still costs a call and a 4KB stack probe, which is ~33% of reliable's profile — but 40% of a 220ns packet-pair is 89ns, or 0.03% of a core on a 64-player server. You would need ~113,000 packet-pairs/second to save 1% of one core.

At relay scale (~1M packets/second) the same 89ns is ~9% of a core, and there the arithmetic genuinely flips. That is the case this serves: whoever needs it can compile it out, and nobody else loses their logs.

Verified both directions, default and override, plus a clean build with logging compiled out. No release accompanies this.