### PR TITLE
conformance: report both state-machine phases, and name the stage that failed

### DIFF
--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -45,8 +45,16 @@ def build_and_run(cxx, build_dir, src_name="drive_state_machine.cpp"):
                "-o", exe, src, "-L" + build_dir] + libs
         r = subprocess.run(cmd, capture_output=True, text=True)
         if r.returncode != 0:
-            print("build failed — is the library built in "
-                  f"{build_dir}?\n{r.stderr[:1500]}", file=sys.stderr)
+            # Say which stage actually failed. Reporting every non-zero exit as
+            # "is the library built?" sent a bad include path to the wrong
+            # diagnosis once already; a missing header is not a missing library.
+            err = r.stderr
+            linking = any(s in err for s in
+                          ("ld:", "cannot find -l", "undefined reference",
+                           "Undefined symbols", "linker command failed"))
+            what = (f"could not link {src_name} — is the library built in {build_dir}?"
+                    if linking else f"could not compile {src_name}")
+            print(f"{what}\n{err[:1500]}", file=sys.stderr)
             sys.exit(2)
         r = subprocess.run([exe], capture_output=True, text=True, timeout=120)
         if r.returncode != 0:
@@ -115,12 +123,13 @@ def main():
     err_src = os.path.join(ROOT, "tools", "conformance", "drive_error_paths.cpp")
     # No silent skip: the driver is committed beside the checker, so its absence
     # is a fault, not a reason to check less.
+    emoves = []
     checks += 1
     if not os.path.exists(err_src):
         fails.append("drive_error_paths.cpp is missing — the error-path phase cannot run")
     else:
         eout = build_and_run(a.cxx, a.build, "drive_error_paths.cpp")
-        emoves, eresult = [], None
+        eresult = None
         for line in eout.splitlines():
             f = line.split()
             if f[0] == "STATE" and int(f[1]) != int(f[2]):
@@ -136,9 +145,15 @@ def main():
         eq("error is entered from CONNECTING, not by another route",
            [f for f, t in emoves if t == ERROR], [CONNECTING])
 
+    def path(ms):
+        return " -> ".join([NAME.get(ms[0][0], "?")] + [NAME.get(t, "?") for _, t in ms])
+
+    # Both phases get their own line. A green run that printed only the happy
+    # path read as though the error phase had never executed, which is exactly
+    # the silence the error-path driver was added to remove.
     print(f"{checks} checks against STATE-MACHINE.md, {len(fails)} failures")
-    print("  observed: " + " -> ".join(
-        [NAME.get(moves[0][0], "?")] + [NAME.get(t, "?") for _, t in moves]))
+    print("  happy path: " + path(moves))
+    print("  error path: " + (path(emoves) if emoves else "no transitions observed"))
     for f in fails: print("  FAIL " + f)
     if fails:
         print("\nSTATE-MACHINE.md and the implementation disagree. One of them is wrong.")


### PR DESCRIPTION
The two things you said were worth having from #309, both in `verify_state_machine.py`.

**1. Both phases are visible now.** The summary printed only the happy path, so a green run read as though the error-path phase had never run — the exact silence `drive_error_paths.cpp` was added to remove. It prints two lines instead:

```
13 checks against STATE-MACHINE.md, 0 failures
  happy path: DISCONNECTED -> CONNECTING -> CONNECTED -> DISCONNECTED
  error path: DISCONNECTED -> CONNECTING -> ERROR
```

If the error-path driver ever produces no transitions the line still prints, saying so — a missing line is easy to not notice, a line reading `no transitions observed` is not.

**2. The failure message names the stage.** `build_and_run` reported every non-zero exit as "is the library built in `<dir>`?", which is what sent yesterday's bad include path to the wrong diagnosis: a missing header is not a missing library. It now separates link from compile and keeps the build-dir hint on the link side only.

Verified by running all three cases locally, not by reading the diff:

- green, output above; `verify_standard.py` also green (13 corpus packets, 0 failures)
- link failure (`--build` at an empty directory) → `could not link drive_state_machine.cpp — is the library built in /tmp/emptylibs?` followed by `ld: library 'yojimbo' not found`
- **yesterday's actual bug**, reintroduced deliberately (`-I ROOT/../serialize`) → `could not compile drive_state_machine.cpp` followed by `fatal error: 'serialize.h' file not found`. That is the case that misdirected me, reporting itself correctly.

Checker output only — no library change, no document change, no release.
