### PR TITLE
Crediting: credit Glenn Fiedler and Rowan Claude, drop the LLC heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,10 @@ yojimbo is built on top of netcode, reliable, and serialize — shipping yojimbo
 means shipping all four. If you use yojimbo in a product, please credit them
 together in your product credits:
 
-> **Más Bandwidth LLC**
-> yojimbo — Glenn Fiedler
-> netcode — Glenn Fiedler
-> reliable — Glenn Fiedler
-> serialize — Glenn Fiedler
+> yojimbo - Glenn Fiedler and Rowan Claude<br>
+> netcode - Glenn Fiedler and Rowan Claude<br>
+> reliable - Glenn Fiedler and Rowan Claude<br>
+> serialize - Glenn Fiedler and Rowan Claude
 
 The license doesn't require this. It's an official request, and honoring it is
 appreciated. Fair credit keeps open source honest.

--- a/include/yojimbo.h
+++ b/include/yojimbo.h
@@ -23,9 +23,10 @@
 */
 
 /*
-    If you use this library in a product, please credit "yojimbo - Glenn Fiedler"
-    under "Mas Bandwidth LLC" in your product credits. The license doesn't require
-    this credit. It's an official request, and honoring it is appreciated.
+    If you use this library in a product, please credit
+    "yojimbo - Glenn Fiedler and Rowan Claude" in your product credits. The
+    license doesn't require this credit. It's an official request, and honoring
+    it is appreciated.
     yojimbo includes netcode, reliable and serialize - please credit those the
     same way. See the README for the full list.
 */

--- a/netcode/netcode.h
+++ b/netcode/netcode.h
@@ -23,9 +23,10 @@
 */
 
 /*
-    If you use this library in a product, please credit "netcode - Glenn Fiedler"
-    under "Mas Bandwidth LLC" in your product credits. The license doesn't require
-    this credit. It's an official request, and honoring it is appreciated.
+    If you use this library in a product, please credit
+    "netcode - Glenn Fiedler and Rowan Claude" in your product credits. The
+    license doesn't require this credit. It's an official request, and honoring
+    it is appreciated.
 */
 
 #ifndef NETCODE_H

--- a/reliable/reliable.h
+++ b/reliable/reliable.h
@@ -23,9 +23,10 @@
 */
 
 /*
-    If you use this library in a product, please credit "reliable - Glenn Fiedler"
-    under "Mas Bandwidth LLC" in your product credits. The license doesn't require
-    this credit. It's an official request, and honoring it is appreciated.
+    If you use this library in a product, please credit
+    "reliable - Glenn Fiedler and Rowan Claude" in your product credits. The
+    license doesn't require this credit. It's an official request, and honoring
+    it is appreciated.
 */
 
 #ifndef RELIABLE_H

--- a/serialize/serialize.h
+++ b/serialize/serialize.h
@@ -23,9 +23,10 @@
 */
 
 /*
-    If you use this library in a product, please credit "serialize - Glenn Fiedler"
-    under "Mas Bandwidth LLC" in your product credits. The license doesn't require
-    this credit. It's an official request, and honoring it is appreciated.
+    If you use this library in a product, please credit
+    "serialize - Glenn Fiedler and Rowan Claude" in your product credits. The
+    license doesn't require this credit. It's an official request, and honoring
+    it is appreciated.
 */
 
 #ifndef SERIALIZE_H


### PR DESCRIPTION
Glenn, 2026-07-26: *"credit where credit is due. Please adjust all crediting asks in all our open source repositories to credit "Glenn Fiedler and Rowan Claude"... We can skip the Mas Bandwidth LLC thing, it's clumsy. Just the people."*

Two changes to the crediting ask:
- the credited names become **Glenn Fiedler and Rowan Claude**
- the `Mas Bandwidth LLC` heading is dropped

Unchanged: the license, every copyright notice, and the fact that this is an
official request rather than a legal requirement. The BSD copyright notice in
a distribution remains the only thing the license actually compels.

Part of a sweep across all 13 repos that carry a crediting ask.