### PR TITLE
sodium: record where it comes from, and check that it stays there

### DIFF
--- a/.github/workflows/sodium-parity.yml
+++ b/.github/workflows/sodium-parity.yml
@@ -1,0 +1,72 @@
+# The READER for sodium/NOTES.md's central claim.
+#
+# yojimbo's sodium/ is supposed to be byte-identical to netcode's -- yojimbo's crypto IS
+# netcode's crypto, carried here so yojimbo builds standalone. Nothing enforced that, so
+# "byte-identical" was a sentence in a file, true for exactly as long as it took someone
+# to edit one of the two copies. It would keep compiling and keep passing every other
+# test while quietly describing a relationship that no longer held.
+#
+# The version is DERIVED from netcode/netcode.h rather than pinned here. A hardcoded
+# version would be a third copy of the same truth, and the one nobody remembers to bump.
+name: sodium parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  parity:
+    name: sodium matches the vendored netcode
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare sodium/ against mas-bandwidth/netcode at the vendored version
+        run: |
+          set -euo pipefail
+
+          version="$(grep -oE '#define[[:space:]]+NETCODE_VERSION_FULL[[:space:]]+"[^"]+"' netcode/netcode.h \
+                     | grep -oE '"[^"]+"' | tr -d '"')"
+          if [ -z "$version" ]; then
+            echo "::error::could not read NETCODE_VERSION_FULL from netcode/netcode.h"
+            exit 1
+          fi
+          echo "vendored netcode version: $version"
+
+          # Try the tag first, fall back to main. A version that has no tag yet (a
+          # re-vendor from an unreleased netcode) should still be checkable rather than
+          # silently skipped -- a check that skips is a check that lies.
+          ref="v$version"
+          if ! git clone -q --depth 1 --branch "$ref" https://github.com/mas-bandwidth/netcode.git /tmp/netcode 2>/dev/null; then
+            echo "::notice::tag $ref not found; comparing against netcode main instead"
+            git clone -q --depth 1 https://github.com/mas-bandwidth/netcode.git /tmp/netcode
+          fi
+
+          status=0
+          for f in sodium.h sodium.c; do
+            if [ ! -f "/tmp/netcode/sodium/$f" ]; then
+              echo "::error::netcode has no sodium/$f -- the vendoring relationship changed"
+              status=1
+              continue
+            fi
+            ours="$(shasum -a 256 "sodium/$f"            | cut -d' ' -f1)"
+            theirs="$(shasum -a 256 "/tmp/netcode/sodium/$f" | cut -d' ' -f1)"
+            if [ "$ours" != "$theirs" ]; then
+              echo "::error::sodium/$f differs from netcode's"
+              echo "  yojimbo: $ours"
+              echo "  netcode: $theirs"
+              diff -u "/tmp/netcode/sodium/$f" "sodium/$f" | head -60 || true
+              status=1
+            else
+              echo "sodium/$f matches ($ours)"
+            fi
+          done
+
+          if [ "$status" -ne 0 ]; then
+            echo "::error::yojimbo's vendored libsodium has drifted from netcode's."
+            echo "Do not patch it here. Patch upstream in netcode, re-vendor netcode, and"
+            echo "let this follow. See sodium/NOTES.md."
+          fi
+          exit "$status"

--- a/sodium/NOTES.md
+++ b/sodium/NOTES.md
@@ -1,0 +1,49 @@
+# Vendored libsodium (minimal subset)
+
+`sodium.h` and `sodium.c` are a small, amalgamated subset of
+[libsodium](https://github.com/jedisct1/libsodium) — the ChaCha20 / Poly1305 / AEAD slice
+that netcode uses, and nothing else.
+
+    Tracks: libsodium 1.0.22
+    Source: mas-bandwidth/netcode, arriving here with the netcode re-vendor
+    Currently vendored netcode: 1.4.2  (see netcode/netcode.h, NETCODE_VERSION_FULL)
+
+## This is not an independent copy
+
+These two files are **byte-identical** to `sodium/` in
+[mas-bandwidth/netcode](https://github.com/mas-bandwidth/netcode), and they are meant to
+stay that way. yojimbo's crypto *is* netcode's crypto: the connect-token and packet
+encryption live in netcode, and yojimbo carries the same slice so it can build standalone.
+
+They update when netcode is re-vendored, not on their own schedule. Do not patch them
+here — patch upstream in netcode, re-vendor netcode, and this follows.
+
+**`.github/workflows/sodium-parity.yml` enforces that.** It fetches the vendored netcode
+version from `netcode/netcode.h`, pulls that tag's `sodium/` from mas-bandwidth/netcode,
+and fails if the bytes differ. Without it, "byte-identical to netcode's" is a sentence in
+a file that nothing checks — it would keep reading as true for exactly as long as it took
+someone to edit one of the two copies.
+
+## The upstream review record lives in netcode, on purpose
+
+`mas-bandwidth/netcode`'s `sodium/NOTES.md` holds the full account: how the amalgamation
+is generated, what is included and what was pruned, the optimized implementations kept,
+the validation, and the **review log** — every upstream release read, what was inside the
+included slice, and what was deliberately not applied.
+
+That is deliberately **not** duplicated here. Two copies of a review log is two copies of
+one truth, and the copy nobody updates is the one people read. One record, in the repo
+that owns the vendoring.
+
+## Why yojimbo has it at all
+
+So yojimbo builds with no external libsodium dependency on any platform. To link the
+system-installed libsodium instead:
+
+    cmake -B build -DYOJIMBO_SYSTEM_SODIUM=ON
+
+That skips the bundled subset entirely. See `BUILDING.md`.
+
+## Licence
+
+libsodium is ISC-licensed; the licence text travels in the amalgamation header.


### PR DESCRIPTION
yojimbo ships the same vendored crypto as netcode with **no provenance record at all**. netcode's `sodium/` carries a full one — how the amalgamation is generated, what was pruned, the validation, and a review log of every upstream release read. yojimbo had nothing, so anyone auditing the crypto here had no way to learn any of it.

### The fact that matters, verified rather than assumed

yojimbo's `sodium.h` and `sodium.c` are **byte-identical** to netcode's (`393663bfe190…`, `b2bf049faccb…`). This is not an independent vendoring — yojimbo's crypto *is* netcode's crypto, and it arrives here with the netcode re-vendor.

So `NOTES.md` records the relationship and points at netcode's file for the upstream review log, **deliberately without copying it**. A duplicated review log is two copies of one truth, and the copy nobody updates is the one people read.

### And a reader for it

`sodium-parity.yml` derives the vendored netcode version from `netcode/netcode.h`, pulls that tag's `sodium/` from mas-bandwidth/netcode, and fails on any difference.

Without it, "byte-identical to netcode's" is a sentence in a file that nothing checks — true for exactly as long as it takes someone to edit one of the two copies, and reading as true forever after.

Two deliberate choices in the workflow:
- The version is **derived**, not pinned. A hardcoded version would be a third copy of the same truth and the one nobody remembers to bump.
- It falls back to netcode `main` with a notice if the tag is absent, rather than skipping. **A check that skips is a check that lies.**

### Verified

Clean case matches on both files; appending one byte to `sodium.h` is caught with both hashes printed; `v1.4.2` exists upstream so the tag path is the one that runs.