### PR TITLE
CLAUDE.md: add the HOT block — decisions that read as bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,35 @@
+<!-- HOT:BEGIN -->
+## HOT — read before reasoning about this repo
+
+WHAT: the C++ client/server networking library built on netcode + reliable + serialize,
+all three VENDORED in-tree (netcode/, reliable/, serialize/) plus a pruned libsodium subset
+in sodium/.
+
+**THE INTERFACE DOES NOT CHANGE.** The library is over ten years old and deliberately
+stable. Do not propose interface changes.
+
+**VENDORED CODE IS NOT EDITED HERE.** sodium/ is byte-identical to netcode's copy and
+`.github/workflows/sodium-parity.yml` fails if it drifts; see sodium/NOTES.md. Patch
+upstream, re-vendor, let it flow down.
+
+DECISIONS THAT READ AS BUGS (they are not — do not "fix" them)
+- **Debug asserts are deliberately kept OFF the untrusted network read path**, so a hostile
+  peer cannot crash a debug server. This is the single most important invariant to preserve
+  when adding validation: the full-trust rule for programmer inputs must never be confused
+  with the zero-trust rule for wire data.
+- **Config invariants assert in constructors** (power-of-two buffer sizes, channel counts)
+  so every debug run validates config at startup; usage contracts assert where exercised;
+  API misuse ALSO degrades gracefully in release. That layering is intentional.
+- **Malformed wire input degrades to a channel error and a disconnect — never an assert.**
+  Validation happens before the memcpy (see the over-long-final-fragment check in
+  `ReliableOrderedChannel::ProcessPacketFragment`).
+- **Allocation failure is handled on essentially every path** deliberately, because this is
+  a game server.
+
+SECURITY: yojimbo 1.6.3 and earlier vendor a netcode missing the AEAD nonce-reuse fix
+(netcode 1.4.0); 1.7.0 was the first with it. See netcode's SECURITY.md.
+<!-- HOT:END -->
+
 # CLAUDE.md — Audit of yojimbo
 
 *An honest code audit written by Claude (July 2026), covering the yojimbo library proper


### PR DESCRIPTION
Coverage was 6/12 across the lane and **the four flagship C libraries were the gap** — the worst possible place for it, since these are the repos most likely to be reasoned about by someone who did not write them.

### Distilled, not invented

Every item in the block was already documented somewhere in this file. The hot block is the part a stranger must read **first**, pulled to the top with `file:line` where the code says so itself. Nothing here is a new claim.

It answers one question: **what in this repo looks like a defect and is not?**

That is the exact failure this mechanism exists to stop. I recently reported `netcode.rs`'s `netcode-official` crate name to Glenn as a defect — when it was a deliberate workaround already written down in that repo's hot block, which I had not read.

### Things that would otherwise get "fixed"

- flat linear scans chosen **over** a hash map, because an attacker controls the keys (source addresses) and could drive a hash into its worst case
- release builds that deliberately carry no config validation — the caller is trusted by design
- serialize macros that hide `return false` on purpose, because invalid data must abort before any attacker-bounded loop
- debug asserts deliberately kept **off** the untrusted read path, so a hostile peer cannot crash a debug server

Glenn, emphatic: the per-repo hot block and the per-bud queue are *"the most important things while you work."*