### PR TITLE
Address: mask IPv6 prefixes instead of comparing the first group (#320)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,20 +29,31 @@ DECISIONS THAT READ AS BUGS (they are not — do not "fix" them)
 SECURITY: yojimbo 1.6.3 and earlier vendor a netcode missing the AEAD nonce-reuse fix
 (netcode 1.4.0); 1.7.0 was the first with it. See netcode's SECURITY.md.
 
-KNOWN OPEN DEFECT -- do not rediscover, and do not assert the fix in tests
-- #320 `Address::IsMulticast` / `IsLinkLocal` / `IsSiteLocal` compare the first 16-bit
-  group for EXACT equality instead of masking the prefix. Multicast is ff00::/8 and
-  link-local is fe80::/10, so only the single address equal to the prefix matches.
-  `IsGlobalUnicast` is the negation of the other three, so a miss does not return false --
-  it returns TRUE. Measured: `ff02::1` (all-nodes multicast) reports mcast=0,
-  global_unicast=1; `febf::1` (valid fe80::/10) reports linklocal=0, global_unicast=1.
-  Fix is `( ipv6[0] & 0xff00 ) == 0xff00` and `( ipv6[0] & 0xffc0 ) == 0xfe80`.
-  Nothing inside yojimbo uses these predicates and nothing tests them -- which is why
-  they drifted. The exposure is a USER filtering on IsGlobalUnicast and accepting
-  multicast.
-  Found by writing tests, not by reading. mas-bandwidth/apt's autopkgtest asserts only
-  the cases that are correct TODAY, deliberately, so the Debian package does not look
-  broken while this is unfixed.
+THE WRITE/READ RULE — read this BEFORE reporting any assert as a missing bounds check
+Glenn, 2026-07-26: "intention is on write, user is responsible to not crash or do undefined
+behavior. asserts are there to help. callers responsibility. on read, obviously, we must
+check." Plus Postel: "be conservative in what you send, permissive in what you receive."
+  WRITE / caller-supplied -> the CALLER validates. Assert-only is the DESIGN; -DNDEBUG
+    removing it is correct. Do NOT add runtime checks here.
+  READ / off the wire     -> the library checks at runtime, for safety.
+yojimbo states this in its own code: yojimbo_config.cpp:34-36 explains that YOJIMBO_CONFIG_CHECK
+logs-then-asserts and the whole Validate() family is compiled to nothing in release
+(yojimbo_config.cpp:163-175). That is deliberate, not an oversight.
+DELIBERATELY ASSERT-ONLY, do NOT "fix" -- a future audit that finds these has found the
+contract: oversized block-message send (reliable_ordered_channel.cpp:562/611 -- SendMessage
+exempts block messages at :168 on purpose); BaseServer::Start's maxClients
+(base_server.cpp:48-50); Client::GenerateInsecureConnectToken (client.cpp:72); the whole
+clientIndex/channelIndex public surface.
+The WIRE path is properly checked and was verified clean by two independent audits: wire
+channelIndex (channel.cpp:446), numChannelEntries (connection.cpp:58), numFragments/fragmentId
+(reliable_ordered_channel.cpp:712-724) and the receive memcpy bounds test at :733-738.
+yojimbo also satisfies serialize's bytes%8 write contract deliberately at connection.cpp:248
+(maxPacketBytes &= ~7) -- do not "simplify" that line.
+FIXED 2026-07-26 (#320): Address::IsMulticast/IsLinkLocal/IsSiteLocal compared the first
+16-bit group for EXACT equality instead of masking the prefix, and IsGlobalUnicast is their
+negation, so ff02::1 (all nodes) reported as GLOBAL UNICAST. Now masked: /8 for multicast,
+/10 for link and site local. There had been ZERO test coverage of these predicates, which is
+how they drifted -- test_address_classification now covers the range boundaries.
 <!-- HOT:END -->
 
 # CLAUDE.md — Audit of yojimbo

--- a/source/yojimbo_address.cpp
+++ b/source/yojimbo_address.cpp
@@ -302,17 +302,22 @@ namespace yojimbo
 
     bool Address::IsLinkLocal() const
     {
-        return m_type == ADDRESS_IPV6 && m_address.ipv6[0] == 0xfe80;
+        // fe80::/10 -- the prefix is 10 bits, so mask rather than compare the whole group.
+        // Comparing == 0xfe80 matched only fe80::/16 and missed the rest of the range.
+        return m_type == ADDRESS_IPV6 && ( m_address.ipv6[0] & 0xffc0 ) == 0xfe80;
     }
 
     bool Address::IsSiteLocal() const
     {
-        return m_type == ADDRESS_IPV6 && m_address.ipv6[0] == 0xfec0;
+        // fec0::/10
+        return m_type == ADDRESS_IPV6 && ( m_address.ipv6[0] & 0xffc0 ) == 0xfec0;
     }
 
     bool Address::IsMulticast() const
     {
-        return m_type == ADDRESS_IPV6 && m_address.ipv6[0] == 0xff00;
+        // ff00::/8. Comparing == 0xff00 matched only the single group ff00 and missed every
+        // real multicast address, including ff02::1 (all nodes).
+        return m_type == ADDRESS_IPV6 && ( m_address.ipv6[0] & 0xff00 ) == 0xff00;
     }
 
     bool Address::IsLoopback() const
@@ -334,9 +339,11 @@ namespace yojimbo
 
     bool Address::IsGlobalUnicast() const
     {
-        return m_type == ADDRESS_IPV6 && m_address.ipv6[0] != 0xfe80
-                                      && m_address.ipv6[0] != 0xfec0
-                                      && m_address.ipv6[0] != 0xff00
+        // Defined as the negation of the others, so a missed classification above did not
+        // merely return false here -- it returned TRUE, reporting multicast as global unicast.
+        return m_type == ADDRESS_IPV6 && !IsLinkLocal()
+                                      && !IsSiteLocal()
+                                      && !IsMulticast()
                                       && !IsLoopback();
     }
 

--- a/test.cpp
+++ b/test.cpp
@@ -161,6 +161,62 @@ bool parse_address( const char string[] )
     return address.IsValid();
 }
 
+void test_address_classification()
+{
+    // These predicates had NO coverage at all, which is how they drifted: IsMulticast,
+    // IsLinkLocal and IsSiteLocal compared the first 16-bit group for exact equality
+    // instead of masking the prefix. Because IsGlobalUnicast is the negation of the other
+    // three, a missed classification did not return false -- it returned TRUE, so ff02::1
+    // (all nodes) reported as global unicast.
+
+    // multicast is ff00::/8 -- the whole range, not just the group ff00
+
+    check( Address( "ff00::1" ).IsMulticast() );
+    check( Address( "ff02::1" ).IsMulticast() );            // all nodes: the common one
+    check( Address( "ff05::1:3" ).IsMulticast() );
+    check( Address( "ffff::1" ).IsMulticast() );
+    check( !Address( "ff02::1" ).IsGlobalUnicast() );
+    check( !Address( "ff05::1:3" ).IsGlobalUnicast() );
+
+    // link local is fe80::/10, so fe80 through febf
+
+    check( Address( "fe80::1" ).IsLinkLocal() );
+    check( Address( "febf::1" ).IsLinkLocal() );
+    check( !Address( "febf::1" ).IsGlobalUnicast() );
+    check( !Address( "fec0::1" ).IsLinkLocal() );           // fec0 is site local, not link local
+
+    // site local is fec0::/10, so fec0 through feff
+
+    check( Address( "fec0::1" ).IsSiteLocal() );
+    check( Address( "feff::1" ).IsSiteLocal() );
+    check( !Address( "fe80::1" ).IsSiteLocal() );
+
+    // and the boundaries below the ranges must NOT be classified
+
+    check( !Address( "fe7f::1" ).IsLinkLocal() );
+    check( !Address( "fe7f::1" ).IsSiteLocal() );
+    check( Address( "fe7f::1" ).IsGlobalUnicast() );
+    check( !Address( "feff::1" ).IsGlobalUnicast() );
+
+    // genuine global unicast still classifies, so the fix cannot pass by returning false
+
+    check( Address( "2001:4860:4860::8888" ).IsGlobalUnicast() );
+    check( !Address( "2001:4860:4860::8888" ).IsMulticast() );
+    check( !Address( "2001:4860:4860::8888" ).IsLoopback() );
+
+    // loopback is unchanged, and is excluded from global unicast
+
+    check( Address( "::1" ).IsLoopback() );
+    check( !Address( "::1" ).IsGlobalUnicast() );
+    check( Address( "127.0.0.1" ).IsLoopback() );
+
+    // IPv4 is never any of the IPv6 classifications
+
+    check( !Address( "127.0.0.1" ).IsMulticast() );
+    check( !Address( "10.0.0.1" ).IsGlobalUnicast() );
+    check( !Address( "224.0.0.1" ).IsMulticast() );
+}
+
 void test_address()
 {
     check( parse_address( "" ) == false );
@@ -3688,6 +3744,7 @@ int main( int argc, char ** argv )
 #endif // #ifndef YOJIMBO_SYSTEM_DEPS
         RUN_TEST( test_queue );
         RUN_TEST( test_address );
+        RUN_TEST( test_address_classification );
         RUN_TEST( test_network_simulator_drains_all_slots );
         RUN_TEST( test_bit_array );
         RUN_TEST( test_sequence_buffer );


### PR DESCRIPTION
Fixes #320.

`IsMulticast`, `IsLinkLocal` and `IsSiteLocal` compared `m_address.ipv6[0]` for **exact equality** against `0xff00` / `0xfe80` / `0xfec0`. Those are prefixes — `ff00::/8`, `fe80::/10`, `fec0::/10` — so only the single address whose first group equalled the prefix ever matched.

`IsGlobalUnicast` is the negation of the other three, so a missed classification didn't return false — it returned **true**.

### Measured before the fix

| address | | `IsMulticast` | `IsGlobalUnicast` |
|---|---|---|---|
| `ff02::1` | all-nodes multicast | `false` | **`true`** |
| `ff05::1:3` | site-local multicast | `false` | **`true`** |
| `febf::1` | valid `fe80::/10` link-local | `IsLinkLocal`=`false` | **`true`** |

### The fix

Mask the prefix (`0xff00` for `/8`, `0xffc0` for `/10`), and rewrite `IsGlobalUnicast` to **call** the other three predicates rather than repeating their constants. Repeating the constants is what let the two fall out of sync in the first place; now a future change to a range can't leave it behind.

### There was no test coverage at all

These are declared in the public header and used nowhere inside yojimbo, so nothing ever exercised them — that is how they drifted. `test_address_classification` now covers:

- each range, including `ff02::1` and `ff05::1:3`
- the boundaries either side: `fe7f` / `fe80` / `febf` / `fec0` / `feff`
- that genuine global unicast still classifies, so the fix can't pass by returning false everywhere
- that IPv4 is never given an IPv6 classification

Verified to **fail** without the fix (suite exits 133) and pass with it.

### Note for the release notes

This changes classification results for addresses previously reported as global unicast. It is a bug fix, but it is a behaviour change.

### Not touched

Nothing on the write/caller-supplied side — the oversized block-message send, `BaseServer::Start`'s `maxClients`, `GenerateInsecureConnectToken`, and the `clientIndex`/`channelIndex` surface are all assert-only **by design**: the caller validates, and `yojimbo_config.cpp:34-36` says so explicitly. Two independent audits confirmed the wire-facing paths are properly checked. `CLAUDE.md` now records that rule so the next audit doesn't re-report the contract as a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)