### PR TITLE
Vendor serialize @ 673306d (fixed-point + 128-bit + pre-C++11 fix) — trial complete, release stays held

### DIFF
--- a/serialize/serialize.h
+++ b/serialize/serialize.h
@@ -50,6 +50,19 @@
 #define serialize_assert assert
 #endif // #ifndef serialize_assert
 
+// static_assert is C++11, and consumers vendor this header into pre-C++11 builds, so compile
+// time invariants go through this macro: real static_assert (message included) from C++11 up
+// and on MSVC (which ships static_assert in every language mode it supports), and a negative
+// size array emulation before that — the message string is dropped, and the compile error
+// points at the macro use site. the attribute silences unused-local-typedef warnings.
+#if ( defined( __cplusplus ) && __cplusplus >= 201103L ) || defined( _MSC_VER )
+#define serialize_static_assert( condition, message ) static_assert( condition, message )
+#else // #if ( defined( __cplusplus ) && __cplusplus >= 201103L ) || defined( _MSC_VER )
+#define serialize_static_assert_join2( a, b ) a##b
+#define serialize_static_assert_join( a, b ) serialize_static_assert_join2( a, b )
+#define serialize_static_assert( condition, message ) typedef char serialize_static_assert_join( serialize_static_assert_line_, __LINE__ )[ ( condition ) ? 1 : -1 ] __attribute__(( unused ))
+#endif // #if ( defined( __cplusplus ) && __cplusplus >= 201103L ) || defined( _MSC_VER )
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
@@ -159,6 +172,14 @@
 // their own function wrappers in their own tree. Everything else — constructors, the full
 // operator surface, the explicit conversions — is C++ only, inside #ifdef __cplusplus.
 //
+// The C++ in this block must stay usable by pre-C++11 consumers: a vendored header does not get
+// to choose the consumer's -std, and real consumers compile it at C++98/03 (clang accepts the
+// declaration-only C++11 extensions here — `= default`, the explicit conversion operators to the
+// 64 bit lanes — with a warning in those modes, but overload resolution before C++11 never
+// SELECTS an explicit conversion operator, so every conversion the library performs routes
+// through C++98 constructs: converting constructors). CI compiles and runs the tests at
+// -std=c++03 to hold this.
+//
 // Semantics match native __int128 exactly, with documented choices where native has none:
 // shift counts outside [0,127] yield zero (all sign bits for the signed arithmetic right
 // shift; native shifts by 128 or more are undefined behavior), and signed INT128_MIN over -1
@@ -181,6 +202,10 @@
 
 #if !defined( SERIALIZE_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
 
+#ifdef __cplusplus
+struct serialize_int128_t;      // forward declaration for the bit preserving converting constructor below
+#endif
+
 typedef struct serialize_uint128_t
 {
     uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
@@ -202,6 +227,14 @@ typedef struct serialize_uint128_t
     serialize_uint128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
     serialize_uint128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
     serialize_uint128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
+
+    // bit preserving conversion from the signed type, defined inline after serialize_int128_t below.
+    // this is a converting CONSTRUCTOR, not a conversion operator on serialize_int128_t, on purpose:
+    // explicit conversion operators are C++11, and consumers vendor this header into pre-C++11
+    // builds where a functional-style cast through one does not compile (overload resolution never
+    // considers explicit conversion functions before C++11). an explicit converting constructor is
+    // C++98 and behaves identically at every cast site.
+    explicit serialize_uint128_t( serialize_int128_t value );
 
     explicit operator uint64_t () const
     {
@@ -496,13 +529,10 @@ typedef struct serialize_int128_t
 
     explicit serialize_int128_t( serialize_uint128_t value ) : lo( value.lo ), hi( value.hi ) {}        // bit preserving
 
-    explicit operator serialize_uint128_t () const                                                // bit preserving
-    {
-        serialize_uint128_t result( 0 );
-        result.lo = lo;
-        result.hi = hi;
-        return result;
-    }
+    // the bit preserving conversion in the other direction is the explicit
+    // serialize_uint128_t( serialize_int128_t ) constructor, declared on the unsigned type and
+    // defined after this struct — a constructor rather than a C++11 explicit conversion operator
+    // so serialize_uint128_t( signed_value ) compiles in pre-C++11 consumers too
 
     explicit operator int64_t () const
     {
@@ -668,6 +698,14 @@ typedef struct serialize_int128_t
 #endif // #ifdef __cplusplus
 
 } serialize_int128_t;
+
+#ifdef __cplusplus
+
+// the bit preserving signed to unsigned conversion declared inside serialize_uint128_t above,
+// defined here where serialize_int128_t is complete
+inline serialize_uint128_t::serialize_uint128_t( serialize_int128_t value ) : lo( value.lo ), hi( value.hi ) {}
+
+#endif // #ifdef __cplusplus
 
 #define SERIALIZE_UINT128_DEFINED 1
 
@@ -2478,7 +2516,7 @@ namespace serialize
     {
         // refuse narrower types at compile time: a uint64_t here would shift by 64 — undefined
         // behavior — and silently is not the 128 bit operation the caller asked for
-        static_assert( sizeof( UInt128 ) == 16, "serialize_uint128 requires a 128 bit type (did you mean serialize_uint64?)" );
+        serialize_static_assert( sizeof( UInt128 ) == 16, "serialize_uint128 requires a 128 bit type (did you mean serialize_uint64?)" );
 
         uint64_t low_half = 0;
         uint64_t high_half = 0;
@@ -2833,8 +2871,8 @@ namespace serialize
     // the emulated pair works as storage too. without native __int128 these ARE the serialize
     // typedefs; with it they are a distinct set of types (present when tests are enabled, or
     // when a sibling header defined the block first), so the specializations never collide
-    template <> struct FixedPointInteger<::serialize_int128_t>            { enum { is_integer = 1, is_signed = 1 }; };
-    template <> struct FixedPointInteger<::serialize_uint128_t>           { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger< ::serialize_int128_t >            { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger< ::serialize_uint128_t >           { enum { is_integer = 1, is_signed = 0 }; };
 #endif // #if defined(SERIALIZE_UINT128_DEFINED)
 
     /**
@@ -2852,8 +2890,8 @@ namespace serialize
     template <> struct FixedPointUnsigned<uint128_t>                { typedef uint128_t type; };
 #endif // #if defined(__SIZEOF_INT128__)
 #if defined(SERIALIZE_UINT128_DEFINED)
-    template <> struct FixedPointUnsigned<::serialize_int128_t>           { typedef ::serialize_uint128_t type; };
-    template <> struct FixedPointUnsigned<::serialize_uint128_t>          { typedef ::serialize_uint128_t type; };
+    template <> struct FixedPointUnsigned< ::serialize_int128_t >           { typedef ::serialize_uint128_t type; };
+    template <> struct FixedPointUnsigned< ::serialize_uint128_t >          { typedef ::serialize_uint128_t type; };
 #endif // #if defined(SERIALIZE_UINT128_DEFINED)
 
     /**
@@ -2878,8 +2916,8 @@ namespace serialize
                 int64_t( ( uint64_t(1) << ( IntegerBits - 1 ) ) - 1 ) :
                 ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
 
-            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
-            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+            serialize_static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            serialize_static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
 
             // shift the whole unit bounds into raw fixed point units in the unsigned domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
             // everything below is a compile time constant: the bounds, the range and the bit count all fold, so the call site carries no runtime bit width computation at all.
@@ -2959,8 +2997,8 @@ namespace serialize
                 ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( ( IntegerBits < 64 ? IntegerBits : 1 ) - 1 ) ) - 1 ) ) :
                 ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
 
-            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
-            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+            serialize_static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            serialize_static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
 
             // shift the whole unit bounds into raw fixed point units in the unsigned 128 bit domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
             // the storage constructor sign extends the int64 bounds for signed storage. everything below folds: the bounds, the range, the bit count and the group structure.
@@ -3070,11 +3108,11 @@ namespace serialize
     template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
     bool serialize_fixed_internal( Stream & stream, Storage & value )
     {
-        static_assert( FixedPointInteger<Storage>::is_integer == 1, "serialize_fixed storage must be an integer type" );
-        static_assert( IntegerBits >= 1, "serialize_fixed needs at least one integer bit. the sign bit counts for signed storage" );
-        static_assert( FractionalBits >= 0, "serialize_fixed fractional bits can't be negative" );
-        static_assert( IntegerBits + FractionalBits == 8 * (int) sizeof( Storage ), "serialize_fixed integer bits plus fractional bits must equal the number of bits in the storage type" );
-        static_assert( MinUnits < MaxUnits, "serialize_fixed min must be below max" );
+        serialize_static_assert( FixedPointInteger<Storage>::is_integer == 1, "serialize_fixed storage must be an integer type" );
+        serialize_static_assert( IntegerBits >= 1, "serialize_fixed needs at least one integer bit. the sign bit counts for signed storage" );
+        serialize_static_assert( FractionalBits >= 0, "serialize_fixed fractional bits can't be negative" );
+        serialize_static_assert( IntegerBits + FractionalBits == 8 * (int) sizeof( Storage ), "serialize_fixed integer bits plus fractional bits must equal the number of bits in the storage type" );
+        serialize_static_assert( MinUnits < MaxUnits, "serialize_fixed min must be below max" );
 
         return FixedPointSerializer< ( 8 * (int) sizeof( Storage ) > 64 ) >::template Serialize<IntegerBits, FractionalBits, MinUnits, MaxUnits>( stream, value );
     }
@@ -4519,7 +4557,7 @@ inline void test_serialize_fixed()
         serialize_check( stream.GetBitsProcessed() == 16 );         // 200 << 8 raw values needs 16 bits
     }
 
-    // compile time refusals. each of the following fails with a static_assert, which is the point.
+    // compile time refusals. each of the following fails with a serialize_static_assert, which is the point.
     // kept as comments because a compile failure can't run inside the suite: uncomment one to verify.
     //
     //     int32_t value = 0;

--- a/serialize/serialize.h
+++ b/serialize/serialize.h
@@ -136,8 +136,568 @@
 #include <wchar.h>      // wcslen
 #include <math.h>       // ceil, floor
 
-namespace serialize 
+// 128 bit integer support.
+//
+// serialize::uint128_t and serialize::int128_t exist on every platform. Where the compiler
+// provides native __int128 (gcc, clang, clang-cl) they are unsigned __int128 and __int128: the
+// fastest representation. On compilers without it (pure MSVC), serialize defines the emulated
+// pair below — serialize_uint128_t and serialize_int128_t, full 128 bit integer types with standard
+// semantics — and announces them with the SERIALIZE_UINT128_DEFINED handshake macro. The two structs
+// are one facility: one announce macro covers the pair, and copies are carried whole, never
+// just one half.
+//
+// THE SHARING CONVENTION: single header libraries cannot include each other, so this definition
+// block is carried, verbatim, by sibling projects under the same handshake (the fixed point
+// library, and games built on these libraries). Whichever header is included first defines the
+// pair; everyone after sees SERIALIZE_UINT128_DEFINED and aliases them, so the types are defined
+// exactly once per translation unit instead of two or three times. The copies exist by design;
+// the handshake makes them mutually exclusive per translation unit, and the differential tests
+// against native __int128 in each C++ home are what keep every copy honest — drift fails loudly.
+//
+// The block is dual language: in C the types are bare POD structs of two uint64_t members,
+// low half then high half, matching little endian layout and the wire order. C projects add
+// their own function wrappers in their own tree. Everything else — constructors, the full
+// operator surface, the explicit conversions — is C++ only, inside #ifdef __cplusplus.
+//
+// Semantics match native __int128 exactly, with documented choices where native has none:
+// shift counts outside [0,127] yield zero (all sign bits for the signed arithmetic right
+// shift; native shifts by 128 or more are undefined behavior), and signed INT128_MIN over -1
+// wraps to INT128_MIN, the bit pattern native hardware produces.
+//
+// DIVISION OR MODULO BY ZERO IS UNDEFINED. Do not do it. It is undefined for native
+// __int128 too — C++ says so, and the hardware disagrees with itself: measured, arm64
+// returns zero for x / 0 but returns the DIVIDEND for x % 0, while x86-64 IDIV/DIV raises a
+// hardware exception and terminates. There is therefore no portable behavior available to
+// match, and any value this block returned would be a divergence from somewhere.
+// What the block guarantees is only that it is TOTAL — it returns zero quotient and zero
+// remainder rather than trapping, so a caller's mistake cannot crash a process and the block
+// keeps its no-assert-dependency design. That is an implementation detail, not a contract:
+// callers may not rely on it, and the differential test against native deliberately excludes
+// zero divisors, because agreement there is not a property either side can promise.
+//
+// When tests are enabled the pair is defined even where native __int128 exists, so the test
+// suite can prove the emulation agrees with native operator by operator and produces byte
+// identical wire.
+
+#if !defined( SERIALIZE_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
+
+typedef struct serialize_uint128_t
 {
+    uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
+    uint64_t hi;            ///< the high 64 bits
+
+#ifdef __cplusplus
+
+    serialize_uint128_t() = default;
+
+    // construction mirrors native conversion to unsigned __int128 exactly: unsigned sources zero
+    // extend, signed sources sign extend (a negative value wraps modulo 2^128, so the high lane
+    // fills with ones). one constructor per standard integer type keeps every call an exact match
+    // after integer promotion — a lone uint64_t constructor would zero extend negative int64
+    // values where native sign extends, silently diverging the wire between representations.
+
+    serialize_uint128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_uint128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_uint128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_uint128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
+    serialize_uint128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
+    serialize_uint128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
+
+    explicit operator uint64_t () const
+    {
+        return lo;
+    }
+
+    bool operator == ( serialize_uint128_t other ) const
+    {
+        return lo == other.lo && hi == other.hi;
+    }
+
+    bool operator != ( serialize_uint128_t other ) const
+    {
+        return ! ( *this == other );
+    }
+
+    bool operator < ( serialize_uint128_t other ) const
+    {
+        return ( hi != other.hi ) ? ( hi < other.hi ) : ( lo < other.lo );
+    }
+
+    bool operator > ( serialize_uint128_t other ) const
+    {
+        return other < *this;
+    }
+
+    bool operator <= ( serialize_uint128_t other ) const
+    {
+        return ! ( other < *this );
+    }
+
+    bool operator >= ( serialize_uint128_t other ) const
+    {
+        return ! ( *this < other );
+    }
+
+    serialize_uint128_t operator ~ () const
+    {
+        serialize_uint128_t result( 0 );
+        result.lo = ~lo;
+        result.hi = ~hi;
+        return result;
+    }
+
+    serialize_uint128_t operator & ( serialize_uint128_t other ) const
+    {
+        serialize_uint128_t result( 0 );
+        result.lo = lo & other.lo;
+        result.hi = hi & other.hi;
+        return result;
+    }
+
+    serialize_uint128_t operator | ( serialize_uint128_t other ) const
+    {
+        serialize_uint128_t result( 0 );
+        result.lo = lo | other.lo;
+        result.hi = hi | other.hi;
+        return result;
+    }
+
+    serialize_uint128_t operator ^ ( serialize_uint128_t other ) const
+    {
+        serialize_uint128_t result( 0 );
+        result.lo = lo ^ other.lo;
+        result.hi = hi ^ other.hi;
+        return result;
+    }
+
+    serialize_uint128_t operator << ( int shift ) const
+    {
+        // shifting a uint64 lane by 64 is undefined behavior, so the half boundary is an explicit
+        // branch. shift counts outside [0,127] yield zero, documented above.
+        serialize_uint128_t result( 0 );
+        if ( shift == 0 )
+        {
+            result = *this;
+        }
+        else if ( shift > 0 && shift < 64 )
+        {
+            result.hi = ( hi << shift ) | ( lo >> ( 64 - shift ) );
+            result.lo = lo << shift;
+        }
+        else if ( shift >= 64 && shift < 128 )
+        {
+            result.hi = lo << ( shift - 64 );
+            result.lo = 0;
+        }
+        return result;
+    }
+
+    serialize_uint128_t operator >> ( int shift ) const
+    {
+        // shifting a uint64 lane by 64 is undefined behavior, so the half boundary is an explicit
+        // branch. shift counts outside [0,127] yield zero, documented above.
+        serialize_uint128_t result( 0 );
+        if ( shift == 0 )
+        {
+            result = *this;
+        }
+        else if ( shift > 0 && shift < 64 )
+        {
+            result.lo = ( lo >> shift ) | ( hi << ( 64 - shift ) );
+            result.hi = hi >> shift;
+        }
+        else if ( shift >= 64 && shift < 128 )
+        {
+            result.lo = hi >> ( shift - 64 );
+            result.hi = 0;
+        }
+        return result;
+    }
+
+    serialize_uint128_t operator + ( serialize_uint128_t other ) const
+    {
+        serialize_uint128_t result( 0 );
+        result.lo = lo + other.lo;
+        result.hi = hi + other.hi + ( ( result.lo < lo ) ? 1 : 0 );         // carry out of the low lane
+        return result;
+    }
+
+    serialize_uint128_t operator - ( serialize_uint128_t other ) const
+    {
+        serialize_uint128_t result( 0 );
+        result.lo = lo - other.lo;
+        result.hi = hi - other.hi - ( ( lo < other.lo ) ? 1 : 0 );          // borrow out of the low lane
+        return result;
+    }
+
+    serialize_uint128_t operator * ( serialize_uint128_t other ) const
+    {
+        // schoolbook multiplication in 32 bit limbs over the uint64 lanes: the low 64 x 64 product
+        // is computed exactly, then the cross products fold into the high lane modulo 2^64
+        const uint64_t a_low = lo & 0xFFFFFFFFULL;
+        const uint64_t a_high = lo >> 32;
+        const uint64_t b_low = other.lo & 0xFFFFFFFFULL;
+        const uint64_t b_high = other.lo >> 32;
+
+        const uint64_t product_ll = a_low * b_low;
+        const uint64_t product_lh = a_low * b_high;
+        const uint64_t product_hl = a_high * b_low;
+        const uint64_t product_hh = a_high * b_high;
+
+        const uint64_t carry = ( ( product_ll >> 32 ) + ( product_lh & 0xFFFFFFFFULL ) + ( product_hl & 0xFFFFFFFFULL ) ) >> 32;
+
+        serialize_uint128_t result( 0 );
+        result.lo = product_ll + ( product_lh << 32 ) + ( product_hl << 32 );
+        result.hi = product_hh + ( product_lh >> 32 ) + ( product_hl >> 32 ) + carry;
+        result.hi += lo * other.hi + hi * other.lo;
+        return result;
+    }
+
+    static void DivMod( serialize_uint128_t dividend, serialize_uint128_t divisor, serialize_uint128_t & quotient, serialize_uint128_t & remainder )
+    {
+        // shift subtract long division. division by zero is UNDEFINED (documented above) — this
+        // returns zero quotient and zero remainder only to stay TOTAL, since the block has no
+        // assert dependency by design. Not a contract; callers may not rely on the value.
+        quotient = serialize_uint128_t( 0 );
+        remainder = serialize_uint128_t( 0 );
+        if ( divisor == serialize_uint128_t( 0 ) )
+        {
+            return;
+        }
+        if ( dividend.hi == 0 && divisor.hi == 0 )
+        {
+            quotient = serialize_uint128_t( dividend.lo / divisor.lo );
+            remainder = serialize_uint128_t( dividend.lo % divisor.lo );
+            return;
+        }
+        for ( int i = 127; i >= 0; i-- )
+        {
+            remainder = remainder << 1;
+            remainder.lo |= ( dividend >> i ).lo & 1;
+            if ( remainder >= divisor )
+            {
+                remainder = remainder - divisor;
+                quotient = quotient | ( serialize_uint128_t( 1 ) << i );
+            }
+        }
+    }
+
+    serialize_uint128_t operator / ( serialize_uint128_t other ) const
+    {
+        serialize_uint128_t quotient( 0 );
+        serialize_uint128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return quotient;
+    }
+
+    serialize_uint128_t operator % ( serialize_uint128_t other ) const
+    {
+        serialize_uint128_t quotient( 0 );
+        serialize_uint128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return remainder;
+    }
+
+    serialize_uint128_t operator + () const
+    {
+        return *this;
+    }
+
+    serialize_uint128_t operator - () const
+    {
+        return serialize_uint128_t( 0 ) - *this;
+    }
+
+    serialize_uint128_t & operator += ( serialize_uint128_t other ) { *this = *this + other; return *this; }
+    serialize_uint128_t & operator -= ( serialize_uint128_t other ) { *this = *this - other; return *this; }
+    serialize_uint128_t & operator *= ( serialize_uint128_t other ) { *this = *this * other; return *this; }
+    serialize_uint128_t & operator /= ( serialize_uint128_t other ) { *this = *this / other; return *this; }
+    serialize_uint128_t & operator %= ( serialize_uint128_t other ) { *this = *this % other; return *this; }
+    serialize_uint128_t & operator &= ( serialize_uint128_t other ) { *this = *this & other; return *this; }
+    serialize_uint128_t & operator |= ( serialize_uint128_t other ) { *this = *this | other; return *this; }
+    serialize_uint128_t & operator ^= ( serialize_uint128_t other ) { *this = *this ^ other; return *this; }
+    serialize_uint128_t & operator <<= ( int shift )          { *this = *this << shift; return *this; }
+    serialize_uint128_t & operator >>= ( int shift )          { *this = *this >> shift; return *this; }
+
+    serialize_uint128_t & operator ++ ()
+    {
+        *this = *this + serialize_uint128_t( 1 );
+        return *this;
+    }
+
+    serialize_uint128_t operator ++ ( int )
+    {
+        serialize_uint128_t before = *this;
+        ++( *this );
+        return before;
+    }
+
+    serialize_uint128_t & operator -- ()
+    {
+        *this = *this - serialize_uint128_t( 1 );
+        return *this;
+    }
+
+    serialize_uint128_t operator -- ( int )
+    {
+        serialize_uint128_t before = *this;
+        --( *this );
+        return before;
+    }
+
+#endif // #ifdef __cplusplus
+
+} serialize_uint128_t;
+
+/**
+    The emulated signed 128 bit integer: a thin two's complement layer over the unsigned lanes.
+    Addition, subtraction, multiplication and the bitwise operators produce the same bit patterns
+    as the unsigned type (two's complement), so they delegate to it instead of duplicating the
+    arithmetic. The signed specific pieces are the comparisons (the high lane compares signed),
+    operator>> (ARITHMETIC shift: vacated bits fill with the sign), division and modulo (sign
+    extraction, unsigned divmod on the magnitudes, sign application — C++ truncation toward zero
+    with the remainder sign following the dividend), unary minus, the sign extending int64_t
+    constructor, and the bit preserving conversions to and from the unsigned type.
+    Documented choices where native has none: shift counts outside [0,127] yield zero for <<
+    and all sign bits for >> (the limit of shifting further); and the one overflowing division,
+    INT128_MIN over -1, wraps to INT128_MIN quotient and zero remainder — the same bit pattern
+    native two's complement hardware produces.
+    Division or modulo by zero is UNDEFINED, as it is for native __int128 — see the block comment
+    on serialize_uint128_t. This type stays total and returns zero rather than trapping, which is
+    an implementation detail and not a contract.
+    This struct is part of the serialize_uint128_t definition block above and is carried with it: the
+    two types are one facility, announced together by the single SERIALIZE_UINT128_DEFINED handshake
+    macro and defined exactly once per translation unit. Copies in sibling projects carry the
+    whole pair, never just one half.
+ */
+
+typedef struct serialize_int128_t
+{
+    uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
+    uint64_t hi;            ///< the high 64 bits. the top bit is the sign
+
+#ifdef __cplusplus
+
+    serialize_int128_t() = default;
+
+    // construction mirrors native conversion to __int128 exactly: signed sources sign extend,
+    // unsigned sources zero extend (any uint64 is below 2^127, so the conversion is value
+    // preserving with a zero high lane). one constructor per standard integer type keeps every
+    // call an exact match after integer promotion — a lone int64_t constructor would wrap large
+    // uint64 values negative where native keeps them positive, silently diverging the wire
+    // between representations.
+
+    serialize_int128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_int128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_int128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_int128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
+    serialize_int128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
+    serialize_int128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
+
+    explicit serialize_int128_t( serialize_uint128_t value ) : lo( value.lo ), hi( value.hi ) {}        // bit preserving
+
+    explicit operator serialize_uint128_t () const                                                // bit preserving
+    {
+        serialize_uint128_t result( 0 );
+        result.lo = lo;
+        result.hi = hi;
+        return result;
+    }
+
+    explicit operator int64_t () const
+    {
+        return int64_t( lo );               // the low lane, wrapping two's complement like a native narrowing conversion
+    }
+
+    bool IsNegative() const
+    {
+        return ( hi >> 63 ) != 0;
+    }
+
+    bool operator == ( serialize_int128_t other ) const
+    {
+        return lo == other.lo && hi == other.hi;
+    }
+
+    bool operator != ( serialize_int128_t other ) const
+    {
+        return ! ( *this == other );
+    }
+
+    bool operator < ( serialize_int128_t other ) const
+    {
+        // signed ordering: the high lanes compare signed, the low lanes break ties unsigned
+        if ( hi != other.hi )
+        {
+            return int64_t( hi ) < int64_t( other.hi );
+        }
+        return lo < other.lo;
+    }
+
+    bool operator > ( serialize_int128_t other ) const
+    {
+        return other < *this;
+    }
+
+    bool operator <= ( serialize_int128_t other ) const
+    {
+        return ! ( other < *this );
+    }
+
+    bool operator >= ( serialize_int128_t other ) const
+    {
+        return ! ( *this < other );
+    }
+
+    // two's complement: addition, subtraction, multiplication and the bitwise operators are the
+    // same bit patterns as unsigned, so they delegate to the unsigned type. signed overflow wraps
+    // by construction, exactly like the underlying hardware.
+
+    serialize_int128_t operator + ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) + serialize_uint128_t( other ) ); }
+    serialize_int128_t operator - ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) - serialize_uint128_t( other ) ); }
+    serialize_int128_t operator * ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) * serialize_uint128_t( other ) ); }
+
+    serialize_int128_t operator ~ () const                     { return serialize_int128_t( ~serialize_uint128_t( *this ) ); }
+    serialize_int128_t operator & ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) & serialize_uint128_t( other ) ); }
+    serialize_int128_t operator | ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) | serialize_uint128_t( other ) ); }
+    serialize_int128_t operator ^ ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) ^ serialize_uint128_t( other ) ); }
+
+    serialize_int128_t operator << ( int shift ) const
+    {
+        // a logical shift of the bit pattern, matching what native two's complement hardware does.
+        // shift counts outside [0,127] yield zero, matching the unsigned type
+        return serialize_int128_t( serialize_uint128_t( *this ) << shift );
+    }
+
+    serialize_int128_t operator >> ( int shift ) const
+    {
+        // ARITHMETIC shift right: the vacated high bits fill with the sign. shift counts outside
+        // [0,127] yield all sign bits — 0 for non negative values, -1 for negative ones — which is
+        // the limit of shifting further, documented above
+        if ( shift < 0 || shift >= 128 )
+        {
+            return IsNegative() ? serialize_int128_t( -1 ) : serialize_int128_t( 0 );
+        }
+        serialize_uint128_t result = serialize_uint128_t( *this ) >> shift;
+        if ( IsNegative() && shift > 0 )
+        {
+            result = result | ( ~serialize_uint128_t( 0 ) << ( 128 - shift ) );
+        }
+        return serialize_int128_t( result );
+    }
+
+    serialize_int128_t operator + () const
+    {
+        return *this;
+    }
+
+    serialize_int128_t operator - () const
+    {
+        return serialize_int128_t( -serialize_uint128_t( *this ) );                 // two's complement negation. -INT128_MIN wraps to itself, like native
+    }
+
+    static void DivMod( serialize_int128_t dividend, serialize_int128_t divisor, serialize_int128_t & quotient, serialize_int128_t & remainder )
+    {
+        // sign extraction, unsigned shift subtract division on the magnitudes, then sign
+        // application: C++ semantics, truncation toward zero with the remainder sign following
+        // the dividend. the documented edge choices live in the comment block above.
+        const bool dividend_negative = dividend.IsNegative();
+        const bool divisor_negative = divisor.IsNegative();
+        const serialize_uint128_t dividend_magnitude = dividend_negative ? -serialize_uint128_t( dividend ) : serialize_uint128_t( dividend );
+        const serialize_uint128_t divisor_magnitude = divisor_negative ? -serialize_uint128_t( divisor ) : serialize_uint128_t( divisor );
+        serialize_uint128_t unsigned_quotient( 0 );
+        serialize_uint128_t unsigned_remainder( 0 );
+        serialize_uint128_t::DivMod( dividend_magnitude, divisor_magnitude, unsigned_quotient, unsigned_remainder );
+        quotient = serialize_int128_t( ( dividend_negative != divisor_negative ) ? -unsigned_quotient : unsigned_quotient );
+        remainder = serialize_int128_t( dividend_negative ? -unsigned_remainder : unsigned_remainder );
+    }
+
+    serialize_int128_t operator / ( serialize_int128_t other ) const
+    {
+        serialize_int128_t quotient( 0 );
+        serialize_int128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return quotient;
+    }
+
+    serialize_int128_t operator % ( serialize_int128_t other ) const
+    {
+        serialize_int128_t quotient( 0 );
+        serialize_int128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return remainder;
+    }
+
+    serialize_int128_t & operator += ( serialize_int128_t other ) { *this = *this + other; return *this; }
+    serialize_int128_t & operator -= ( serialize_int128_t other ) { *this = *this - other; return *this; }
+    serialize_int128_t & operator *= ( serialize_int128_t other ) { *this = *this * other; return *this; }
+    serialize_int128_t & operator /= ( serialize_int128_t other ) { *this = *this / other; return *this; }
+    serialize_int128_t & operator %= ( serialize_int128_t other ) { *this = *this % other; return *this; }
+    serialize_int128_t & operator &= ( serialize_int128_t other ) { *this = *this & other; return *this; }
+    serialize_int128_t & operator |= ( serialize_int128_t other ) { *this = *this | other; return *this; }
+    serialize_int128_t & operator ^= ( serialize_int128_t other ) { *this = *this ^ other; return *this; }
+    serialize_int128_t & operator <<= ( int shift )         { *this = *this << shift; return *this; }
+    serialize_int128_t & operator >>= ( int shift )         { *this = *this >> shift; return *this; }
+
+    serialize_int128_t & operator ++ ()
+    {
+        *this = *this + serialize_int128_t( 1 );
+        return *this;
+    }
+
+    serialize_int128_t operator ++ ( int )
+    {
+        serialize_int128_t before = *this;
+        ++( *this );
+        return before;
+    }
+
+    serialize_int128_t & operator -- ()
+    {
+        *this = *this - serialize_int128_t( 1 );
+        return *this;
+    }
+
+    serialize_int128_t operator -- ( int )
+    {
+        serialize_int128_t before = *this;
+        --( *this );
+        return before;
+    }
+
+#endif // #ifdef __cplusplus
+
+} serialize_int128_t;
+
+#define SERIALIZE_UINT128_DEFINED 1
+
+#endif // #if !defined( SERIALIZE_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
+
+namespace serialize
+{
+#if defined(__SIZEOF_INT128__)
+
+    /**
+        Native 128 bit integer types, where the compiler provides them (gcc, clang, clang-cl).
+        int128_t is the storage type for wide fixed point (Q112.16 and friends). uint128_t is the 128 bit wire interchange type. On compilers without __int128 both fall back to the emulated pair below, so serialize::int128_t and serialize::uint128_t exist on every platform.
+        __extension__ keeps -Wpedantic quiet: __int128 is a language extension.
+     */
+
+    __extension__ typedef          __int128  int128_t;
+    __extension__ typedef unsigned __int128 uint128_t;
+
+#else // #if defined(__SIZEOF_INT128__)
+
+    /**
+        The 128 bit integer types on compilers without native __int128: the emulated ::serialize_uint128_t and ::serialize_int128_t pair.
+        See the comment block on serialize_uint128_t above for the sharing convention between projects.
+     */
+
+    typedef ::serialize_int128_t   int128_t;
+    typedef ::serialize_uint128_t uint128_t;
+
+#endif // #if defined(__SIZEOF_INT128__)
+
     /**
         Calculates the population count of an unsigned 32 bit integer at compile time.
         Population count is the number of bits in the integer that set to 1.
@@ -187,6 +747,65 @@ namespace serialize
     {
         static const uint32_t result = ( min == max ) ? 0 : ( Log2<uint32_t(max-min)>::result + 1 );
     };
+
+    /**
+        Calculates the number of bits needed to represent an unsigned 64 bit integer at compile time.
+        This is floor( log2( x ) ) + 1, and zero for an input of zero.
+        @see serialize::BitsRequired64
+     */
+
+    template <uint64_t x> struct BitCount64
+    {
+        static const int result = 1 + BitCount64< ( x >> 1 ) >::result;
+    };
+
+    template <> struct BitCount64<0>
+    {
+        static const int result = 0;
+    };
+
+    /**
+        Calculates the number of bits required to serialize a 64 bit integer value in [min,max] at compile time.
+        The subtraction is performed in the unsigned domain, so ranges wider than 2^63 work.
+        @see serialize::BitsRequired
+        @see serialize::bits_required64
+     */
+
+    template <uint64_t min, uint64_t max> struct BitsRequired64
+    {
+        static const int result = BitCount64< max - min >::result;
+    };
+
+#if defined(__SIZEOF_INT128__)
+
+    /**
+        Calculates the number of bits needed to represent an unsigned 128 bit integer at compile time.
+        This is floor( log2( x ) ) + 1, and zero for an input of zero.
+        @see serialize::BitsRequired128
+     */
+
+    template <uint128_t x> struct BitCount128
+    {
+        static const int result = 1 + BitCount128< ( x >> 1 ) >::result;
+    };
+
+    template <> struct BitCount128<0>
+    {
+        static const int result = 0;
+    };
+
+    /**
+        Calculates the number of bits required to serialize a 128 bit integer value in [min,max] at compile time.
+        The subtraction is performed in the unsigned domain, so ranges wider than 2^127 work.
+        @see serialize::BitsRequired64
+     */
+
+    template <uint128_t min, uint128_t max> struct BitsRequired128
+    {
+        static const int result = BitCount128< max - min >::result;
+    };
+
+#endif // #if defined(__SIZEOF_INT128__)
 
     /**
         Calculates the population count of an unsigned 32 bit integer.
@@ -264,6 +883,29 @@ namespace serialize
         const uint32_t high = uint32_t( diff >> 32 );
         return high ? ( 32 + bits_required( 0, high ) ) : bits_required( 0, uint32_t( diff ) );
 #endif // #ifdef __GNUC__
+    }
+
+    /**
+        Calculates the number of bits required to serialize a 128 bit integer in range [min,max].
+        The subtraction is performed in the unsigned domain, so ranges wider than 2^127 work.
+        Unlike the compile time serialize::BitsRequired128, which needs native __int128 as a non type
+        template parameter, this runs on every platform: the emulated pair supports every operation
+        it uses, so the 128 bit ranged codec works on pure MSVC too.
+        @param min The minimum value.
+        @param max The maximum value.
+        @returns The number of bits required to serialize the integer in [0,128].
+     */
+
+    inline int bits_required128( uint128_t min, uint128_t max )
+    {
+        if ( min == max )
+        {
+            return 0;
+        }
+        // subtract in the unsigned domain: max - min overflows signed arithmetic when the range is wider than 2^127
+        const uint128_t diff = max - min;
+        const uint64_t high = uint64_t( diff >> 64 );
+        return high ? ( 64 + bits_required64( 0, high ) ) : bits_required64( 0, uint64_t( diff ) );
     }
 
     /**
@@ -912,6 +1554,52 @@ namespace serialize
         }
 
         /**
+            Serialize a 128 bit integer (write).
+            @param value The integer value in [min,max].
+            @param min The minimum value.
+            @param max The maximum value.
+            @returns Always returns true. All checking is performed by debug asserts only on write.
+         */
+
+        bool SerializeInteger128( int128_t value, int128_t min, int128_t max )
+        {
+            serialize_assert( min < max );
+            serialize_assert( value >= min );
+            serialize_assert( value <= max );
+            const int bits = bits_required128( uint128_t(min), uint128_t(max) );
+            // subtract in the unsigned domain: value - min overflows signed arithmetic when the range is wider than 2^127
+            const uint128_t unsigned_value = uint128_t(value) - uint128_t(min);
+            // 32 bit groups, least significant first: the same convention as serialize_bits, serialize_uint64 and the wide fixed point path
+            const uint32_t group0 = uint32_t( uint64_t( unsigned_value       ) & 0xFFFFFFFF );
+            const uint32_t group1 = uint32_t( uint64_t( unsigned_value >> 32 ) & 0xFFFFFFFF );
+            const uint32_t group2 = uint32_t( uint64_t( unsigned_value >> 64 ) & 0xFFFFFFFF );
+            const uint32_t group3 = uint32_t( uint64_t( unsigned_value >> 96 ) & 0xFFFFFFFF );
+            if ( bits <= 32 )
+            {
+                m_writer.WriteBits( group0, bits );
+            }
+            else if ( bits <= 64 )
+            {
+                m_writer.WriteBits( group0, 32 );
+                m_writer.WriteBits( group1, bits - 32 );
+            }
+            else if ( bits <= 96 )
+            {
+                m_writer.WriteBits( group0, 32 );
+                m_writer.WriteBits( group1, 32 );
+                m_writer.WriteBits( group2, bits - 64 );
+            }
+            else
+            {
+                m_writer.WriteBits( group0, 32 );
+                m_writer.WriteBits( group1, 32 );
+                m_writer.WriteBits( group2, 32 );
+                m_writer.WriteBits( group3, bits - 96 );
+            }
+            return true;
+        }
+
+        /**
             Serialize a number of bits (write).
             @param value The unsigned integer value to serialize. Must be in range [0,(1<<bits)-1].
             @param bits The number of bits to write in [1,32].
@@ -1100,6 +1788,55 @@ namespace serialize
         }
 
         /**
+            Serialize a 128 bit integer (read).
+            @param value The integer value read is stored here. It is guaranteed to be in [min,max] if this function succeeds.
+            @param min The minimum allowed value.
+            @param max The maximum allowed value.
+            @returns Returns true if the serialize succeeded and the value is in the correct range. False otherwise.
+         */
+
+        bool SerializeInteger128( int128_t & value, int128_t min, int128_t max )
+        {
+            serialize_assert( min < max );
+            const int bits = bits_required128( uint128_t(min), uint128_t(max) );
+            if ( m_reader.WouldReadPastEnd( bits ) )
+                return false;
+            // 32 bit groups, least significant first: the same convention as the write path
+            uint32_t group0 = 0;
+            uint32_t group1 = 0;
+            uint32_t group2 = 0;
+            uint32_t group3 = 0;
+            if ( bits <= 32 )
+            {
+                group0 = m_reader.ReadBits( bits );
+            }
+            else if ( bits <= 64 )
+            {
+                group0 = m_reader.ReadBits( 32 );
+                group1 = m_reader.ReadBits( bits - 32 );
+            }
+            else if ( bits <= 96 )
+            {
+                group0 = m_reader.ReadBits( 32 );
+                group1 = m_reader.ReadBits( 32 );
+                group2 = m_reader.ReadBits( bits - 64 );
+            }
+            else
+            {
+                group0 = m_reader.ReadBits( 32 );
+                group1 = m_reader.ReadBits( 32 );
+                group2 = m_reader.ReadBits( 32 );
+                group3 = m_reader.ReadBits( bits - 96 );
+            }
+            const uint128_t unsigned_value = ( uint128_t( group3 ) << 96 ) | ( uint128_t( group2 ) << 64 ) | ( uint128_t( group1 ) << 32 ) | uint128_t( group0 );
+            if ( unsigned_value > uint128_t(max) - uint128_t(min) )
+                return false;
+            // add in the unsigned domain: unsigned_value + min overflows signed arithmetic when the range is wider than 2^127
+            value = int128_t( unsigned_value + uint128_t(min) );
+            return true;
+        }
+
+        /**
             Serialize a number of bits (read).
             @param value The integer value read is stored here. Will be in range [0,(1<<bits)-1].
             @param bits The number of bits to read in [1,32].
@@ -1242,6 +1979,25 @@ namespace serialize
             serialize_assert( value >= min );
             serialize_assert( value <= max );
             const int bits = bits_required64( uint64_t(min), uint64_t(max) );
+            m_bitsWritten += bits;
+            return true;
+        }
+
+        /**
+            Serialize a 128 bit integer (measure).
+            @param value The integer value to measure. Not actually used or checked beyond the debug asserts.
+            @param min The minimum value.
+            @param max The maximum value.
+            @returns Always returns true. All checking is performed by debug asserts on write.
+         */
+
+        bool SerializeInteger128( int128_t value, int128_t min, int128_t max )
+        {
+            (void) value;
+            serialize_assert( min < max );
+            serialize_assert( value >= min );
+            serialize_assert( value <= max );
+            const int bits = bits_required128( uint128_t(min), uint128_t(max) );
             m_bitsWritten += bits;
             return true;
         }
@@ -1399,6 +2155,46 @@ namespace serialize
                     return false;                                       \
                 }                                                       \
             }                                                           \
+        } while (0)
+
+    /**
+        Serialize a ranged 128 bit integer to the stream (read/write/measure).
+        This is a helper macro to make writing unified serialize functions easier.
+        The value is serialized as an offset from min in the minimal number of bits for the range, exactly as serialize_int and serialize_int64 do at their widths, and the bounds are runtime values. Where the range fits 64 bits or fewer the bytes are identical to serialize_int64 over the same bounds.
+        The bounds and value are serialize::int128_t, which exists on every platform: native __int128 where the compiler provides it, the emulated pair where it doesn't. The bit count comes from the runtime serialize::bits_required128, so this works on pure MSVC — unlike the compile time serialize::BitsRequired128, which needs native __int128.
+        **Do not confuse this with serialize_uint128**, which is not ranged — it is a raw 128 bit field and always costs 128 bits.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The 128 bit integer value to serialize, in [min,max].
+        @param min The minimum value.
+        @param max The maximum value.
+     */
+
+    #define serialize_int128( stream, value, min, max )                                             \
+        do                                                                                          \
+        {                                                                                           \
+            serialize_assert( serialize::int128_t(min) < serialize::int128_t(max) );                \
+            serialize::int128_t int128_value = 0;                                                   \
+            if ( Stream::IsWriting )                                                                \
+            {                                                                                       \
+                serialize_assert( serialize::int128_t(value) >= serialize::int128_t(min) );         \
+                serialize_assert( serialize::int128_t(value) <= serialize::int128_t(max) );         \
+                int128_value = serialize::int128_t( value );                                        \
+            }                                                                                       \
+            if ( !stream.SerializeInteger128( int128_value, min, max ) )                            \
+            {                                                                                       \
+                return false;                                                                       \
+            }                                                                                       \
+            if ( Stream::IsReading )                                                                \
+            {                                                                                       \
+                value = int128_value;                                                               \
+                if ( serialize::int128_t(value) < serialize::int128_t(min) ||                       \
+                     serialize::int128_t(value) > serialize::int128_t(max) )                        \
+                {                                                                                   \
+                    return false;                                                                   \
+                }                                                                                   \
+            }                                                                                       \
         } while (0)
 
     /**
@@ -1666,6 +2462,57 @@ namespace serialize
      */
 
     #define serialize_uint64( stream, value ) serialize_bits( stream, value, 64 )
+
+    /**
+        Serialize a 128 bit unsigned integer (read/write/measure), templated over the 128 bit type.
+        The wire format is 128 bits raw: the low 64 bit half first, then the high half, following the lo-then-hi convention of serialize_bits.
+        UInt128 may be the native unsigned __int128 (see serialize::uint128_t) or an emulated 128 bit unsigned integer type on compilers without native support, such as pure MSVC.
+        The requirements on UInt128 are exactly: construction from uint64_t, operator\<\< and operator\>\> with int shift counts, operator|, and explicit conversion (static_cast) to uint64_t truncating to the low 64 bits.
+        This function is a template and only compiles when instantiated, so it is available on every compiler; only the serialize::uint128_t convenience typedef needs the __SIZEOF_INT128__ guard.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The 128 bit unsigned integer value.
+        @returns True if the serialize succeeded, false otherwise.
+     */
+
+    template <typename Stream, typename UInt128> bool serialize_uint128_internal( Stream & stream, UInt128 & value )
+    {
+        // refuse narrower types at compile time: a uint64_t here would shift by 64 — undefined
+        // behavior — and silently is not the 128 bit operation the caller asked for
+        static_assert( sizeof( UInt128 ) == 16, "serialize_uint128 requires a 128 bit type (did you mean serialize_uint64?)" );
+
+        uint64_t low_half = 0;
+        uint64_t high_half = 0;
+        if ( Stream::IsWriting )
+        {
+            low_half = uint64_t( value );
+            high_half = uint64_t( value >> 64 );
+        }
+        serialize_bits( stream, low_half, 64 );
+        serialize_bits( stream, high_half, 64 );
+        if ( Stream::IsReading )
+        {
+            value = ( UInt128( high_half ) << 64 ) | UInt128( low_half );
+        }
+        return true;
+    }
+
+    /**
+        Serialize unsigned 128 bit integer (read/write/measure).
+        The wire format is 128 bits raw: the low 64 bit half first, then the high half, following the lo-then-hi convention of serialize_bits.
+        The value may be serialize::uint128_t — which exists on every platform: native unsigned __int128 where the compiler provides it, the emulated serialize_uint128_t elsewhere — or any 128 bit unsigned integer type meeting the requirements documented on serialize_uint128_internal. All representations produce identical bytes.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The 128 bit unsigned integer value.
+     */
+
+    #define serialize_uint128( stream, value )                                      \
+        do                                                                          \
+        {                                                                           \
+            if ( !serialize::serialize_uint128_internal( stream, value ) )          \
+            {                                                                       \
+                return false;                                                       \
+            }                                                                       \
+        } while (0)
 
     /**
         Serialize an array of bytes to the stream (read/write/measure).
@@ -1962,6 +2809,301 @@ namespace serialize
             }                                                                               \
         } while (0)
 
+    /**
+        Compile time trait marking the integer types usable as fixed point storage.
+        Written locally because std::is_integral is not guaranteed to cover __int128 on every compiler, and this header does not include \<type_traits\>.
+     */
+
+    template <typename T> struct FixedPointInteger                  { enum { is_integer = 0, is_signed = 0 }; };
+    template <> struct FixedPointInteger<signed char>               { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned char>             { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<short>                     { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned short>            { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<int>                       { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned int>              { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<long>                      { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned long>             { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<long long>                 { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned long long>        { enum { is_integer = 1, is_signed = 0 }; };
+#if defined(__SIZEOF_INT128__)
+    template <> struct FixedPointInteger<int128_t>                  { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<uint128_t>                 { enum { is_integer = 1, is_signed = 0 }; };
+#endif // #if defined(__SIZEOF_INT128__)
+#if defined(SERIALIZE_UINT128_DEFINED)
+    // the emulated pair works as storage too. without native __int128 these ARE the serialize
+    // typedefs; with it they are a distinct set of types (present when tests are enabled, or
+    // when a sibling header defined the block first), so the specializations never collide
+    template <> struct FixedPointInteger<::serialize_int128_t>            { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<::serialize_uint128_t>           { enum { is_integer = 1, is_signed = 0 }; };
+#endif // #if defined(SERIALIZE_UINT128_DEFINED)
+
+    /**
+        Compile time map from a 128 bit fixed point storage type to its unsigned counterpart,
+        in which the wide codec runs its raw offset math. Both the native and the emulated types
+        map to their unsigned partner; two's complement wrap around is exact in both, so the
+        codec is representation generic and wide fixed point works on compilers without native
+        __int128.
+     */
+
+    template <typename T> struct FixedPointUnsigned;
+
+#if defined(__SIZEOF_INT128__)
+    template <> struct FixedPointUnsigned<int128_t>                 { typedef uint128_t type; };
+    template <> struct FixedPointUnsigned<uint128_t>                { typedef uint128_t type; };
+#endif // #if defined(__SIZEOF_INT128__)
+#if defined(SERIALIZE_UINT128_DEFINED)
+    template <> struct FixedPointUnsigned<::serialize_int128_t>           { typedef ::serialize_uint128_t type; };
+    template <> struct FixedPointUnsigned<::serialize_uint128_t>          { typedef ::serialize_uint128_t type; };
+#endif // #if defined(SERIALIZE_UINT128_DEFINED)
+
+    /**
+        Fixed point codec, specialized on storage width.
+        The false specialization covers storage of 64 bits or fewer and works entirely in the 64 bit unsigned domain.
+        The true specialization covers 128 bit storage. It is representation generic — the raw offset math runs in the storage type's unsigned counterpart via FixedPointUnsigned, and its compile time constants live in the 64 bit domain — so it works with native __int128 storage and with the emulated pair alike, and wide fixed point is available on every platform.
+        Splitting on width keeps every shift and every compile time bit count valid for the domain it runs in.
+        IMPORTANT: Generally, you don't use this directly. Use the serialize_fixed, read_fixed and write_fixed macros instead.
+     */
+
+    template <bool WideStorage> struct FixedPointSerializer;
+
+    template <> struct FixedPointSerializer<false>
+    {
+        template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
+        static bool Serialize( Stream & stream, Storage & value )
+        {
+            // the whole unit capacity of the Q format. computed in the unsigned domain so the widest formats (Q64.0 and friends) cannot overflow signed arithmetic
+            const int64_t min_representable_units = FixedPointInteger<Storage>::is_signed ?
+                int64_t( uint64_t(0) - ( uint64_t(1) << ( IntegerBits - 1 ) ) ) : int64_t(0);
+            const int64_t max_representable_units = FixedPointInteger<Storage>::is_signed ?
+                int64_t( ( uint64_t(1) << ( IntegerBits - 1 ) ) - 1 ) :
+                ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
+
+            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+
+            // shift the whole unit bounds into raw fixed point units in the unsigned domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
+            // everything below is a compile time constant: the bounds, the range and the bit count all fold, so the call site carries no runtime bit width computation at all.
+            const uint64_t raw_min = uint64_t( MinUnits ) << FractionalBits;
+            const uint64_t raw_max = uint64_t( MaxUnits ) << FractionalBits;
+            const uint64_t raw_range = raw_max - raw_min;
+
+            const int bits = BitsRequired64<raw_min, raw_max>::result;
+
+            uint64_t offset = 0;
+
+            if ( Stream::IsWriting )
+            {
+                // subtract in the unsigned domain: raw - raw_min overflows signed arithmetic when the range is wider than 2^63
+                offset = uint64_t( value ) - raw_min;
+                serialize_assert( offset <= raw_range );        // the value must be within [min,max] whole units. all checking is performed by debug asserts on write
+            }
+
+            if ( bits <= 32 )
+            {
+                uint32_t unsigned_value = uint32_t( offset );
+                if ( !stream.SerializeBits( unsigned_value, bits ) )
+                {
+                    return false;
+                }
+                offset = unsigned_value;
+            }
+            else
+            {
+                // low dword first, then the high remainder: same convention as serialize_bits and serialize_int64
+                uint32_t low_half = uint32_t( offset & 0xFFFFFFFF );
+                uint32_t high_half = uint32_t( offset >> 32 );
+                if ( !stream.SerializeBits( low_half, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( high_half, bits - 32 ) )
+                {
+                    return false;
+                }
+                offset = ( uint64_t( high_half ) << 32 ) | low_half;
+            }
+
+            if ( Stream::IsReading )
+            {
+                // reject raw values outside [raw_min,raw_max] smuggled into the bit headroom. reject, never clamp
+                if ( offset > raw_range )
+                {
+                    return false;
+                }
+                // reconstruct in the unsigned domain, then convert: wraps two's complement for signed storage
+                value = Storage( raw_min + offset );
+            }
+
+            return true;
+        }
+    };
+
+    template <> struct FixedPointSerializer<true>
+    {
+        template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
+        static bool Serialize( Stream & stream, Storage & value )
+        {
+            // the unsigned counterpart of the storage type: native unsigned __int128 for native
+            // storage, the emulated serialize_uint128_t for emulated storage. all raw offset math runs
+            // in this type, where wrap around is exact two's complement in both representations,
+            // so this codec is representation generic and needs no compiler guard at all.
+            typedef typename FixedPointUnsigned<Storage>::type Unsigned;
+
+            // the whole unit capacity of the Q format, in the 64 bit compile time domain: with 65
+            // or more integer bits the capacity covers any int64 bound, and below that the
+            // capacity math fits 64 bits. the inner clamps keep the unselected ternary arms free
+            // of invalid shift counts.
+            const int64_t min_representable_units = FixedPointInteger<Storage>::is_signed ?
+                ( ( IntegerBits >= 65 ) ? INT64_MIN : int64_t( uint64_t(0) - ( uint64_t(1) << ( ( IntegerBits <= 64 ? IntegerBits : 1 ) - 1 ) ) ) ) : int64_t(0);
+            const int64_t max_representable_units = FixedPointInteger<Storage>::is_signed ?
+                ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( ( IntegerBits < 64 ? IntegerBits : 1 ) - 1 ) ) - 1 ) ) :
+                ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
+
+            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+
+            // shift the whole unit bounds into raw fixed point units in the unsigned 128 bit domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
+            // the storage constructor sign extends the int64 bounds for signed storage. everything below folds: the bounds, the range, the bit count and the group structure.
+            const Unsigned raw_min = Unsigned( Storage( MinUnits ) ) << FractionalBits;
+            const Unsigned raw_max = Unsigned( Storage( MaxUnits ) ) << FractionalBits;
+            const Unsigned raw_range = raw_max - raw_min;
+
+            // the wire cost, computed in the 64 bit compile time domain: the range in whole units
+            // is exact in a uint64, and shifting it left by FractionalBits adds exactly
+            // FractionalBits to its bit length.
+            const int bits = BitsRequired64< uint64_t( MinUnits ), uint64_t( MaxUnits ) >::result + FractionalBits;
+
+            Unsigned offset = 0;
+
+            if ( Stream::IsWriting )
+            {
+                // subtract in the unsigned domain: raw - raw_min overflows signed arithmetic when the range is wider than 2^127
+                offset = Unsigned( value ) - raw_min;
+                serialize_assert( offset <= raw_range );        // the value must be within [min,max] whole units. all checking is performed by debug asserts on write
+            }
+
+            // the offset is written in 32 bit groups, least significant group first: the same convention as serialize_bits.
+            // the group structure is selected at compile time, so each SerializeBits call receives a constant bit count.
+            uint32_t group0 = 0;
+            uint32_t group1 = 0;
+            uint32_t group2 = 0;
+            uint32_t group3 = 0;
+
+            if ( Stream::IsWriting )
+            {
+                group0 = uint32_t( uint64_t( offset )       & 0xFFFFFFFF );
+                group1 = uint32_t( uint64_t( offset >> 32 ) & 0xFFFFFFFF );
+                group2 = uint32_t( uint64_t( offset >> 64 ) & 0xFFFFFFFF );
+                group3 = uint32_t( uint64_t( offset >> 96 ) & 0xFFFFFFFF );
+            }
+
+            if ( bits <= 32 )
+            {
+                if ( !stream.SerializeBits( group0, bits ) )
+                {
+                    return false;
+                }
+            }
+            else if ( bits <= 64 )
+            {
+                if ( !stream.SerializeBits( group0, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group1, bits - 32 ) )
+                {
+                    return false;
+                }
+            }
+            else if ( bits <= 96 )
+            {
+                if ( !stream.SerializeBits( group0, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group1, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group2, bits - 64 ) )
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if ( !stream.SerializeBits( group0, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group1, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group2, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group3, bits - 96 ) )
+                {
+                    return false;
+                }
+            }
+
+            if ( Stream::IsReading )
+            {
+                offset = ( Unsigned( group3 ) << 96 ) | ( Unsigned( group2 ) << 64 ) | ( Unsigned( group1 ) << 32 ) | Unsigned( group0 );
+
+                // reject raw values outside [raw_min,raw_max] smuggled into the bit headroom. reject, never clamp
+                if ( offset > raw_range )
+                {
+                    return false;
+                }
+                // reconstruct in the unsigned domain, then convert: wraps two's complement for signed storage
+                value = Storage( raw_min + offset );
+            }
+
+            return true;
+        }
+    };
+
+    template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
+    bool serialize_fixed_internal( Stream & stream, Storage & value )
+    {
+        static_assert( FixedPointInteger<Storage>::is_integer == 1, "serialize_fixed storage must be an integer type" );
+        static_assert( IntegerBits >= 1, "serialize_fixed needs at least one integer bit. the sign bit counts for signed storage" );
+        static_assert( FractionalBits >= 0, "serialize_fixed fractional bits can't be negative" );
+        static_assert( IntegerBits + FractionalBits == 8 * (int) sizeof( Storage ), "serialize_fixed integer bits plus fractional bits must equal the number of bits in the storage type" );
+        static_assert( MinUnits < MaxUnits, "serialize_fixed min must be below max" );
+
+        return FixedPointSerializer< ( 8 * (int) sizeof( Storage ) > 64 ) >::template Serialize<IntegerBits, FractionalBits, MinUnits, MaxUnits>( stream, value );
+    }
+
+    /**
+        Serialize a fixed point value to the stream (read/write/measure).
+        This is a helper macro to make writing unified serialize functions easier.
+        The Q format and the bounds are compile time constants: integer_bits plus fraction_bits must equal the number of bits in the storage type, with the sign bit counting towards integer_bits for signed storage. For example, Q48.16 in an int64_t is ( 48, 16 ) and Q112.16 in a serialize::int128_t is ( 112, 16 ). Any integer storage type works, including 128 bit storage on every platform: native __int128 where the compiler provides it, the emulated pair where it doesn't.
+        The bounds are whole units and must be constant expressions: a runtime bound fails to compile, and bounds that don't fit the Q format fail with a static assert. The value is serialized as an offset from min in the minimal number of bits for the range — a constant of the call site — and the round trip is exact: fixed point values are integers underneath, so unlike compressed floats there is no quantization error and results are identical across platforms.
+        For storage of 64 bits or fewer the wire format is byte identical to serialize_int64 of the raw value over the raw bounds.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The fixed point value to serialize, in [min,max] whole units. The storage type sets the width of the Q format.
+        @param integer_bits The number of integer bits in the Q format, including the sign bit for signed storage. Compile time constant.
+        @param fraction_bits The number of fractional bits in the Q format. Compile time constant.
+        @param min The minimum value in whole units. Compile time constant.
+        @param max The maximum value in whole units. Compile time constant.
+     */
+
+    #define serialize_fixed( stream, value, integer_bits, fraction_bits, min, max )                                 \
+        do                                                                                                          \
+        {                                                                                                           \
+            if ( !serialize::serialize_fixed_internal<integer_bits, fraction_bits, min, max>( stream, value ) )     \
+            {                                                                                                       \
+                return false;                                                                                       \
+            }                                                                                                       \
+        } while (0)
+
     // read macros corresponding to each serialize_*. useful when you want separate read and write functions.
 
     #define read_bits( stream, value, bits )                                                \
@@ -2026,11 +3168,46 @@ namespace serialize
             }                                                                               \
         } while (0)
 
+    #define read_int128( stream, value, min, max )                                          \
+        do                                                                                  \
+        {                                                                                   \
+            serialize_assert( serialize::int128_t(min) < serialize::int128_t(max) );        \
+            serialize::int128_t int128_value = 0;                                           \
+            if ( !stream.SerializeInteger128( int128_value, min, max ) )                    \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+            value = int128_value;                                                           \
+            if ( serialize::int128_t(value) < serialize::int128_t(min) ||                   \
+                 serialize::int128_t(value) > serialize::int128_t(max) )                    \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+        } while (0)
+
+    #define read_fixed( stream, value, integer_bits, fraction_bits, min, max )                                  \
+        do                                                                                                      \
+        {                                                                                                       \
+            if ( !serialize::serialize_fixed_internal<integer_bits, fraction_bits, min, max>( stream, value ) ) \
+            {                                                                                                   \
+                return false;                                                                                   \
+            }                                                                                                   \
+        } while (0)
+
     #define read_bool( stream, value )      read_bits( stream, value, 1 )
     #define read_uint8( stream, value )     read_bits( stream, value, 8 )
     #define read_uint16( stream, value )    read_bits( stream, value, 16 )
     #define read_uint32( stream, value )    read_bits( stream, value, 32 )
     #define read_uint64( stream, value )    read_bits( stream, value, 64 )
+
+    #define read_uint128( stream, value )                                                   \
+        do                                                                                  \
+        {                                                                                   \
+            if ( !serialize::serialize_uint128_internal( stream, value ) )                  \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+        } while (0)
 
     #define read_float                  serialize_float
     #define read_double                 serialize_double
@@ -2110,11 +3287,34 @@ namespace serialize
             stream.SerializeInteger64( int64_value, min, max );                             \
         } while (0)
 
+    #define write_int128( stream, value, min, max )                                         \
+        do                                                                                  \
+        {                                                                                   \
+            serialize_assert( serialize::int128_t( min ) < serialize::int128_t( max ) );    \
+            serialize_assert( serialize::int128_t( value ) >= serialize::int128_t( min ) ); \
+            serialize_assert( serialize::int128_t( value ) <= serialize::int128_t( max ) ); \
+            serialize::int128_t int128_value = serialize::int128_t( value );                \
+            stream.SerializeInteger128( int128_value, min, max );                           \
+        } while (0)
+
+    #define write_fixed( stream, value, integer_bits, fraction_bits, min, max )                                 \
+        do                                                                                                      \
+        {                                                                                                       \
+            serialize::serialize_fixed_internal<integer_bits, fraction_bits, min, max>( stream, value );        \
+        } while (0)
+
     #define write_bool( stream, value )         write_bits( stream, value, 1 )
     #define write_uint8( stream, value )        write_bits( stream, value, 8 )
     #define write_uint16( stream, value )       write_bits( stream, value, 16 )
     #define write_uint32( stream, value )       write_bits( stream, value, 32 )
     #define write_uint64( stream, value )       write_bits( stream, value, 64 )
+
+    #define write_uint128( stream, value )                                                  \
+        do                                                                                  \
+        {                                                                                   \
+            serialize::uint128_t uint128_value = ( value );                                 \
+            serialize::serialize_uint128_internal( stream, uint128_value );                 \
+        } while (0)
 
     #define write_float( stream, value )                                                    \
         do                                                                                  \
@@ -2353,6 +3553,42 @@ inline void test_bits_required64()
     serialize_check( serialize::bits_required64( 0, 0xFFFFFFFFFFFFFFFFULL ) == 64 );
     serialize_check( serialize::bits_required64( uint64_t(INT64_MIN), uint64_t(INT64_MAX) ) == 64 );
     serialize_check( serialize::bits_required64( uint64_t(-5000000000LL), uint64_t(+5000000000LL) ) == 34 );
+}
+
+inline void test_bits_required128()
+{
+    typedef serialize::uint128_t u128;
+
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 0 ) ) == 0 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 1 ) ) == 1 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 255 ) ) == 8 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 4294967295ULL ) ) == 32 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 4294967296ULL ) ) == 33 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 0xFFFFFFFFFFFFFFFFULL ) ) == 64 );
+
+    // the boundary the 64 bit helper cannot reach: one past a full low lane needs the high lane
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 1 ) << 64 ) == 65 );
+    serialize_check( serialize::bits_required128( u128( 0 ), ( u128( 1 ) << 127 ) ) == 128 );
+    serialize_check( serialize::bits_required128( u128( 0 ), ~u128( 0 ) ) == 128 );
+
+    // the two helpers must agree wherever the range fits 64 bits, or the wire identity claim in
+    // STANDARD.md is false and serialize_int128 would silently disagree with serialize_int64
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 4294967296ULL ) ) == serialize::bits_required64( 0, 4294967296ULL ) );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( ( 1ULL << 40 ) ) ) == serialize::bits_required64( 0, ( 1ULL << 40 ) ) );
+
+    // NEGATIVE BOUNDS MUST ARRIVE SIGN EXTENDED, which is what the codec does — it converts
+    // serialize::int128_t bounds straight to the unsigned domain. This is the same 34 bits the 64
+    // bit helper reports for the same signed range.
+    serialize_check( serialize::bits_required128( u128( serialize::int128_t( -5000000000LL ) ), u128( serialize::int128_t( +5000000000LL ) ) ) == 34 );
+
+    // AND THE TRAP IT WOULD BE EASY TO WALK INTO, pinned so nobody "fixes" the conversion:
+    // widening an ALREADY WRAPPED uint64_t bound zero extends instead of sign extending, so the
+    // range comes out just under 2^128 and the field would cost 128 bits instead of 34. Correct
+    // arithmetic on the wrong input — no assert would ever fire.
+    serialize_check( serialize::bits_required128( u128( uint64_t(-5000000000LL) ), u128( uint64_t(+5000000000LL) ) ) == 128 );
+
+    // a range wider than 2^127: the subtraction must run in the unsigned domain or this wraps wrong
+    serialize_check( serialize::bits_required128( u128( 1 ), ~u128( 0 ) ) == 128 );
 }
 
 inline void test_zigzag()
@@ -2604,6 +3840,18 @@ bool ReadFunction( serialize::ReadStream & readStream )
     }
 
     {
+        int64_t value = 0;
+        read_fixed( readStream, value, 48, 16, -100000, +100000 );
+        serialize_check( value == int64_t( 12345 ) * 65536 + 32768 );       // 12345.5 in Q48.16
+    }
+
+    {
+        serialize::uint128_t value = 0;
+        read_uint128( readStream, value );
+        serialize_check( value == ( ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL ) );
+    }
+
+    {
         float value;
         read_float( readStream, value );
         serialize_check( value == 100.0f );
@@ -2697,6 +3945,13 @@ inline void test_read_write()
         write_uint64( writeStream, 0xFFFFFFFFFFFFFFFFULL );
         write_int( writeStream, 55, 10, 90 );
         write_int64( writeStream, -50000000001LL, -60000000000LL, 60000000000LL );
+
+        int64_t fixed_point_value = int64_t( 12345 ) * 65536 + 32768;               // 12345.5 in Q48.16
+        write_fixed( writeStream, fixed_point_value, 48, 16, -100000, +100000 );
+
+        serialize::uint128_t big_value = ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL;
+        write_uint128( writeStream, big_value );
+
         write_float( writeStream, 100.0f );
         write_double( writeStream, 1000000000.0f );
 
@@ -3111,6 +4366,1342 @@ inline void test_compressed_float_validation()
     }
 }
 
+// Fixed point test helpers. Every configuration in the matrix runs the same case list, and every
+// round trip also runs the measure stream and requires exact agreement with the write stream:
+// fixed point serialization involves no alignment, so measure is exact, not just conservative.
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_round_trip( Storage raw_value )
+{
+    uint8_t buffer[32 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+    serialize::WriteStream writeStream( buffer, 32 );
+    Storage written = raw_value;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( writeStream, written ) ) == true );
+    writeStream.Flush();
+
+    serialize::MeasureStream measureStream;
+    Storage measured = raw_value;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( measureStream, measured ) ) == true );
+    serialize_check( measureStream.GetBitsProcessed() == writeStream.GetBitsProcessed() );
+
+    serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+    Storage read_back = 0;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( readStream, read_back ) ) == true );
+    serialize_check( read_back == raw_value );
+}
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_cases( Storage one_unit )
+{
+    // the multiplications keep the Storage typed operand on the left, so the emulated 128 bit
+    // types (member operators only) work as Storage here too
+    const Storage raw_min = Storage( one_unit * Storage( MinUnits ) );
+    const Storage raw_max = Storage( one_unit * Storage( MaxUnits ) );
+
+    // exact raw bounds, and one raw step inside each
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( raw_min );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( raw_max );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_min + 1 ) );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_max - 1 ) );
+
+    // whole unit values one unit inside each bound
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( one_unit * Storage( MinUnits + 1 ) ) );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( one_unit * Storage( MaxUnits - 1 ) ) );
+
+    // a value with every fraction bit set
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_min + one_unit - 1 ) );
+
+    // the middle of the range, computed without overflowing the storage type
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_min / 2 + raw_max / 2 ) );
+
+    // zero, one and minus one whole units, where the bounds allow them
+    if ( MinUnits <= 0 && MaxUnits >= 0 )
+    {
+        check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( 0 ) );
+    }
+    if ( MinUnits <= 1 && MaxUnits >= 1 )
+    {
+        check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( one_unit );
+    }
+    if ( MinUnits <= -1 && MaxUnits >= -1 )
+    {
+        check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( Storage( 0 ) - one_unit ) );
+    }
+}
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_rejects_out_of_range( Storage )
+{
+    // recompute the wire parameters independently of the codec, then hand build a stream encoding
+    // an offset of exactly raw_range + 1: one raw step past raw_max, smuggled into the bit headroom
+    const uint64_t raw_range = ( uint64_t( MaxUnits ) << FractionalBits ) - ( uint64_t( MinUnits ) << FractionalBits );
+    const int bits = serialize::bits_required64( 0, raw_range );
+
+    const uint64_t max_encodable = ( bits < 64 ) ? ( ( uint64_t(1) << bits ) - 1 ) : 0xFFFFFFFFFFFFFFFFULL;
+    if ( raw_range == max_encodable )
+    {
+        return;                             // no headroom: every encoding decodes in range for this configuration
+    }
+
+    const uint64_t smuggled = raw_range + 1;
+
+    uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+    serialize::WriteStream writeStream( buffer, 16 );
+    if ( bits <= 32 )
+    {
+        writeStream.SerializeBits( uint32_t( smuggled ), bits );
+    }
+    else
+    {
+        writeStream.SerializeBits( uint32_t( smuggled & 0xFFFFFFFF ), 32 );
+        writeStream.SerializeBits( uint32_t( smuggled >> 32 ), bits - 32 );
+    }
+    writeStream.Flush();
+
+    serialize::ReadStream readStream( buffer, 16 );
+    Storage value = 0;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( readStream, value ) ) == false );
+}
+
+inline void test_serialize_fixed()
+{
+    // the storage x Q format matrix. every configuration runs the full case list in check_fixed_cases:
+    // exact raw bounds, one raw step inside each, whole unit values inside each bound, all fraction
+    // bits set, the middle of the range, and zero / +1.0 / -1.0 units where the bounds allow them.
+
+    // int16_t
+    check_fixed_cases<8, 8, -100, +100>( int16_t( 256 ) );
+    check_fixed_cases<12, 4, -2000, +2000>( int16_t( 16 ) );
+
+    // int32_t
+    check_fixed_cases<16, 16, -30000, +30000>( int32_t( 65536 ) );
+    check_fixed_cases<24, 8, -8000000, +8000000>( int32_t( 256 ) );
+    check_fixed_cases<32, 0, -100000, +100000>( int32_t( 1 ) );                                 // pure integer Q: fraction_bits == 0 is legal
+
+    // int64_t
+    check_fixed_cases<48, 16, -100000000000LL, +100000000000LL>( int64_t( 65536 ) );
+    check_fixed_cases<32, 32, -1000000, +1000000>( int64_t( 1 ) << 32 );
+    check_fixed_cases<64, 0, -5000000000LL, +5000000000LL>( int64_t( 1 ) );                     // pure integer Q at full width
+
+    // unsigned storage
+    check_fixed_cases<16, 0, 0, 60000>( uint16_t( 1 ) );
+    check_fixed_cases<16, 16, 0, 60000>( uint32_t( 65536 ) );
+    check_fixed_cases<48, 16, 0, 1000000000>( uint64_t( 65536 ) );
+
+    // single unit range: the whole wire is the fractional part
+    check_fixed_cases<16, 16, 0, 1>( int32_t( 65536 ) );
+
+    // asymmetric bounds
+    check_fixed_cases<48, 16, -3, +100000>( int64_t( 65536 ) );
+
+    // the wire cost is a compile time constant of the call site. pin a few
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        int64_t value = int64_t( 12345 ) * 65536 + 32768;                                       // 12345.5 in Q48.16
+        serialize_check( ( serialize::serialize_fixed_internal<48, 16, -100000, +100000>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 34 );         // 200000 << 16 raw values needs 34 bits
+    }
+    {
+        uint8_t buffer[8];
+        serialize::WriteStream stream( buffer, 8 );
+        int32_t value = 65536 / 2;                                                              // 0.5 in Q16.16
+        serialize_check( ( serialize::serialize_fixed_internal<16, 16, 0, 1>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 17 );         // 1 << 16 raw values needs 17 bits
+    }
+    {
+        uint8_t buffer[8];
+        serialize::WriteStream stream( buffer, 8 );
+        int16_t value = -832;                                                                   // -3.25 in Q8.8
+        serialize_check( ( serialize::serialize_fixed_internal<8, 8, -100, +100>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 16 );         // 200 << 8 raw values needs 16 bits
+    }
+
+    // compile time refusals. each of the following fails with a static_assert, which is the point.
+    // kept as comments because a compile failure can't run inside the suite: uncomment one to verify.
+    //
+    //     int32_t value = 0;
+    //     serialize::serialize_fixed_internal<16, 8, 0, 100>( stream, value );                 // 16 + 8 != 32: the Q format doesn't fill the storage type
+    //     serialize::serialize_fixed_internal<16, 16, -40000, +40000>( stream, value );        // bounds exceed the Q16.16 whole unit capacity [-32768,32767]
+    //     serialize::serialize_fixed_internal<16, 16, 100, 100>( stream, value );              // min must be below max
+    //     float not_an_integer = 0.0f;
+    //     serialize::serialize_fixed_internal<16, 16, 0, 100>( stream, not_an_integer );       // storage must be an integer type
+    //     int runtime_bound = 100;
+    //     serialize_fixed( stream, value, 16, 16, 0, runtime_bound );                          // bounds must be compile time constants
+}
+
+inline void test_serialize_fixed_validation()
+{
+    // a malicious packet can smuggle a raw value past raw_max into the bit headroom of the offset
+    // encoding. reads must reject one raw step past the top of the range, on every configuration
+    // in the matrix that has headroom.
+    check_fixed_rejects_out_of_range<8, 8, -100, +100>( int16_t( 0 ) );
+    check_fixed_rejects_out_of_range<12, 4, -2000, +2000>( int16_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 16, -30000, +30000>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<24, 8, -8000000, +8000000>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<32, 0, -100000, +100000>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<48, 16, -100000000000LL, +100000000000LL>( int64_t( 0 ) );
+    check_fixed_rejects_out_of_range<32, 32, -1000000, +1000000>( int64_t( 0 ) );
+    check_fixed_rejects_out_of_range<64, 0, -5000000000LL, +5000000000LL>( int64_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 0, 0, 60000>( uint16_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 16, 0, 60000>( uint32_t( 0 ) );
+    check_fixed_rejects_out_of_range<48, 16, 0, 1000000000>( uint64_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 16, 0, 1>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<48, 16, -3, +100000>( int64_t( 0 ) );
+
+    // reads past the end of the buffer must fail cleanly
+    {
+        uint8_t buffer[4 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 2 );
+        int64_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<48, 16, -100000000000LL, +100000000000LL>( readStream, value ) ) == false );
+    }
+}
+
+inline void test_serialize_fixed_matches_int64()
+{
+    // fraction_bits == 0 is pure integer Q, and for storage of 64 bits or fewer the fixed point
+    // wire format is byte identical to serialize_int64 of the raw value over the raw bounds.
+    // sweep values and require identical bytes and identical bit counts: this equivalence binds
+    // the new path to the proven one.
+
+    const int64_t values[] = { -5000000000LL, -4999999999LL, -1, 0, +1, 12345678, 4999999999LL, 5000000000LL };
+
+    for ( int i = 0; i < (int) ( sizeof( values ) / sizeof( values[0] ) ); i++ )
+    {
+        // > 32 bit range: the two group path
+        uint8_t fixed_buffer[16] = { 0 };
+        serialize::WriteStream fixedStream( fixed_buffer, 16 );
+        int64_t fixed_value = values[i];
+        serialize_check( ( serialize::serialize_fixed_internal<64, 0, -5000000000LL, +5000000000LL>( fixedStream, fixed_value ) ) == true );
+        fixedStream.Flush();
+
+        uint8_t int64_buffer[16] = { 0 };
+        serialize::WriteStream int64Stream( int64_buffer, 16 );
+        serialize_check( int64Stream.SerializeInteger64( values[i], -5000000000LL, +5000000000LL ) == true );
+        int64Stream.Flush();
+
+        serialize_check( fixedStream.GetBitsProcessed() == int64Stream.GetBitsProcessed() );
+        serialize_check( memcmp( fixed_buffer, int64_buffer, sizeof( fixed_buffer ) ) == 0 );
+    }
+
+    // <= 32 bit range: the single group path, on 32 bit storage
+    const int32_t narrow_values[] = { -100000, -99999, -1, 0, +1, 54321, 99999, 100000 };
+
+    for ( int i = 0; i < (int) ( sizeof( narrow_values ) / sizeof( narrow_values[0] ) ); i++ )
+    {
+        uint8_t fixed_buffer[16] = { 0 };
+        serialize::WriteStream fixedStream( fixed_buffer, 16 );
+        int32_t fixed_value = narrow_values[i];
+        serialize_check( ( serialize::serialize_fixed_internal<32, 0, -100000, +100000>( fixedStream, fixed_value ) ) == true );
+        fixedStream.Flush();
+
+        uint8_t int64_buffer[16] = { 0 };
+        serialize::WriteStream int64Stream( int64_buffer, 16 );
+        serialize_check( int64Stream.SerializeInteger64( narrow_values[i], -100000, +100000 ) == true );
+        int64Stream.Flush();
+
+        serialize_check( fixedStream.GetBitsProcessed() == int64Stream.GetBitsProcessed() );
+        serialize_check( memcmp( fixed_buffer, int64_buffer, sizeof( fixed_buffer ) ) == 0 );
+    }
+
+    // the equivalence is not limited to fraction_bits == 0: for any Q format the wire is
+    // serialize_int64 of the raw value over the raw bounds. fixed point adds no wire structure,
+    // only the compile time scaling convention.
+    const int32_t q16_16_raw_values[] = { -30000 * 65536, -( 3 * 65536 + 16384 ), 0, 65536 / 2, 12345 * 65536 + 1, 30000 * 65536 };
+
+    for ( int i = 0; i < (int) ( sizeof( q16_16_raw_values ) / sizeof( q16_16_raw_values[0] ) ); i++ )
+    {
+        uint8_t fixed_buffer[16] = { 0 };
+        serialize::WriteStream fixedStream( fixed_buffer, 16 );
+        int32_t fixed_value = q16_16_raw_values[i];
+        serialize_check( ( serialize::serialize_fixed_internal<16, 16, -30000, +30000>( fixedStream, fixed_value ) ) == true );
+        fixedStream.Flush();
+
+        uint8_t int64_buffer[16] = { 0 };
+        serialize::WriteStream int64Stream( int64_buffer, 16 );
+        serialize_check( int64Stream.SerializeInteger64( q16_16_raw_values[i], int64_t( -30000 ) * 65536, int64_t( +30000 ) * 65536 ) == true );
+        int64Stream.Flush();
+
+        serialize_check( fixedStream.GetBitsProcessed() == int64Stream.GetBitsProcessed() );
+        serialize_check( memcmp( fixed_buffer, int64_buffer, sizeof( fixed_buffer ) ) == 0 );
+    }
+}
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_wide_rejects_out_of_range( Storage )
+{
+    // recompute the wire parameters independently of the codec, then hand build a stream encoding
+    // an offset of exactly raw_range + 1: one raw step past raw_max, smuggled into the bit headroom
+    const serialize::uint128_t raw_min = serialize::uint128_t( serialize::int128_t( MinUnits ) ) << FractionalBits;
+    const serialize::uint128_t raw_max = serialize::uint128_t( serialize::int128_t( MaxUnits ) ) << FractionalBits;
+    const serialize::uint128_t raw_range = raw_max - raw_min;
+
+    int bits = 0;
+    for ( serialize::uint128_t x = raw_range; x != 0; x >>= 1 )
+    {
+        bits++;
+    }
+
+    const serialize::uint128_t max_encodable = ( bits < 128 ) ? ( ( serialize::uint128_t( 1 ) << bits ) - 1 ) : ~( serialize::uint128_t( 0 ) );
+    if ( raw_range == max_encodable )
+    {
+        return;                             // no headroom: every encoding decodes in range for this configuration
+    }
+
+    serialize::uint128_t smuggled = raw_range + 1;
+
+    uint8_t buffer[24 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+    serialize::WriteStream writeStream( buffer, 24 );
+    int bits_left = bits;
+    while ( bits_left > 0 )
+    {
+        const int group_bits = ( bits_left < 32 ) ? bits_left : 32;
+        writeStream.SerializeBits( uint32_t( uint64_t( smuggled ) & 0xFFFFFFFF ), group_bits );
+        smuggled >>= group_bits;
+        bits_left -= group_bits;
+    }
+    writeStream.Flush();
+
+    serialize::ReadStream readStream( buffer, 24 );
+    Storage value = 0;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( readStream, value ) ) == false );
+}
+
+inline void test_serialize_fixed_wide()
+{
+#if defined(__SIZEOF_INT128__)
+    // compile time bit counts in the 128 bit domain. the metafunction needs native __int128
+    // template parameters, so these checks are the one native only piece of this test
+    serialize_check( ( serialize::BitsRequired128<0, 0>::result ) == 0 );
+    serialize_check( ( serialize::BitsRequired128<0, 1>::result ) == 1 );
+    serialize_check( ( serialize::BitsRequired128<0, ( serialize::uint128_t( 1 ) << 64 )>::result ) == 65 );
+    serialize_check( ( serialize::BitsRequired128<0, ~( serialize::uint128_t( 0 ) )>::result ) == 128 );
+#endif // #if defined(__SIZEOF_INT128__)
+
+    // the matrix, wide: Q112.16 with a raw range past 64 bits (three groups on the wire), Q112.16
+    // with a small range (a single group on wide storage), Q64.64 (the fraction alone spans 64 bits),
+    // Q64.64 over the full unit range (128 bits on the wire, four groups), and the unsigned wide case.
+    check_fixed_cases<112, 16, -1152921504606846976LL, +1152921504606846976LL>( serialize::int128_t( 65536 ) );     // ±2^60 units: 78 bits on the wire
+    check_fixed_cases<112, 16, -2, +2>( serialize::int128_t( 65536 ) );
+    check_fixed_cases<64, 64, -1000, +1000>( serialize::int128_t( 1 ) << 64 );
+    check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( serialize::int128_t( 1 ) << 64 );                              // full unit range: 128 bits on the wire
+    check_fixed_cases<112, 16, 0, 2305843009213693952LL>( serialize::uint128_t( 65536 ) );                          // 2^61 units, unsigned
+
+    // the 33..64 bit two group band on wide storage: both boundaries exactly, plus the example's
+    // own Q112.16 ±1e11 shape (54 bits), which used to live only in example.cpp and not in CI
+    check_fixed_cases<112, 16, -32768, +32768>( serialize::int128_t( 65536 ) );                                     // 33 bits: the band's low edge
+    check_fixed_cases<112, 16, -100000000000LL, +100000000000LL>( serialize::int128_t( 65536 ) );                   // 54 bits: the example's shape
+    check_fixed_cases<112, 16, -140737488355328LL, +140737488355327LL>( serialize::int128_t( 65536 ) );             // 64 bits: the band's high edge
+
+    // the wire cost is a compile time constant of the call site, wide paths included. pin a few
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = serialize::int128_t( 12345 ) * 65536;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 78 );         // 2^61 << 16 raw values needs 78 bits
+    }
+    {
+        uint8_t buffer[24];
+        serialize::WriteStream stream( buffer, 24 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<64, 64, INT64_MIN, INT64_MAX>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 128 );        // the full unit range costs the full storage width
+    }
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = serialize::int128_t( 12345678901LL ) * serialize::int128_t( 65536 );
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -100000000000LL, +100000000000LL>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 54 );         // the example's shape: 2e11 << 16 raw values needs 54 bits, inside the two group band
+    }
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -32768, +32768>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 33 );         // the band's low edge
+    }
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -140737488355328LL, +140737488355327LL>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 64 );         // the band's high edge
+    }
+
+    // one raw step past raw_max must be rejected on read, through every group structure —
+    // the 33..64 bit two group band included
+    check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -2, +2>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( serialize::uint128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -32768, +32768>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -100000000000LL, +100000000000LL>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -140737488355328LL, +140737488355327LL>( serialize::int128_t( 0 ) );
+
+    // reads past the end of the buffer must fail cleanly
+    {
+        uint8_t buffer[4 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 4 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( readStream, value ) ) == false );
+    }
+}
+
+inline void test_serialize_fixed_wide_emulated()
+{
+    // the wide codec is representation generic: the emulated 128 bit pair works as storage, which
+    // is what makes wide fixed point available on compilers without native __int128. run the wide
+    // case list through the emulated types explicitly, on every platform — where native exists
+    // this doubles as proof that both representations drive the same codec.
+    check_fixed_cases<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -2, +2>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<64, 64, -1000, +1000>( ::serialize_int128_t( 1 ) << 64 );
+    check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( ::serialize_int128_t( 1 ) << 64 );
+    check_fixed_cases<112, 16, 0, 2305843009213693952LL>( ::serialize_uint128_t( 65536 ) );
+
+    // the 33..64 bit two group band on emulated wide storage: both boundaries and the example's shape
+    check_fixed_cases<112, 16, -32768, +32768>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -100000000000LL, +100000000000LL>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -140737488355328LL, +140737488355327LL>( ::serialize_int128_t( 65536 ) );
+
+    // one raw step past raw_max must be rejected through the emulated read path too
+    check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( ::serialize_uint128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -32768, +32768>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -100000000000LL, +100000000000LL>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -140737488355328LL, +140737488355327LL>( ::serialize_int128_t( 0 ) );
+
+#if defined(__SIZEOF_INT128__)
+    // cross representation wire identity: native and emulated storage must produce byte identical
+    // wire through the same configuration, and each must read the other's bytes back exactly
+    {
+        const int64_t raw = -( int64_t( 54321 ) * 65536 + 12345 );
+
+        uint8_t native_buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+        serialize::WriteStream nativeStream( native_buffer, 16 );
+        serialize::int128_t native_value = raw;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( nativeStream, native_value ) ) == true );
+        nativeStream.Flush();
+
+        uint8_t emulated_buffer[16 + 8] = { 0 };
+        serialize::WriteStream emulatedStream( emulated_buffer, 16 );
+        ::serialize_int128_t emulated_value( raw );
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( emulatedStream, emulated_value ) ) == true );
+        emulatedStream.Flush();
+
+        serialize_check( nativeStream.GetBitsProcessed() == emulatedStream.GetBitsProcessed() );
+        serialize_check( memcmp( native_buffer, emulated_buffer, 16 ) == 0 );
+
+        // read the native bytes back through emulated storage
+        serialize::ReadStream readStream( native_buffer, nativeStream.GetBytesProcessed() );
+        ::serialize_int128_t read_back( 0 );
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( readStream, read_back ) ) == true );
+        serialize_check( read_back == ::serialize_int128_t( raw ) );
+    }
+#endif // #if defined(__SIZEOF_INT128__)
+}
+
+inline void test_serialize_uint128()
+{
+    // round trips across the value patterns: zero, max, each half alone, alternating bits, distinct halves
+    {
+        const serialize::uint128_t values[] = {
+            0,
+            ~( serialize::uint128_t( 0 ) ),
+            serialize::uint128_t( 0xFFFFFFFFFFFFFFFFULL ) << 64,                                // high half only
+            serialize::uint128_t( 0xFFFFFFFFFFFFFFFFULL ),                                      // low half only
+            ( serialize::uint128_t( 0xAAAAAAAAAAAAAAAAULL ) << 64 ) | 0x5555555555555555ULL,    // alternating bits
+            ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL,    // distinct halves
+        };
+
+        for ( int i = 0; i < (int) ( sizeof( values ) / sizeof( values[0] ) ); i++ )
+        {
+            uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+            serialize::WriteStream writeStream( buffer, 16 );
+            serialize::uint128_t written = values[i];
+            serialize_check( serialize::serialize_uint128_internal( writeStream, written ) == true );
+            writeStream.Flush();
+
+            serialize::MeasureStream measureStream;
+            serialize::uint128_t measured = values[i];
+            serialize_check( serialize::serialize_uint128_internal( measureStream, measured ) == true );
+            serialize_check( measureStream.GetBitsProcessed() == writeStream.GetBitsProcessed() );
+            serialize_check( writeStream.GetBitsProcessed() == 128 );
+
+            serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+            serialize::uint128_t read_back = 0;
+            serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
+            serialize_check( read_back == values[i] );
+        }
+    }
+
+    // cross form consistency: serialize_uint128 must be byte identical to two serialize_uint64
+    // operations on the halves, low half first. this is the portability story: an implementation
+    // without a 128 bit type reproduces the wire exactly with two 64 bit operations.
+    {
+        const uint64_t low_half = 0xFEDCBA9876543210ULL;
+        const uint64_t high_half = 0x0123456789ABCDEFULL;
+
+        uint8_t uint128_buffer[16 + 8] = { 0 };
+        serialize::WriteStream uint128Stream( uint128_buffer, 16 );
+        serialize::uint128_t value = ( serialize::uint128_t( high_half ) << 64 ) | low_half;
+        serialize_check( serialize::serialize_uint128_internal( uint128Stream, value ) == true );
+        uint128Stream.Flush();
+
+        uint8_t halves_buffer[16 + 8] = { 0 };
+        serialize::WriteStream halvesStream( halves_buffer, 16 );
+        write_uint64( halvesStream, low_half );
+        write_uint64( halvesStream, high_half );
+        halvesStream.Flush();
+
+        serialize_check( uint128Stream.GetBitsProcessed() == halvesStream.GetBitsProcessed() );
+        serialize_check( memcmp( uint128_buffer, halves_buffer, 16 ) == 0 );
+    }
+
+    // golden pin: the wire format for a uint128 is its 16 bytes in little endian order, low half
+    // first. pinned forever. additive: the pre-existing golden test below is untouched, and this
+    // pin runs on every platform — serialize::uint128_t exists everywhere, so the native and
+    // emulated representations must both reproduce exactly these bytes.
+    {
+        static const uint8_t golden_uint128_bytes[] =
+        {
+            0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE,
+            0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01
+        };
+
+        const serialize::uint128_t golden_value = ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL;
+
+        uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        serialize::uint128_t written = golden_value;
+        serialize_check( serialize::serialize_uint128_internal( writeStream, written ) == true );
+        writeStream.Flush();
+        serialize_check( writeStream.GetBytesProcessed() == 16 );
+        serialize_check( memcmp( buffer, golden_uint128_bytes, 16 ) == 0 );
+
+        memcpy( buffer, golden_uint128_bytes, 16 );
+        serialize::ReadStream readStream( buffer, 16 );
+        serialize::uint128_t read_back = 0;
+        serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
+        serialize_check( read_back == golden_value );
+    }
+}
+
+inline void test_serialize_int128()
+{
+    typedef serialize::int128_t i128;
+
+    // 1. WIRE IDENTITY WITH serialize_int64 wherever the range fits 64 bits. this is what lets a
+    //    schema widen a field without a wire change, so it is pinned by memcmp rather than assumed.
+    {
+        const int64_t min64 = -5000000000LL;
+        const int64_t max64 = +5000000000LL;
+        const int64_t values[] = { min64, min64 + 1, -1, 0, +1, 4123456789LL, max64 - 1, max64 };
+
+        for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+        {
+            uint8_t buffer128[32 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+            uint8_t buffer64[32 + 8] = { 0 };
+
+            serialize::WriteStream w128( buffer128, 32 );
+            serialize_check( w128.SerializeInteger128( i128( values[i] ), i128( min64 ), i128( max64 ) ) == true );
+            w128.Flush();
+
+            serialize::WriteStream w64( buffer64, 32 );
+            serialize_check( w64.SerializeInteger64( values[i], min64, max64 ) == true );
+            w64.Flush();
+
+            serialize_check( w128.GetBitsProcessed() == w64.GetBitsProcessed() );
+            serialize_check( w128.GetBytesProcessed() == w64.GetBytesProcessed() );
+            serialize_check( memcmp( buffer128, buffer64, (size_t) w64.GetBytesProcessed() ) == 0 );
+
+            serialize::ReadStream readStream( buffer128, 32 );
+            i128 read_back = 0;
+            serialize_check( readStream.SerializeInteger128( read_back, i128( min64 ), i128( max64 ) ) == true );
+            serialize_check( read_back == i128( values[i] ) );
+        }
+    }
+
+    // 2. the wide bands the 64 bit path cannot express at all: three group and four group ranges,
+    //    including the widest possible range, which exercises the fourth group and the unsigned
+    //    domain subtraction that a signed one would overflow
+    {
+        const i128 wide_min = -( i128( 1 ) << 100 );
+        const i128 wide_max =  ( i128( 1 ) << 100 );
+        const i128 values[] = { wide_min, wide_min + 1, i128( -1 ), i128( 0 ), i128( 1 ), ( i128( 1 ) << 99 ), wide_max - 1, wide_max };
+
+        for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+        {
+            uint8_t buffer[32 + 8] = { 0 };
+
+            serialize::WriteStream writeStream( buffer, 32 );
+            serialize_check( writeStream.SerializeInteger128( values[i], wide_min, wide_max ) == true );
+            writeStream.Flush();
+            serialize_check( writeStream.GetBitsProcessed() == 102 );        // bits_required128( -2^100, 2^100 ) == 102
+
+            serialize::ReadStream readStream( buffer, 32 );
+            i128 read_back = 0;
+            serialize_check( readStream.SerializeInteger128( read_back, wide_min, wide_max ) == true );
+            serialize_check( read_back == values[i] );
+        }
+    }
+
+    // 3. the full 128 bit range: every group full, and the range is wider than 2^127
+    {
+        const i128 full_min = i128( ( serialize::uint128_t( 1 ) << 127 ) );                  // INT128_MIN
+        const i128 full_max = i128( ~( serialize::uint128_t( 1 ) << 127 ) );                 // INT128_MAX
+        const i128 values[] = { full_min, full_min + 1, i128( -1 ), i128( 0 ), i128( 1 ), full_max - 1, full_max };
+
+        for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+        {
+            uint8_t buffer[32 + 8] = { 0 };
+
+            serialize::WriteStream writeStream( buffer, 32 );
+            serialize_check( writeStream.SerializeInteger128( values[i], full_min, full_max ) == true );
+            writeStream.Flush();
+            serialize_check( writeStream.GetBitsProcessed() == 128 );
+
+            serialize::ReadStream readStream( buffer, 32 );
+            i128 read_back = 0;
+            serialize_check( readStream.SerializeInteger128( read_back, full_min, full_max ) == true );
+            serialize_check( read_back == values[i] );
+        }
+    }
+
+    // 4. the measure stream must agree with the write stream exactly, at every group width
+    {
+        const i128 cases[][3] =
+        {
+            { i128( 0 ), i128( 0 ), i128( 255 ) },
+            { i128( 7 ), i128( -5000000000LL ), i128( +5000000000LL ) },
+            { i128( 1 ), -( i128( 1 ) << 100 ), ( i128( 1 ) << 100 ) },
+            { i128( 0 ), i128( ( serialize::uint128_t( 1 ) << 127 ) ), i128( ~( serialize::uint128_t( 1 ) << 127 ) ) },
+        };
+
+        for ( int i = 0; i < (int) ( sizeof(cases) / sizeof(cases[0]) ); i++ )
+        {
+            uint8_t buffer[32 + 8] = { 0 };
+
+            serialize::WriteStream writeStream( buffer, 32 );
+            serialize_check( writeStream.SerializeInteger128( cases[i][0], cases[i][1], cases[i][2] ) == true );
+            writeStream.Flush();
+
+            serialize::MeasureStream measureStream;
+            serialize_check( measureStream.SerializeInteger128( cases[i][0], cases[i][1], cases[i][2] ) == true );
+            serialize_check( measureStream.GetBitsProcessed() == writeStream.GetBitsProcessed() );
+        }
+    }
+
+    // 5. a value outside the bounds must be REFUSED on read. the bit count is identical for both
+    //    bound pairs here, so the reader consumes the same bits and the range check is what
+    //    convicts it — proving the refusal, not just the absence of a crash
+    {
+        uint8_t buffer[32 + 8] = { 0 };
+
+        serialize::WriteStream writeStream( buffer, 32 );
+        serialize_check( writeStream.SerializeInteger128( i128( 255 ), i128( 0 ), i128( 255 ) ) == true );
+        writeStream.Flush();
+
+        serialize_check( serialize::bits_required128( serialize::uint128_t( 0 ), serialize::uint128_t( 200 ) ) == 8 );
+
+        serialize::ReadStream readStream( buffer, 32 );
+        i128 read_back = 0;
+        serialize_check( readStream.SerializeInteger128( read_back, i128( 0 ), i128( 200 ) ) == false );
+    }
+
+    // 6. a truncated buffer must be refused rather than read past the end
+    {
+        uint8_t buffer[32 + 8] = { 0 };
+
+        serialize::ReadStream readStream( buffer, 4 );          // 32 bits available, 128 required
+        i128 read_back = 0;
+        serialize_check( readStream.SerializeInteger128( read_back, i128( ( serialize::uint128_t( 1 ) << 127 ) ), i128( ~( serialize::uint128_t( 1 ) << 127 ) ) ) == false );
+    }
+
+    // 7. THE GOLDEN PIN, and its bytes were derived from STANDARD.md's stated rule in the
+    //    conformance checker's language, not read back out of this implementation — so this
+    //    memcmp is the document and the code agreeing, rather than the code agreeing with itself.
+    //    Bounds of +/- 2^70 need 72 bits, which is the THREE GROUP structure: 32, 32, then 8.
+    {
+        static const uint8_t golden_int128_bytes[] =
+        {
+            0x11, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE,
+            0x3F, 0x00, 0x00, 0x00
+        };
+
+        const i128 golden_min = -( i128( 1 ) << 70 );
+        const i128 golden_max =  ( i128( 1 ) << 70 );
+        const i128 golden_value = -( i128( 0x0123456789ABCDEFLL ) );
+
+        uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        serialize_check( writeStream.SerializeInteger128( golden_value, golden_min, golden_max ) == true );
+        writeStream.Flush();
+        serialize_check( writeStream.GetBitsProcessed() == 72 );
+        serialize_check( memcmp( buffer, golden_int128_bytes, sizeof( golden_int128_bytes ) ) == 0 );
+
+        memcpy( buffer, golden_int128_bytes, sizeof( golden_int128_bytes ) );
+        serialize::ReadStream readStream( buffer, 16 );
+        i128 read_back = 0;
+        serialize_check( readStream.SerializeInteger128( read_back, golden_min, golden_max ) == true );
+        serialize_check( read_back == golden_value );
+    }
+}
+
+// builds an emulated 128 bit value from its two lanes. the emulated type is defined on every
+// platform when tests are enabled — where native __int128 exists it coexists with it, so the
+// tests below run everywhere and the differential test can compare the two representations.
+
+inline ::serialize_uint128_t uint128_emulated( uint64_t hi, uint64_t lo )
+{
+    ::serialize_uint128_t result( lo );
+    result.hi = hi;
+    return result;
+}
+
+inline void test_uint128_emulation()
+{
+    // known answer checks for the emulated 128 bit unsigned integer, unguarded so they run on
+    // every platform — including the ones with no native __int128, where the emulation is the
+    // only implementation and the differential test below cannot run.
+
+    const uint64_t lo = 0xFEDCBA9876543210ULL;
+    const uint64_t hi = 0x0123456789ABCDEFULL;
+
+    // construction from uint64_t fills the low lane. explicit conversion truncates back to it
+    {
+        ::serialize_uint128_t value( lo );
+        serialize_check( value.lo == lo && value.hi == 0 );
+        serialize_check( uint64_t( value ) == lo );
+        serialize_check( uint64_t( uint128_emulated( hi, lo ) ) == lo );
+    }
+
+    // construction from every standard integer type mirrors native conversion: signed sources
+    // sign extend (negatives wrap modulo 2^128), unsigned sources zero extend. these are the
+    // exact cross signed cases that diverged before the per-type constructors existed.
+    {
+        serialize_check( ::serialize_uint128_t( int64_t( -1 ) ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_uint128_t( INT64_MIN ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_uint128_t( uint64_t( 1 ) << 63 ) == uint128_emulated( 0, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_uint128_t( UINT64_MAX ) == uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_uint128_t( -5 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );       // int: sign extends
+        serialize_check( ::serialize_uint128_t( 3000000000U ) == uint128_emulated( 0, 3000000000ULL ) );                          // unsigned: zero extends
+        serialize_check( ::serialize_uint128_t( int64_t( 7 ) ) == uint128_emulated( 0, 7 ) );                                     // non negative signed: zero high lane
+    }
+
+    // all six comparisons, driven by the high lane, the low lane, and equality
+    {
+        const ::serialize_uint128_t a = uint128_emulated( 1, 0 );
+        const ::serialize_uint128_t b = uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );
+        const ::serialize_uint128_t c = uint128_emulated( 1, 1 );
+        serialize_check( a > b );                                       // the high lane dominates
+        serialize_check( b < a );
+        serialize_check( c > a );                                       // the low lane breaks ties
+        serialize_check( a >= b && a <= a && a >= a );
+        serialize_check( b <= a && b != a && a == a );
+        serialize_check( !( a < b ) && !( a == b ) && !( a != a ) );
+    }
+
+    // left shift edges: 0, 1, 63, 64, 65, 127, and out of range counts
+    {
+        const ::serialize_uint128_t value = uint128_emulated( hi, lo );
+        serialize_check( ( value << 0 ) == value );
+        serialize_check( ( value << 1 ) == uint128_emulated( ( hi << 1 ) | ( lo >> 63 ), lo << 1 ) );
+        serialize_check( ( value << 63 ) == uint128_emulated( ( hi << 63 ) | ( lo >> 1 ), lo << 63 ) );
+        serialize_check( ( value << 64 ) == uint128_emulated( lo, 0 ) );                    // the low lane becomes the high lane
+        serialize_check( ( value << 65 ) == uint128_emulated( lo << 1, 0 ) );
+        serialize_check( ( value << 127 ) == uint128_emulated( lo << 63, 0 ) );
+        serialize_check( ( value << 128 ) == ::serialize_uint128_t( 0 ) );                        // >= 128 yields zero, documented
+        serialize_check( ( value << 200 ) == ::serialize_uint128_t( 0 ) );
+    }
+
+    // right shift edges: the mirror image
+    {
+        const ::serialize_uint128_t value = uint128_emulated( hi, lo );
+        serialize_check( ( value >> 0 ) == value );
+        serialize_check( ( value >> 1 ) == uint128_emulated( hi >> 1, ( lo >> 1 ) | ( hi << 63 ) ) );
+        serialize_check( ( value >> 63 ) == uint128_emulated( hi >> 63, ( lo >> 63 ) | ( hi << 1 ) ) );
+        serialize_check( ( value >> 64 ) == uint128_emulated( 0, hi ) );                    // the high lane becomes the low lane
+        serialize_check( ( value >> 65 ) == uint128_emulated( 0, hi >> 1 ) );
+        serialize_check( ( value >> 127 ) == uint128_emulated( 0, hi >> 63 ) );
+        serialize_check( ( value >> 128 ) == ::serialize_uint128_t( 0 ) );                        // >= 128 yields zero, documented
+        serialize_check( ( value >> 200 ) == ::serialize_uint128_t( 0 ) );
+    }
+
+    // addition carries out of the low lane, subtraction borrows back into it
+    {
+        const ::serialize_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
+        const ::serialize_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( max64 + ::serialize_uint128_t( 1 ) == uint128_emulated( 1, 0 ) );        // carry
+        serialize_check( all_ones + ::serialize_uint128_t( 1 ) == ::serialize_uint128_t( 0 ) );         // wraps modulo 2^128
+        serialize_check( ::serialize_uint128_t( 0 ) - ::serialize_uint128_t( 1 ) == all_ones );         // borrow wraps back
+        serialize_check( uint128_emulated( 1, 0 ) - ::serialize_uint128_t( 1 ) == max64 );        // borrow out of the high lane
+
+        ::serialize_uint128_t accumulator( 0xFFFFFFFFFFFFFFFFULL );
+        accumulator += ::serialize_uint128_t( 1 );
+        serialize_check( accumulator == uint128_emulated( 1, 0 ) );
+        accumulator -= ::serialize_uint128_t( 1 );
+        serialize_check( accumulator == max64 );
+    }
+
+    // increment and decrement, both forms, across the lane boundary
+    {
+        ::serialize_uint128_t value( 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( value++ == ::serialize_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );             // post returns the value before
+        serialize_check( value == uint128_emulated( 1, 0 ) );
+        serialize_check( ++value == uint128_emulated( 1, 1 ) );                             // pre returns the value after
+        serialize_check( value-- == uint128_emulated( 1, 1 ) );
+        serialize_check( --value == ::serialize_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );
+    }
+
+    // multiplication: lane crossing products with known answers
+    {
+        const ::serialize_uint128_t two_to_32( uint64_t( 1 ) << 32 );
+        const ::serialize_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
+        const ::serialize_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::serialize_uint128_t( 3 ) * ::serialize_uint128_t( 5 ) == ::serialize_uint128_t( 15 ) );
+        serialize_check( two_to_32 * two_to_32 == uint128_emulated( 1, 0 ) );                                       // 2^64 crosses into the high lane
+        serialize_check( max64 * max64 == uint128_emulated( 0xFFFFFFFFFFFFFFFEULL, 1 ) );                           // 2^128 - 2^65 + 1
+        serialize_check( uint128_emulated( 1, 0 ) * ::serialize_uint128_t( 5 ) == uint128_emulated( 5, 0 ) );             // the high lane path
+        serialize_check( all_ones * all_ones == ::serialize_uint128_t( 1 ) );                                             // ( 2^128 - 1 )^2 mod 2^128
+
+        ::serialize_uint128_t accumulator( 3 );
+        accumulator *= ::serialize_uint128_t( 5 );
+        serialize_check( accumulator == ::serialize_uint128_t( 15 ) );
+    }
+
+    // division and modulo: the small fast path, wide dividends, wide divisors, and the
+    // TOTALITY of division by zero — the operation is undefined and these pin only that it
+    // returns rather than traps, never that the value is a contract
+    {
+        const ::serialize_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::serialize_uint128_t( 100 ) / ::serialize_uint128_t( 7 ) == ::serialize_uint128_t( 14 ) );
+        serialize_check( ::serialize_uint128_t( 100 ) % ::serialize_uint128_t( 7 ) == ::serialize_uint128_t( 2 ) );
+        serialize_check( uint128_emulated( 1, 7 ) / ::serialize_uint128_t( 16 ) == ::serialize_uint128_t( uint64_t( 1 ) << 60 ) );      // 2^64 + 7 over 16
+        serialize_check( uint128_emulated( 1, 7 ) % ::serialize_uint128_t( 16 ) == ::serialize_uint128_t( 7 ) );
+        serialize_check( uint128_emulated( uint64_t( 1 ) << 63, 0 ) / uint128_emulated( 1, 0 ) == ::serialize_uint128_t( uint64_t( 1 ) << 63 ) );     // 2^127 over 2^64
+        serialize_check( all_ones / ::serialize_uint128_t( 3 ) == uint128_emulated( 0x5555555555555555ULL, 0x5555555555555555ULL ) );
+        serialize_check( all_ones % ::serialize_uint128_t( 3 ) == ::serialize_uint128_t( 0 ) );
+        serialize_check( ::serialize_uint128_t( 7 ) / uint128_emulated( 1, 0 ) == ::serialize_uint128_t( 0 ) );                 // dividend below divisor
+        serialize_check( ::serialize_uint128_t( 7 ) % uint128_emulated( 1, 0 ) == ::serialize_uint128_t( 7 ) );
+        serialize_check( all_ones / ::serialize_uint128_t( 0 ) == ::serialize_uint128_t( 0 ) );                                 // by zero is UNDEFINED: this pins totality, not a value contract
+        serialize_check( all_ones % ::serialize_uint128_t( 0 ) == ::serialize_uint128_t( 0 ) );
+
+        ::serialize_uint128_t accumulator( 100 );
+        accumulator /= ::serialize_uint128_t( 7 );
+        serialize_check( accumulator == ::serialize_uint128_t( 14 ) );
+        accumulator = ::serialize_uint128_t( 100 );
+        accumulator %= ::serialize_uint128_t( 7 );
+        serialize_check( accumulator == ::serialize_uint128_t( 2 ) );
+    }
+
+    // bitwise operators work lane by lane
+    {
+        const ::serialize_uint128_t a = uint128_emulated( 0xF0F0F0F0F0F0F0F0ULL, 0xAAAAAAAAAAAAAAAAULL );
+        const ::serialize_uint128_t b = uint128_emulated( 0xFF00FF00FF00FF00ULL, 0xCCCCCCCCCCCCCCCCULL );
+        serialize_check( ( a & b ) == uint128_emulated( 0xF000F000F000F000ULL, 0x8888888888888888ULL ) );
+        serialize_check( ( a | b ) == uint128_emulated( 0xFFF0FFF0FFF0FFF0ULL, 0xEEEEEEEEEEEEEEEEULL ) );
+        serialize_check( ( a ^ b ) == uint128_emulated( 0x0FF00FF00FF00FF0ULL, 0x6666666666666666ULL ) );
+        serialize_check( ~a == uint128_emulated( 0x0F0F0F0F0F0F0F0FULL, 0x5555555555555555ULL ) );
+
+        ::serialize_uint128_t accumulator = a;
+        accumulator &= b;
+        serialize_check( accumulator == ( a & b ) );
+        accumulator = a;
+        accumulator |= b;
+        serialize_check( accumulator == ( a | b ) );
+        accumulator = a;
+        accumulator ^= b;
+        serialize_check( accumulator == ( a ^ b ) );
+        accumulator = a;
+        accumulator <<= 64;
+        serialize_check( accumulator == ( a << 64 ) );
+        accumulator = a;
+        accumulator >>= 64;
+        serialize_check( accumulator == ( a >> 64 ) );
+    }
+
+    // unary plus is the identity, unary minus is two's complement negation
+    {
+        const ::serialize_uint128_t value = uint128_emulated( hi, lo );
+        serialize_check( +value == value );
+        serialize_check( -::serialize_uint128_t( 0 ) == ::serialize_uint128_t( 0 ) );
+        serialize_check( -::serialize_uint128_t( 1 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( -value + value == ::serialize_uint128_t( 0 ) );
+    }
+}
+
+inline ::serialize_int128_t int128_emulated( uint64_t hi, uint64_t lo )
+{
+    ::serialize_int128_t result( 0 );
+    result.hi = hi;
+    result.lo = lo;
+    return result;
+}
+
+inline void test_int128_emulation()
+{
+    // known answer checks for the emulated signed 128 bit integer, unguarded so they run on every
+    // platform. the signed type is a thin two's complement layer over the unsigned lanes, so these
+    // concentrate on the signed specific pieces: sign extension, signed ordering, the arithmetic
+    // right shift, division sign quadrants, and the documented edge choices.
+
+    const ::serialize_int128_t int128_min = int128_emulated( 0x8000000000000000ULL, 0 );
+    const ::serialize_int128_t int128_max = int128_emulated( 0x7FFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+
+    // the int64_t constructor sign extends into the high lane; the explicit conversion truncates
+    // back to the low lane; the unsigned conversions preserve the bit pattern both ways
+    {
+        serialize_check( ::serialize_int128_t( -1 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_int128_t( INT64_MIN ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_int128_t( INT64_MAX ) == int128_emulated( 0, 0x7FFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_int128_t( 1 ) == int128_emulated( 0, 1 ) );
+        serialize_check( int64_t( ::serialize_int128_t( -5 ) ) == -5 );
+        serialize_check( int64_t( ::serialize_int128_t( INT64_MIN ) ) == INT64_MIN );
+
+        // unsigned sources are value preserving with a zero high lane, exactly like native: a
+        // uint64 with the top bit set stays a large positive value, it does NOT wrap negative.
+        // these are the exact cross signed cases that diverged before the per-type constructors.
+        serialize_check( ::serialize_int128_t( uint64_t( 1 ) << 63 ) == int128_emulated( 0, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_int128_t( uint64_t( 1 ) << 63 ) > ::serialize_int128_t( 0 ) );
+        serialize_check( ::serialize_int128_t( UINT64_MAX ) == int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_int128_t( UINT64_MAX ) > ::serialize_int128_t( 0 ) );
+        serialize_check( ::serialize_int128_t( -5 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );     // int: sign extends
+        serialize_check( ::serialize_int128_t( 3000000000U ) == int128_emulated( 0, 3000000000ULL ) );                        // unsigned: zero extends
+
+        const ::serialize_uint128_t bit_pattern = ::serialize_uint128_t( ::serialize_int128_t( -1 ) );
+        serialize_check( bit_pattern.lo == 0xFFFFFFFFFFFFFFFFULL && bit_pattern.hi == 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::serialize_int128_t( bit_pattern ) == ::serialize_int128_t( -1 ) );
+    }
+
+    // signed ordering: negatives below positives, the high lane compares signed, the low lane
+    // breaks ties unsigned
+    {
+        serialize_check( ::serialize_int128_t( -1 ) < ::serialize_int128_t( 0 ) );
+        serialize_check( ::serialize_int128_t( 0 ) < ::serialize_int128_t( 1 ) );
+        serialize_check( int128_min < ::serialize_int128_t( INT64_MIN ) );
+        serialize_check( int128_min < ::serialize_int128_t( -1 ) );
+        serialize_check( int128_max > ::serialize_int128_t( INT64_MAX ) );
+        serialize_check( int128_min < int128_max );
+        serialize_check( int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 5 ) < int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 7 ) );       // low lane tiebreak among negatives
+        serialize_check( ::serialize_int128_t( -3 ) <= ::serialize_int128_t( -3 ) && ::serialize_int128_t( -3 ) >= ::serialize_int128_t( -3 ) );
+        serialize_check( ::serialize_int128_t( -3 ) != ::serialize_int128_t( 3 ) );
+        serialize_check( !( ::serialize_int128_t( 1 ) < ::serialize_int128_t( -1 ) ) );
+    }
+
+    // addition, subtraction and multiplication with mixed signs, and the documented wrap
+    {
+        serialize_check( ::serialize_int128_t( -3 ) + ::serialize_int128_t( 5 ) == ::serialize_int128_t( 2 ) );
+        serialize_check( ::serialize_int128_t( 3 ) - ::serialize_int128_t( 5 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ::serialize_int128_t( -3 ) * ::serialize_int128_t( 5 ) == ::serialize_int128_t( -15 ) );
+        serialize_check( ::serialize_int128_t( -3 ) * ::serialize_int128_t( -5 ) == ::serialize_int128_t( 15 ) );
+        serialize_check( int128_max + ::serialize_int128_t( 1 ) == int128_min );                          // wraps two's complement, documented
+        serialize_check( int128_min - ::serialize_int128_t( 1 ) == int128_max );
+        serialize_check( ::serialize_int128_t( INT64_MAX ) * ::serialize_int128_t( 4 ) == int128_emulated( 1, 0xFFFFFFFFFFFFFFFCULL ) );        // crosses the lane boundary
+    }
+
+    // the arithmetic right shift fills with the sign: edges 0, 1, 63, 64, 65, 127 and out of range
+    {
+        serialize_check( ( int128_min >> 0 ) == int128_min );
+        serialize_check( ( int128_min >> 1 ) == int128_emulated( 0xC000000000000000ULL, 0 ) );
+        serialize_check( ( int128_min >> 63 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );                             // -2^64
+        serialize_check( ( int128_min >> 64 ) == ::serialize_int128_t( INT64_MIN ) );
+        serialize_check( ( int128_min >> 65 ) == ::serialize_int128_t( INT64_MIN / 2 ) );
+        serialize_check( ( int128_min >> 127 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( int128_min >> 128 ) == ::serialize_int128_t( -1 ) );                           // all sign bits, documented
+        serialize_check( ( int128_min >> 200 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( ::serialize_int128_t( -7 ) >> 1 ) == ::serialize_int128_t( -4 ) );                   // arithmetic shift rounds toward negative infinity
+        serialize_check( ( int128_max >> 127 ) == ::serialize_int128_t( 0 ) );
+        serialize_check( ( int128_max >> 128 ) == ::serialize_int128_t( 0 ) );                            // non negative: sign fill is zero
+        serialize_check( ( ( ::serialize_int128_t( 1 ) << 100 ) >> 100 ) == ::serialize_int128_t( 1 ) );
+    }
+
+    // the left shift moves the bit pattern like hardware: negative values included
+    {
+        serialize_check( ( ::serialize_int128_t( -1 ) << 1 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ( ::serialize_int128_t( -1 ) << 64 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );
+        serialize_check( ( ::serialize_int128_t( 1 ) << 127 ) == int128_min );
+        serialize_check( ( ::serialize_int128_t( -1 ) << 128 ) == ::serialize_int128_t( 0 ) );                  // out of range yields zero, documented
+    }
+
+    // division and modulo: all four sign quadrants, truncation toward zero, the remainder sign
+    // follows the dividend, and the documented edge choices
+    {
+        serialize_check( ::serialize_int128_t( 7 ) / ::serialize_int128_t( 3 ) == ::serialize_int128_t( 2 ) );
+        serialize_check( ::serialize_int128_t( 7 ) % ::serialize_int128_t( 3 ) == ::serialize_int128_t( 1 ) );
+        serialize_check( ::serialize_int128_t( -7 ) / ::serialize_int128_t( 3 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ::serialize_int128_t( -7 ) % ::serialize_int128_t( 3 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ::serialize_int128_t( 7 ) / ::serialize_int128_t( -3 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ::serialize_int128_t( 7 ) % ::serialize_int128_t( -3 ) == ::serialize_int128_t( 1 ) );
+        serialize_check( ::serialize_int128_t( -7 ) / ::serialize_int128_t( -3 ) == ::serialize_int128_t( 2 ) );
+        serialize_check( ::serialize_int128_t( -7 ) % ::serialize_int128_t( -3 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ::serialize_int128_t( -1 ) / ::serialize_int128_t( 2 ) == ::serialize_int128_t( 0 ) );       // truncation toward zero, not the floor
+        serialize_check( ::serialize_int128_t( -1 ) % ::serialize_int128_t( 2 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( int128_min / ::serialize_int128_t( 2 ) == int128_emulated( 0xC000000000000000ULL, 0 ) );
+        serialize_check( int128_min / ::serialize_int128_t( 1 ) == int128_min );
+        serialize_check( int128_min / ::serialize_int128_t( -1 ) == int128_min );                         // the one overflowing case wraps, documented
+        serialize_check( int128_min % ::serialize_int128_t( -1 ) == ::serialize_int128_t( 0 ) );
+        serialize_check( int128_max / ::serialize_int128_t( 0 ) == ::serialize_int128_t( 0 ) );                 // by zero is UNDEFINED: this pins totality, not a value contract
+        serialize_check( int128_max % ::serialize_int128_t( 0 ) == ::serialize_int128_t( 0 ) );
+    }
+
+    // unary minus is two's complement negation; ~ and the bitwise operators work on the pattern
+    {
+        serialize_check( -::serialize_int128_t( 5 ) == ::serialize_int128_t( -5 ) );
+        serialize_check( -::serialize_int128_t( -5 ) == ::serialize_int128_t( 5 ) );
+        serialize_check( -int128_min == int128_min );                                               // -INT128_MIN wraps to itself, documented
+        serialize_check( +::serialize_int128_t( -5 ) == ::serialize_int128_t( -5 ) );
+        serialize_check( ~::serialize_int128_t( 0 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( ::serialize_int128_t( -1 ) & ::serialize_int128_t( 5 ) ) == ::serialize_int128_t( 5 ) );
+        serialize_check( ( ::serialize_int128_t( 0 ) | ::serialize_int128_t( -1 ) ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( ::serialize_int128_t( -1 ) ^ ::serialize_int128_t( -1 ) ) == ::serialize_int128_t( 0 ) );
+    }
+
+    // increment and decrement, both forms, across zero and across the lane boundary
+    {
+        ::serialize_int128_t value( -1 );
+        serialize_check( ++value == ::serialize_int128_t( 0 ) );
+        serialize_check( value++ == ::serialize_int128_t( 0 ) );
+        serialize_check( value == ::serialize_int128_t( 1 ) );
+        serialize_check( --value == ::serialize_int128_t( 0 ) );
+        serialize_check( value-- == ::serialize_int128_t( 0 ) );
+        serialize_check( value == ::serialize_int128_t( -1 ) );
+
+        ::serialize_int128_t boundary = int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );                      // 2^64 - 1
+        serialize_check( ++boundary == int128_emulated( 1, 0 ) );
+
+        ::serialize_int128_t accumulator( -10 );
+        accumulator += ::serialize_int128_t( 4 );  serialize_check( accumulator == ::serialize_int128_t( -6 ) );
+        accumulator -= ::serialize_int128_t( -6 ); serialize_check( accumulator == ::serialize_int128_t( 0 ) );
+        accumulator = ::serialize_int128_t( -3 );
+        accumulator *= ::serialize_int128_t( -3 ); serialize_check( accumulator == ::serialize_int128_t( 9 ) );
+        accumulator /= ::serialize_int128_t( -2 ); serialize_check( accumulator == ::serialize_int128_t( -4 ) );
+        accumulator %= ::serialize_int128_t( 3 );  serialize_check( accumulator == ::serialize_int128_t( -1 ) );
+        accumulator <<= 64;                  serialize_check( accumulator == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );
+        accumulator >>= 64;                  serialize_check( accumulator == ::serialize_int128_t( -1 ) );
+        accumulator &= ::serialize_int128_t( 6 );  serialize_check( accumulator == ::serialize_int128_t( 6 ) );
+        accumulator |= ::serialize_int128_t( 1 );  serialize_check( accumulator == ::serialize_int128_t( 7 ) );
+        accumulator ^= ::serialize_int128_t( -1 ); serialize_check( accumulator == ::serialize_int128_t( -8 ) );
+    }
+}
+
+#if defined(__SIZEOF_INT128__)
+
+inline serialize::uint128_t uint128_native_from_emulated( ::serialize_uint128_t value )
+{
+    return ( serialize::uint128_t( value.hi ) << 64 ) | value.lo;
+}
+
+inline void check_uint128_agree( ::serialize_uint128_t emulated, serialize::uint128_t native )
+{
+    serialize_check( emulated.lo == uint64_t( native ) );
+    serialize_check( emulated.hi == uint64_t( native >> 64 ) );
+}
+
+inline void test_uint128_differential()
+{
+    // where native __int128 exists, the emulated type is proven against it operator by operator:
+    // a fixed seed LCG generates operand pairs, and every operator must agree exactly. this is
+    // the test that keeps the sibling copies of the emulation block honest — drift fails loudly.
+
+    uint64_t lcg = 0x123456789ABCDEF0ULL;
+
+    #define serialize_test_next_lcg() ( lcg = lcg * 6364136223846793005ULL + 1442695040888963407ULL )
+
+    for ( int i = 0; i < 400; i++ )
+    {
+        uint64_t a_hi = serialize_test_next_lcg();
+        uint64_t a_lo = serialize_test_next_lcg();
+        uint64_t b_hi = serialize_test_next_lcg();
+        uint64_t b_lo = serialize_test_next_lcg();
+
+        // bias some operands toward the interesting edges: empty lanes, saturated lanes, equal operands
+        switch ( i % 8 )
+        {
+            case 1: a_hi = 0; break;
+            case 2: a_lo = 0; break;
+            case 3: b_hi = 0; break;
+            case 4: b_lo = 0; break;
+            case 5: a_hi = 0xFFFFFFFFFFFFFFFFULL; a_lo = 0xFFFFFFFFFFFFFFFFULL; break;
+            case 6: b_hi = 0; b_lo = uint64_t( 1 ) << ( i % 63 ); break;                    // powers of two divide cleanly
+            case 7: b_hi = a_hi; b_lo = a_lo; break;
+            default: break;
+        }
+
+        const ::serialize_uint128_t ea = uint128_emulated( a_hi, a_lo );
+        const ::serialize_uint128_t eb = uint128_emulated( b_hi, b_lo );
+        const serialize::uint128_t na = ( serialize::uint128_t( a_hi ) << 64 ) | a_lo;
+        const serialize::uint128_t nb = ( serialize::uint128_t( b_hi ) << 64 ) | b_lo;
+
+        check_uint128_agree( ea + eb, na + nb );
+        check_uint128_agree( ea - eb, na - nb );
+        check_uint128_agree( ea * eb, na * nb );
+        check_uint128_agree( ea & eb, na & nb );
+        check_uint128_agree( ea | eb, na | nb );
+        check_uint128_agree( ea ^ eb, na ^ nb );
+        check_uint128_agree( ~ea, ~na );
+        check_uint128_agree( -ea, serialize::uint128_t( 0 ) - na );
+        check_uint128_agree( +ea, na );
+
+        if ( eb != ::serialize_uint128_t( 0 ) )
+        {
+            check_uint128_agree( ea / eb, na / nb );            // zero divisors are excluded PERMANENTLY: by zero is undefined on both sides and native hardware disagrees with itself (arm64 x/0 is 0 but x%0 is the dividend; x86-64 traps), so agreement is not a property either side can promise. Totality is pinned in test_uint128_emulation instead
+            check_uint128_agree( ea % eb, na % nb );
+        }
+
+        const int shift = int( b_lo % 128 );                    // native shifts of 128 or more are undefined; the emulated choice is pinned in test_uint128_emulation
+        check_uint128_agree( ea << shift, na << shift );
+        check_uint128_agree( ea >> shift, na >> shift );
+
+        serialize_check( ( ea == eb ) == ( na == nb ) );
+        serialize_check( ( ea != eb ) == ( na != nb ) );
+        serialize_check( ( ea <  eb ) == ( na <  nb ) );
+        serialize_check( ( ea >  eb ) == ( na >  nb ) );
+        serialize_check( ( ea <= eb ) == ( na <= nb ) );
+        serialize_check( ( ea >= eb ) == ( na >= nb ) );
+
+        // construction agreement from both signednesses of the drawn lanes
+        check_uint128_agree( ::serialize_uint128_t( a_lo ), serialize::uint128_t( a_lo ) );
+        check_uint128_agree( ::serialize_uint128_t( int64_t( a_lo ) ), serialize::uint128_t( int64_t( a_lo ) ) );
+
+        ::serialize_uint128_t emulated_accumulator = ea;
+        serialize::uint128_t native_accumulator = na;
+        check_uint128_agree( ++emulated_accumulator, ++native_accumulator );
+        check_uint128_agree( emulated_accumulator++, native_accumulator++ );
+        check_uint128_agree( emulated_accumulator, native_accumulator );
+        check_uint128_agree( --emulated_accumulator, --native_accumulator );
+        check_uint128_agree( emulated_accumulator--, native_accumulator-- );
+        check_uint128_agree( emulated_accumulator, native_accumulator );
+
+        emulated_accumulator = ea;
+        native_accumulator = na;
+        emulated_accumulator += eb; native_accumulator += nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator -= eb; native_accumulator -= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator *= eb; native_accumulator *= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator &= eb; native_accumulator &= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator |= eb; native_accumulator |= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator ^= eb; native_accumulator ^= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator <<= shift; native_accumulator <<= shift; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator >>= shift; native_accumulator >>= shift; check_uint128_agree( emulated_accumulator, native_accumulator );
+        if ( eb != ::serialize_uint128_t( 0 ) )
+        {
+            emulated_accumulator = ea; native_accumulator = na;
+            emulated_accumulator /= eb; native_accumulator /= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+            emulated_accumulator = ea; native_accumulator = na;
+            emulated_accumulator %= eb; native_accumulator %= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        }
+    }
+
+    #undef serialize_test_next_lcg
+
+    // construction differential: the exact cross signed cases the audit proved uncovered.
+    // identical source expressions must construct identical values in both representations.
+    {
+        check_uint128_agree( ::serialize_uint128_t( int64_t( -1 ) ),       serialize::uint128_t( int64_t( -1 ) ) );
+        check_uint128_agree( ::serialize_uint128_t( INT64_MIN ),           serialize::uint128_t( INT64_MIN ) );
+        check_uint128_agree( ::serialize_uint128_t( uint64_t( 1 ) << 63 ), serialize::uint128_t( uint64_t( 1 ) << 63 ) );
+        check_uint128_agree( ::serialize_uint128_t( UINT64_MAX ),          serialize::uint128_t( UINT64_MAX ) );
+        check_uint128_agree( ::serialize_uint128_t( -5 ),                  serialize::uint128_t( -5 ) );
+        check_uint128_agree( ::serialize_uint128_t( 3000000000U ),         serialize::uint128_t( 3000000000U ) );
+    }
+
+    // cross representation wire identity: the emulated type and native __int128 must produce
+    // byte identical wire through serialize_uint128, and each must read the other's bytes back
+    // exactly. this is what makes the emulation a drop in replacement on compilers without
+    // native 128 bit support.
+    {
+        const uint64_t lanes[][2] =                             // { hi, lo }
+        {
+            { 0, 0 },
+            { 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL },
+            { 0xFFFFFFFFFFFFFFFFULL, 0 },                                       // high half only
+            { 0, 0xFFFFFFFFFFFFFFFFULL },                                       // low half only
+            { 0x0123456789ABCDEFULL, 0xFEDCBA9876543210ULL },                   // distinct halves
+        };
+
+        for ( int i = 0; i < (int) ( sizeof( lanes ) / sizeof( lanes[0] ) ); i++ )
+        {
+            ::serialize_uint128_t emulated = uint128_emulated( lanes[i][0], lanes[i][1] );
+            serialize::uint128_t native = uint128_native_from_emulated( emulated );
+
+            uint8_t emulated_buffer[16 + 8] = { 0 };            // + 8: read buffer allocations extend 8 bytes past the data
+            serialize::WriteStream emulatedStream( emulated_buffer, 16 );
+            serialize_check( serialize::serialize_uint128_internal( emulatedStream, emulated ) == true );
+            emulatedStream.Flush();
+
+            uint8_t native_buffer[16 + 8] = { 0 };
+            serialize::WriteStream nativeStream( native_buffer, 16 );
+            serialize_check( serialize::serialize_uint128_internal( nativeStream, native ) == true );
+            nativeStream.Flush();
+
+            serialize_check( emulatedStream.GetBitsProcessed() == nativeStream.GetBitsProcessed() );
+            serialize_check( memcmp( emulated_buffer, native_buffer, 16 ) == 0 );
+
+            // read the native bytes back through the emulated type
+            serialize::ReadStream readStream( native_buffer, 16 );
+            ::serialize_uint128_t read_back( 0 );
+            serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
+            serialize_check( read_back == uint128_emulated( lanes[i][0], lanes[i][1] ) );
+        }
+    }
+}
+
+inline serialize::int128_t int128_native_from_emulated( ::serialize_int128_t value )
+{
+    return serialize::int128_t( ( serialize::uint128_t( value.hi ) << 64 ) | value.lo );
+}
+
+inline void check_int128_agree( ::serialize_int128_t emulated, serialize::int128_t native )
+{
+    serialize_check( emulated.lo == uint64_t( serialize::uint128_t( native ) ) );
+    serialize_check( emulated.hi == uint64_t( serialize::uint128_t( native ) >> 64 ) );
+}
+
+inline void test_int128_differential()
+{
+    // the signed counterpart of test_uint128_differential: a fixed seed LCG generates operand
+    // pairs biased toward the sign boundaries, and every operator must agree exactly with native
+    // signed __int128. where the native operation would be undefined behavior — signed overflow
+    // in + - * << and unary minus — the native expectation is computed in the unsigned domain,
+    // which is the defined spelling of the two's complement wrap the emulation implements.
+
+    const serialize::int128_t native_int128_min = serialize::int128_t( serialize::uint128_t( 1 ) << 127 );
+
+    uint64_t lcg = 0xFEDCBA9876543210ULL;
+
+    #define serialize_test_next_lcg() ( lcg = lcg * 6364136223846793005ULL + 1442695040888963407ULL )
+
+    for ( int i = 0; i < 400; i++ )
+    {
+        uint64_t a_hi = serialize_test_next_lcg();
+        uint64_t a_lo = serialize_test_next_lcg();
+        uint64_t b_hi = serialize_test_next_lcg();
+        uint64_t b_lo = serialize_test_next_lcg();
+
+        // bias operands toward the sign boundaries: zero, ±1, INT64_MIN/MAX sign extended,
+        // INT128_MIN/MAX, negated and equal pairs
+        switch ( i % 10 )
+        {
+            case 1: a_hi = 0; a_lo = 0; break;
+            case 2: a_hi = 0xFFFFFFFFFFFFFFFFULL; a_lo = 0xFFFFFFFFFFFFFFFFULL; break;              // -1
+            case 3: a_hi = 0xFFFFFFFFFFFFFFFFULL; a_lo = 0x8000000000000000ULL; break;              // INT64_MIN sign extended
+            case 4: a_hi = 0; a_lo = 0x7FFFFFFFFFFFFFFFULL; break;                                  // INT64_MAX
+            case 5: a_hi = 0x8000000000000000ULL; a_lo = 0; break;                                  // INT128_MIN
+            case 6: a_hi = 0x7FFFFFFFFFFFFFFFULL; a_lo = 0xFFFFFFFFFFFFFFFFULL; break;              // INT128_MAX
+            case 7: b_hi = 0xFFFFFFFFFFFFFFFFULL; b_lo = 0xFFFFFFFFFFFFFFFFULL; break;              // -1: the overflowing divisor
+            case 8: b_hi = ~a_hi; b_lo = ~a_lo; break;                                              // ~a: b = -a - 1, mixed signs
+            case 9: b_hi = a_hi; b_lo = a_lo; break;
+            default: break;
+        }
+
+        const ::serialize_int128_t ea = int128_emulated( a_hi, a_lo );
+        const ::serialize_int128_t eb = int128_emulated( b_hi, b_lo );
+        const serialize::uint128_t ua = ( serialize::uint128_t( a_hi ) << 64 ) | a_lo;
+        const serialize::uint128_t ub = ( serialize::uint128_t( b_hi ) << 64 ) | b_lo;
+        const serialize::int128_t na = serialize::int128_t( ua );
+        const serialize::int128_t nb = serialize::int128_t( ub );
+
+        // + - * and unary minus: native expectations via the unsigned domain, avoiding native
+        // signed overflow, which is undefined behavior. the wrap is the semantics under test.
+        check_int128_agree( ea + eb, serialize::int128_t( ua + ub ) );
+        check_int128_agree( ea - eb, serialize::int128_t( ua - ub ) );
+        check_int128_agree( ea * eb, serialize::int128_t( ua * ub ) );
+        check_int128_agree( -ea, serialize::int128_t( serialize::uint128_t( 0 ) - ua ) );
+        check_int128_agree( +ea, na );
+
+        check_int128_agree( ea & eb, na & nb );
+        check_int128_agree( ea | eb, na | nb );
+        check_int128_agree( ea ^ eb, na ^ nb );
+        check_int128_agree( ~ea, ~na );
+
+        if ( nb != 0 && ! ( na == native_int128_min && nb == -1 ) )
+        {
+            check_int128_agree( ea / eb, na / nb );         // the excluded case is native undefined behavior; the emulated wrap is pinned in test_int128_emulation
+            check_int128_agree( ea % eb, na % nb );
+        }
+
+        const int shift = int( b_lo % 128 );                // native shifts of 128 or more are undefined; the emulated choice is pinned in test_int128_emulation
+        check_int128_agree( ea >> shift, na >> shift );                                             // native >> on negatives is the arithmetic shift on every target compiler
+        check_int128_agree( ea << shift, serialize::int128_t( ua << shift ) );                      // native << on negatives is undefined pre C++20: the unsigned domain is the defined spelling
+
+        serialize_check( ( ea == eb ) == ( na == nb ) );
+        serialize_check( ( ea != eb ) == ( na != nb ) );
+        serialize_check( ( ea <  eb ) == ( na <  nb ) );
+        serialize_check( ( ea >  eb ) == ( na >  nb ) );
+        serialize_check( ( ea <= eb ) == ( na <= nb ) );
+        serialize_check( ( ea >= eb ) == ( na >= nb ) );
+
+        // increments and decrements via the unsigned domain, since native ++ overflows at INT128_MAX
+        ::serialize_int128_t incremented = ea;
+        ++incremented;
+        check_int128_agree( incremented, serialize::int128_t( ua + 1 ) );
+        incremented--;
+        check_int128_agree( incremented, na );
+        ::serialize_int128_t decremented = ea;
+        --decremented;
+        check_int128_agree( decremented, serialize::int128_t( ua - 1 ) );
+
+        // conversions: the sign extending and value preserving constructors and the truncating
+        // conversion match native, from both signednesses of the drawn lane
+        const int64_t seed64 = int64_t( a_lo );
+        check_int128_agree( ::serialize_int128_t( seed64 ), serialize::int128_t( seed64 ) );
+        check_int128_agree( ::serialize_int128_t( a_lo ), serialize::int128_t( a_lo ) );
+        serialize_check( int64_t( ea ) == int64_t( uint64_t( ua ) ) );
+
+        // compound forms via the unsigned domain where overflow could occur
+        ::serialize_int128_t accumulator = ea;
+        accumulator += eb; check_int128_agree( accumulator, serialize::int128_t( ua + ub ) );
+        accumulator = ea;
+        accumulator -= eb; check_int128_agree( accumulator, serialize::int128_t( ua - ub ) );
+        accumulator = ea;
+        accumulator *= eb; check_int128_agree( accumulator, serialize::int128_t( ua * ub ) );
+        accumulator = ea;
+        accumulator &= eb; check_int128_agree( accumulator, na & nb );
+        accumulator = ea;
+        accumulator |= eb; check_int128_agree( accumulator, na | nb );
+        accumulator = ea;
+        accumulator ^= eb; check_int128_agree( accumulator, na ^ nb );
+        accumulator = ea;
+        accumulator >>= shift; check_int128_agree( accumulator, na >> shift );
+        accumulator = ea;
+        accumulator <<= shift; check_int128_agree( accumulator, serialize::int128_t( ua << shift ) );
+        if ( nb != 0 && ! ( na == native_int128_min && nb == -1 ) )
+        {
+            accumulator = ea;
+            accumulator /= eb; check_int128_agree( accumulator, na / nb );
+            accumulator = ea;
+            accumulator %= eb; check_int128_agree( accumulator, na % nb );
+        }
+    }
+
+    #undef serialize_test_next_lcg
+
+    // construction differential: the exact cross signed cases the audit proved uncovered.
+    // identical source expressions must construct identical values in both representations.
+    {
+        check_int128_agree( ::serialize_int128_t( int64_t( -1 ) ),       serialize::int128_t( int64_t( -1 ) ) );
+        check_int128_agree( ::serialize_int128_t( INT64_MIN ),           serialize::int128_t( INT64_MIN ) );
+        check_int128_agree( ::serialize_int128_t( uint64_t( 1 ) << 63 ), serialize::int128_t( uint64_t( 1 ) << 63 ) );
+        check_int128_agree( ::serialize_int128_t( UINT64_MAX ),          serialize::int128_t( UINT64_MAX ) );
+        check_int128_agree( ::serialize_int128_t( -5 ),                  serialize::int128_t( -5 ) );
+        check_int128_agree( ::serialize_int128_t( 3000000000U ),         serialize::int128_t( 3000000000U ) );
+    }
+}
+
+#endif // #if defined(__SIZEOF_INT128__)
+
 // Golden wire format test. The exact bytes produced by the serializer are pinned down here and must never change.
 // If this test fails, the wire format has changed and previously written data no longer decodes: a breaking change.
 // The values below are chosen so every platform quantizes identically (see the compressed float: 5.0 in [0,10]
@@ -3137,6 +5728,12 @@ struct GoldenWireData
     uint8_t bytes[7];
     char string[16];
     wchar_t wstring[8];
+    int16_t fixed_q8_8;
+    int32_t fixed_q16_16;
+    int64_t fixed_q48_16;
+    uint32_t fixed_q16_16_unsigned;
+    serialize::int128_t fixed_q112_16_wide;
+    serialize::int128_t fixed_q64_64_wide;
 };
 
 inline void GoldenWireInit( GoldenWireData & data )
@@ -3164,6 +5761,13 @@ inline void GoldenWireInit( GoldenWireData & data )
     // built from explicit code points so the source file encoding can never change the golden bytes
     const wchar_t golden_wide_string[4] = { 0x043C, 0x0438, 0x0440, 0 };            // cyrillic, BMP only
     serialize_copy_wstring( data.wstring, golden_wide_string, sizeof( data.wstring ) / sizeof( wchar_t ) );
+    data.fixed_q8_8 = int16_t( -( 3 * 256 + 64 ) );                                 // -3.25 in Q8.8
+    data.fixed_q16_16 = 1234 * 65536 + 32768;                                       // 1234.5 in Q16.16
+    data.fixed_q48_16 = -( int64_t( 54321 ) * 65536 + 12345 );                      // -54321.1883... in Q48.16
+    data.fixed_q16_16_unsigned = 29999u * 65536 + 65535;                            // 29999.99998... in Q16.16: every fraction bit set
+    data.fixed_q112_16_wide = serialize::int128_t( -( int64_t( 98765432109LL ) * 65536 + 4321 ) );      // -98765432109.066 in Q112.16: 75 bits on the wire, three groups
+    data.fixed_q64_64_wide = ( serialize::int128_t( 0x0123456789ABCDEFLL ) << 64 )
+                           + serialize::int128_t( 0x0FEDCBA987654321LL );           // Q64.64 over the full unit range: 128 bits, four groups, every group distinct
 }
 
 template <typename Stream> bool GoldenWireSerialize( Stream & stream, GoldenWireData & data )
@@ -3189,6 +5793,14 @@ template <typename Stream> bool GoldenWireSerialize( Stream & stream, GoldenWire
     serialize_bytes( stream, data.bytes, (int) sizeof( data.bytes ) );
     serialize_string( stream, data.string, (int) sizeof( data.string ) );
     serialize_wstring( stream, data.wstring, (int) ( sizeof( data.wstring ) / sizeof( wchar_t ) ) );
+    serialize_align( stream );                  // the fixed point section starts byte aligned, so every byte pinned above it stays put
+    serialize_fixed( stream, data.fixed_q8_8, 8, 8, -100, +100 );
+    serialize_fixed( stream, data.fixed_q16_16, 16, 16, -2000, +2000 );
+    serialize_fixed( stream, data.fixed_q48_16, 48, 16, -100000, +100000 );
+    serialize_fixed( stream, data.fixed_q16_16_unsigned, 16, 16, 0, 30000 );
+    serialize_align( stream );                  // the wide fixed section starts byte aligned, so every byte pinned above it stays put
+    serialize_fixed( stream, data.fixed_q112_16_wide, 112, 16, -144115188075855872LL, +144115188075855872LL );      // ±2^57 units: 75 bits, the three group structure
+    serialize_fixed( stream, data.fixed_q64_64_wide, 64, 64, INT64_MIN, INT64_MAX );                                // full unit range: 128 bits, the four group structure
     return true;
 }
 
@@ -3199,7 +5811,11 @@ static const uint8_t golden_wire_bytes[] =
     0x55, 0x55, 0xFF, 0xFC, 0xD1, 0x48, 0xE0, 0x59, 0xD1, 0x48, 0xC0, 0x7B,
     0xF3, 0x6A, 0xE2, 0x59, 0xD1, 0x48, 0x84, 0xB7, 0x06, 0xDE, 0xAD, 0xBE,
     0xEF, 0xCA, 0xFE, 0x01, 0x06, 0x67, 0x6F, 0x6C, 0x64, 0x65, 0x6E, 0xE3,
-    0x21, 0x00, 0x00, 0xC0, 0x21, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00
+    0x21, 0x00, 0x00, 0xC0, 0x21, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00,
+    0xC0, 0x60, 0x00, 0x80, 0xA2, 0x7C, 0xFC, 0xEC, 0x26, 0xCB, 0xFF, 0xFF,
+    0x4B, 0x1D, 0x1F, 0xEF, 0xD2, 0x1A, 0x1F, 0x01, 0xE9, 0xFF, 0xFF, 0x09,
+    0x19, 0x2A, 0x3B, 0x4C, 0x5D, 0x6E, 0x7F, 0x78, 0x6F, 0x5E, 0x4D, 0x3C,
+    0x2B, 0x1A, 0x09, 0x04
 };
 
 inline void test_golden_wire_format()
@@ -3248,6 +5864,12 @@ inline void test_golden_wire_format()
         serialize_check( memcmp( data.bytes, expected.bytes, sizeof( data.bytes ) ) == 0 );
         serialize_check( strcmp( data.string, expected.string ) == 0 );
         serialize_check( wcscmp( data.wstring, expected.wstring ) == 0 );
+        serialize_check( data.fixed_q8_8 == expected.fixed_q8_8 );
+        serialize_check( data.fixed_q16_16 == expected.fixed_q16_16 );
+        serialize_check( data.fixed_q48_16 == expected.fixed_q48_16 );
+        serialize_check( data.fixed_q16_16_unsigned == expected.fixed_q16_16_unsigned );
+        serialize_check( data.fixed_q112_16_wide == expected.fixed_q112_16_wide );
+        serialize_check( data.fixed_q64_64_wide == expected.fixed_q64_64_wide );
     }
 }
 
@@ -3363,6 +5985,7 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_bitpacker );
         SERIALIZE_RUN_TEST( test_bits_required );
         SERIALIZE_RUN_TEST( test_bits_required64 );
+        SERIALIZE_RUN_TEST( test_bits_required128 );
         SERIALIZE_RUN_TEST( test_zigzag );
         SERIALIZE_RUN_TEST( test_serialize );
         SERIALIZE_RUN_TEST( test_read_write );
@@ -3374,6 +5997,19 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_wstring_validation );
         SERIALIZE_RUN_TEST( test_int_relative_validation );
         SERIALIZE_RUN_TEST( test_compressed_float_validation );
+        SERIALIZE_RUN_TEST( test_serialize_fixed );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_validation );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_matches_int64 );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_wide );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_wide_emulated );
+        SERIALIZE_RUN_TEST( test_serialize_uint128 );
+        SERIALIZE_RUN_TEST( test_serialize_int128 );
+        SERIALIZE_RUN_TEST( test_uint128_emulation );
+        SERIALIZE_RUN_TEST( test_int128_emulation );
+#if defined(__SIZEOF_INT128__)
+        SERIALIZE_RUN_TEST( test_uint128_differential );
+        SERIALIZE_RUN_TEST( test_int128_differential );
+#endif // #if defined(__SIZEOF_INT128__)
         SERIALIZE_RUN_TEST( test_golden_wire_format );
         SERIALIZE_RUN_TEST( test_unaligned_writer );
         SERIALIZE_RUN_TEST( test_large_buffer );


### PR DESCRIPTION
**Final vendor — trial complete. The yojimbo RELEASE stays held per Glenn** ("Once it's ready, you can try that in a branch, don't make a release yet tho") — merging this PR completes the vendor branch only; no release, no tag, nothing cut. The trial fulfilled Glenn's stated purpose — "Vendoring into yojimbo and making sure it works is an important step to make sure we haven't broken backwards compatibility" — by catching a real backwards-compat defect (see "The trial caught one" below), which is now fixed upstream and re-vendored here from merged serialize main.

## What is vendored

`serialize/serialize.h` from mas-bandwidth/serialize **main** at `673306d8aaef77b9de4037c00342984b2cbd0a03` (the merge of serialize PR #28). Blob `66ff362b`, sha256 `7511acbdd78e845805b91107a9244ebb2d9954a2ae80429c647b286535e9c928`. This supersedes the trial vendor (branch `fixed-point` @ `6ad407d`, blob `7b42e65b`): serialize PR #26 merged to main as planned, and PR #28 on top carries the pre-C++11 fix this trial's CI caught. New surface unchanged from the trial: `serialize_fixed`, `serialize_int128` (ranged), `serialize_uint128`, the emulated 128-bit pair `serialize_uint128_t` / `serialize_int128_t`, and the `SERIALIZE_UINT128_DEFINED` handshake guard.

## The trial caught one: pre-C++11 consumers

Exactly the class of break the vendor trial exists to find, and yojimbo was the only consumer strict enough to find it: the macOS arm64 debug make leg (job 92728237341) compiles at Apple clang's **default language mode, gnu++98**, and the trial-vendored header failed there — `no matching conversion for functional-style cast from 'const serialize_int128_t' to 'serialize_uint128_t'` at serialize.h:556-563 and onward. The emulated pair's signed-to-unsigned conversion was a C++11 explicit conversion *operator*; pre-C++11 overload resolution never selects one. serialize's own CI is all-green at ≥C++14, so no upstream leg could see it.

Fixed upstream in serialize PR #28 (merged): the conversion is now a C++98 explicit converting *constructor* (bit-identical semantics, golden pins + emulated-vs-native differential tests + 29/29 conformance prove no wire change), the fixed-point template specializations are digraph-proofed, compile-time invariants route through `serialize_static_assert` (real `static_assert` ≥C++11 and on MSVC, a C++98 emulation below), and serialize CI gained a `pre-C++11 consumer (clang -std=c++03)` leg that compiles and runs the full suite in both emulated-pair configurations, so the class never regresses. Pre-verified here before pushing: full yojimbo build + **ALL TESTS PASS** at `-std=gnu++98` — the failing leg's exact language mode — with the re-vendored header.

## The pre-existing hash mismatch, resolved

A pre-trial observation said yojimbo's vendored `serialize/serialize.h` (`1d4a618b…`) differed from serialize main (`1f9cefd6…`). Investigated first, as it gates the meaning of "the vendor proves backwards compatibility":

- Those are **sha256 digests, not git blob ids** — neither exists as an object in either repo (`git cat-file --batch-all-objects` on both).
- `sha256` of yojimbo's vendored copy = `1d4a618b2f6e9aef222d5916a91e14fd2cadbfac5b56df883839b04c3f1b3fa4` — **byte-identical** to serialize `origin/main:serialize.h` (same sha256; git blob `c5d1561f` on both sides, confirmed with `git ls-tree`).
- `1f9cefd6…` is the sha256 of the `~/rowan-working/serialize` **working tree**, which is checked out on the `fixed-point` branch — i.e. the measured "difference from main" was main-vs-fixed-point: the new work itself.

**Verdict: no deliberate local patch, no drift.** The vendored copy matched upstream main exactly before this PR; the mismatch was a comparison-methodology artifact (sha256 vs `git hash-object`, against the wrong ref). Nothing to re-apply.

## Contract and collision checks

- `maxPacketBytes &= ~7` (`source/yojimbo_connection.cpp:248`): serialize's bytes%8 write contract is unchanged in the new header (`serialize_assert( ( bytes % 8 ) == 0 )` in both BitWriter constructors) — the line stands, untouched.
- Macro namespace: yojimbo defines exactly one `serialize_*` macro of its own (`serialize_sequence_relative`, `include/yojimbo_serialize.h:68`) — no collision with the new `serialize_int128` / `serialize_uint128` / `serialize_fixed`. (The re-vendor adds `serialize_static_assert` and its two join helpers — still `serialize_`-prefixed, still no collision.)
- `test.cpp` includes `serialize.h` and `sodium.h` in the same TU with `SERIALIZE_ENABLE_TESTS=1`. sodium's global `typedef … uint128_t` does not collide: serialize's emulated types are `serialize_`-prefixed at global scope and `serialize::uint128_t` is namespaced; `test.cpp` has no `using namespace serialize`. Compiles clean under Apple clang and under `-fsanitize=address,undefined`.
- `SERIALIZE_ENABLE_TESTS=1` force-defines the emulated 128-bit pair even on native-`__int128` arm64, so `bin/test` exercises both representations.

## Local test results (macOS arm64, Apple Silicon)

From the trial round (GitHub Actions was in a major outage; everything CI-runnable was run locally, mirroring `.github/workflows/ci.yml`):

| Job | Command (as in ci.yml) | Result |
|---|---|---|
| build-test Debug | `cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug && cmake --build build-debug -j && ./bin/test` | **ALL TESTS PASS** |
| build-test Release | `cmake -B build-release -DCMAKE_BUILD_TYPE=Release && cmake --build build-release -j && ./bin/test` | **ALL TESTS PASS** |
| sanitizers | same flags as CI (`-fsanitize=address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=all`), clang, Debug, `./bin/test` | **ALL TESTS PASS** |
| soak | sanitized build, `./bin/soak 20000` | **clean exit, 17604 messages exchanged** |
| fuzz | five targets built with `-DFUZZ_STANDALONE` + ASan/UBSan (Apple clang ships no libFuzzer runtime — `fuzz/fuzz_standalone.h` exists for exactly this); committed corpus replayed through each, then pseudo-random smoke (`FUZZ_ITERS`: reliable 200k, netcode 50k, connect_token 50k, connection 20k, structured 20k) | **all OK, no findings** |
| conformance | `python3 tools/conformance/verify_standard.py`; `verify_state_machine.py --build build-release` | **13/13 packets decoded, 0 failures; 13/13 state checks, 0 failures** |
| system-sodium | `cmake -DYOJIMBO_SYSTEM_SODIUM=ON` (Homebrew libsodium 1.0.22), Debug, `./bin/test` | **ALL TESTS PASS** |

Re-vendor round adds: full build + `./bin/test` **ALL TESTS PASS** at `-std=gnu++98` (Debug), the previously-failing leg's language mode, with the final header.

The Debug/sanitized runs include serialize's own self-test block inside `bin/test` (via `SERIALIZE_ENABLE_TESTS`), which now covers the new surface: `test_serialize_fixed`, `test_serialize_fixed_validation`, `test_serialize_fixed_matches_int64`, `test_serialize_fixed_wide`, `test_serialize_fixed_wide_emulated`, `test_serialize_uint128`, `test_serialize_int128`, `test_uint128_emulation`, `test_int128_emulation`, `test_uint128_differential`, `test_int128_differential`, `test_bits_required128` — all passing inside yojimbo.

Not runnable on this bench: Windows/MSVC job, MSan job (Linux-only), true libFuzzer (standalone driver used instead, per the repo's own provision), LSan leak detection (unsupported by Apple clang on arm64 — yojimbo's debug leak trackers for memory and messages were active in the Debug/sanitized runs). The system-deps job pins upstream release tags and would not exercise this vendored file by design.

## Sequencing

1. ~~serialize PR #26 merges to serialize main~~ — done (`eec6eb6`).
2. ~~Fix the backwards-compat defect the trial caught~~ — serialize PR #28, merged (main @ `673306d`).
3. ~~Re-vendor from serialize main~~ — this branch's final commit.
4. Merge this PR on green, per Glenn's standing grant ("check in PRs when green").
5. **The release stays held per Glenn regardless — nothing is cut.**
