### PR TITLE
Expose custom packet I/O through Adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,9 @@ if(YOJIMBO_BUILD_TESTS)
         target_link_libraries(${app} PRIVATE yojimbo)
     endforeach()
 
+    add_executable(custom_packet_io_test custom_packet_io_test.cpp)
+    target_link_libraries(custom_packet_io_test PRIVATE yojimbo)
+
     # serialize is header-only; its self-tests are gated on this and called from test.cpp.
     target_compile_definitions(test PRIVATE SERIALIZE_ENABLE_TESTS=1)
 

--- a/custom_packet_io_test.cpp
+++ b/custom_packet_io_test.cpp
@@ -1,0 +1,203 @@
+/*
+    Yojimbo Client/Server Network Library.
+
+    Copyright © 2016 - 2026, Más Bandwidth LLC.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+           in the documentation and/or other materials provided with the distribution.
+
+        3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived
+           from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+    USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "yojimbo.h"
+#include "netcode.h"
+#include "shared.h"
+
+#include <deque>
+#include <stdio.h>
+#include <string.h>
+
+using namespace yojimbo;
+
+struct MemoryPacket
+{
+    Address from;
+    int bytes;
+    uint8_t data[NETCODE_MAX_PACKET_SIZE];
+};
+
+class MemoryPacketAdapter : public TestAdapter
+{
+public:
+    explicit MemoryPacketAdapter( const Address & localAddress )
+        : m_localAddress( localAddress ), m_peer( NULL ), m_sentPackets( 0 ), m_receivedPackets( 0 )
+    {
+    }
+
+    void Connect( MemoryPacketAdapter & peer )
+    {
+        m_peer = &peer;
+    }
+
+    bool UseCustomPacketIO() const
+    {
+        return true;
+    }
+
+    void SendPacket( const Address & to, const uint8_t * packetData, int packetBytes )
+    {
+        if ( !m_peer || to != m_peer->m_localAddress || packetBytes <= 0 || packetBytes > NETCODE_MAX_PACKET_SIZE )
+            return;
+
+        MemoryPacket packet;
+        packet.from = m_localAddress;
+        packet.bytes = packetBytes;
+        memcpy( packet.data, packetData, packetBytes );
+        m_peer->m_packets.push_back( packet );
+        ++m_sentPackets;
+    }
+
+    int ReceivePacket( Address & from, uint8_t * packetData, int maxPacketBytes )
+    {
+        if ( m_packets.empty() )
+            return 0;
+
+        const MemoryPacket packet = m_packets.front();
+        m_packets.pop_front();
+        if ( packet.bytes > maxPacketBytes )
+            return 0;
+
+        from = packet.from;
+        memcpy( packetData, packet.data, packet.bytes );
+        ++m_receivedPackets;
+        return packet.bytes;
+    }
+
+    int SentPackets() const { return m_sentPackets; }
+    int ReceivedPackets() const { return m_receivedPackets; }
+
+private:
+    Address m_localAddress;
+    MemoryPacketAdapter * m_peer;
+    std::deque<MemoryPacket> m_packets;
+    int m_sentPackets;
+    int m_receivedPackets;
+};
+
+static bool Require( bool condition, const char * message )
+{
+    if ( condition )
+        return true;
+    printf( "FAIL: %s\n", message );
+    return false;
+}
+
+int main()
+{
+    if ( !InitializeYojimbo() )
+        return 1;
+
+    bool ok = true;
+    {
+        const Address clientAddress( "203.0.113.2", 41230 );
+        const Address serverAddress( "203.0.113.1", 41230 );
+        MemoryPacketAdapter clientAdapter( clientAddress );
+        MemoryPacketAdapter serverAdapter( serverAddress );
+        clientAdapter.Connect( serverAdapter );
+        serverAdapter.Connect( clientAdapter );
+
+        ClientServerConfig config;
+        config.numChannels = 2;
+        config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+        config.channel[1].type = CHANNEL_TYPE_UNRELIABLE_UNORDERED;
+
+        uint8_t privateKey[KeyBytes];
+        memset( privateKey, 0, sizeof( privateKey ) );
+        double time = 100.0;
+
+        Server server( GetDefaultAllocator(), privateKey, serverAddress, config, serverAdapter, time );
+        server.Start( 1 );
+        Client client( GetDefaultAllocator(), clientAddress, config, clientAdapter, time );
+        client.InsecureConnect( privateKey, 1, serverAddress );
+
+        for ( int i = 0; i < 256 && !client.IsConnected(); ++i )
+        {
+            client.SendPackets();
+            server.SendPackets();
+            client.ReceivePackets();
+            server.ReceivePackets();
+            time += 0.1;
+            client.AdvanceTime( time );
+            server.AdvanceTime( time );
+        }
+
+        ok &= Require( client.GetAddress() == clientAddress, "client synthetic local address changed" );
+        ok &= Require( server.GetAddress() == serverAddress, "server synthetic local address changed" );
+        ok &= Require( client.IsConnected(), "client did not connect over custom packet I/O" );
+        ok &= Require( server.GetNumConnectedClients() == 1, "server did not admit the custom-I/O client" );
+        ok &= Require( clientAdapter.SentPackets() > 0 && clientAdapter.ReceivedPackets() > 0,
+                       "client adapter did not send and receive packets" );
+        ok &= Require( serverAdapter.SentPackets() > 0 && serverAdapter.ReceivedPackets() > 0,
+                       "server adapter did not send and receive packets" );
+
+        TestMessage * toServer = (TestMessage*) client.CreateMessage( TEST_MESSAGE );
+        TestMessage * toClient = (TestMessage*) server.CreateMessage( 0, TEST_MESSAGE );
+        ok &= Require( toServer != NULL && toClient != NULL, "could not allocate channel test messages" );
+        if ( toServer && toClient )
+        {
+            toServer->sequence = 11;
+            toClient->sequence = 22;
+            client.SendMessage( 0, toServer );
+            server.SendMessage( 0, 1, toClient );
+
+            Message * fromClient = NULL;
+            Message * fromServer = NULL;
+            for ( int i = 0; i < 256 && ( !fromClient || !fromServer ); ++i )
+            {
+                client.SendPackets();
+                server.SendPackets();
+                client.ReceivePackets();
+                server.ReceivePackets();
+                if ( !fromClient )
+                    fromClient = server.ReceiveMessage( 0, 0 );
+                if ( !fromServer )
+                    fromServer = client.ReceiveMessage( 1 );
+                time += 0.1;
+                client.AdvanceTime( time );
+                server.AdvanceTime( time );
+            }
+
+            ok &= Require( fromClient && ((TestMessage*) fromClient)->sequence == 11,
+                           "reliable client message did not cross custom packet I/O" );
+            ok &= Require( fromServer && ((TestMessage*) fromServer)->sequence == 22,
+                           "unreliable server message did not cross custom packet I/O" );
+            if ( fromClient )
+                server.ReleaseMessage( 0, fromClient );
+            if ( fromServer )
+                client.ReleaseMessage( fromServer );
+        }
+
+        client.Disconnect();
+        server.Stop();
+    }
+    ShutdownYojimbo();
+
+    if ( !ok )
+        return 1;
+
+    printf( "OK: custom packet I/O handshake passed without native sockets\n" );
+    return 0;
+}

--- a/include/yojimbo_adapter.h
+++ b/include/yojimbo_adapter.h
@@ -29,6 +29,8 @@
 
 namespace yojimbo
 {
+    class Address;
+
     /**
         Specifies the message factory and callbacks for clients and servers.
         An instance of this class is passed into the client and server constructors.
@@ -66,6 +68,45 @@ namespace yojimbo
             (void) allocator;
             yojimbo_assert( false );
             return NULL;
+        }
+
+        /**
+            Override to route netcode.io packets through a custom datagram transport.
+            The result must remain stable for the lifetime of the client or server.
+            The default is false and preserves yojimbo's native UDP sockets.
+         */
+
+        virtual bool UseCustomPacketIO() const
+        {
+            return false;
+        }
+
+        /**
+            Send one complete netcode.io datagram through the custom transport.
+            Called only when UseCustomPacketIO returns true.
+         */
+
+        virtual void SendPacket( const Address & to, const uint8_t * packetData, int packetBytes )
+        {
+            (void) to;
+            (void) packetData;
+            (void) packetBytes;
+            yojimbo_assert( false );
+        }
+
+        /**
+            Receive one complete netcode.io datagram from the custom transport.
+            Set from to the stable transport-visible source address and return the byte count.
+            Return zero when no packet is available.
+         */
+
+        virtual int ReceivePacket( Address & from, uint8_t * packetData, int maxPacketBytes )
+        {
+            (void) from;
+            (void) packetData;
+            (void) maxPacketBytes;
+            yojimbo_assert( false );
+            return 0;
         }
 
         /**

--- a/include/yojimbo_client.h
+++ b/include/yojimbo_client.h
@@ -30,6 +30,7 @@
 #include "yojimbo_base_client.h"
 
 struct netcode_client_t;
+struct netcode_address_t;
 
 namespace yojimbo
 {
@@ -165,6 +166,10 @@ namespace yojimbo
         void SendLoopbackPacketCallbackFunction( int clientIndex, const uint8_t * packetData, int packetBytes, uint64_t packetSequence );
 
         static void StaticSendLoopbackPacketCallbackFunction( void * context, int clientIndex, const uint8_t * packetData, int packetBytes, uint64_t packetSequence );
+
+        static void StaticSendPacketOverride( void * context, netcode_address_t * to, const uint8_t * packetData, int packetBytes );
+
+        static int StaticReceivePacketOverride( void * context, netcode_address_t * from, uint8_t * packetData, int maxPacketBytes );
 
         ClientServerConfig m_config;                    ///< Client/server configuration.
         netcode_client_t * m_client;                    ///< netcode client data.

--- a/include/yojimbo_server.h
+++ b/include/yojimbo_server.h
@@ -30,6 +30,7 @@
 #include "yojimbo_address.h"
 
 struct netcode_server_t;
+struct netcode_address_t;
 
 namespace yojimbo
 {
@@ -144,6 +145,10 @@ namespace yojimbo
         static void StaticConnectDisconnectCallbackFunction( void * context, int clientIndex, int connected );
 
         static void StaticSendLoopbackPacketCallbackFunction( void * context, int clientIndex, const uint8_t * packetData, int packetBytes, uint64_t packetSequence );
+
+        static void StaticSendPacketOverride( void * context, netcode_address_t * to, const uint8_t * packetData, int packetBytes );
+
+        static int StaticReceivePacketOverride( void * context, netcode_address_t * from, uint8_t * packetData, int maxPacketBytes );
 
         ClientServerConfig m_config;
         netcode_server_t * m_server;

--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -8,6 +8,34 @@
 
 namespace yojimbo
 {
+    static Address ClientAddressFromNetcode( const netcode_address_t & address )
+    {
+        if ( address.type == NETCODE_ADDRESS_IPV4 )
+            return Address( address.data.ipv4, address.port );
+        if ( address.type == NETCODE_ADDRESS_IPV6 )
+            return Address( address.data.ipv6, address.port );
+        return Address();
+    }
+
+    static bool ClientAddressToNetcode( const Address & address, netcode_address_t & result )
+    {
+        memset( &result, 0, sizeof( result ) );
+        result.port = address.GetPort();
+        if ( address.GetType() == ADDRESS_IPV4 )
+        {
+            result.type = NETCODE_ADDRESS_IPV4;
+            memcpy( result.data.ipv4, address.GetAddress4(), sizeof( result.data.ipv4 ) );
+            return true;
+        }
+        if ( address.GetType() == ADDRESS_IPV6 )
+        {
+            result.type = NETCODE_ADDRESS_IPV6;
+            memcpy( result.data.ipv6, address.GetAddress6(), sizeof( result.data.ipv6 ) );
+            return true;
+        }
+        return false;
+    }
+
     // Map a netcode client error state to the disconnect reason we record for this client.
     // This is where "server is full" vs "update your client" vs "network problem" comes from.
     static int ClientDisconnectReasonForNetcodeState( int netcodeState )
@@ -303,11 +331,18 @@ namespace yojimbo
         netcodeConfig.callback_context              = this;
         netcodeConfig.state_change_callback         = StaticStateChangeCallbackFunction;
         netcodeConfig.send_loopback_packet_callback = StaticSendLoopbackPacketCallbackFunction;
+        if ( GetAdapter().UseCustomPacketIO() )
+        {
+            netcodeConfig.override_send_and_receive = 1;
+            netcodeConfig.send_packet_override = StaticSendPacketOverride;
+            netcodeConfig.receive_packet_override = StaticReceivePacketOverride;
+        }
         m_client = netcode_client_create(addressString, &netcodeConfig, GetTime());
         
         if ( m_client )
         {
-            m_boundAddress.SetPort( netcode_client_get_port( m_client ) );
+            if ( !GetAdapter().UseCustomPacketIO() )
+                m_boundAddress.SetPort( netcode_client_get_port( m_client ) );
         }
     }
 
@@ -361,5 +396,23 @@ namespace yojimbo
     {
         Client * client = (Client*) context;
         client->SendLoopbackPacketCallbackFunction( clientIndex, packetData, packetBytes, packetSequence );
+    }
+
+    void Client::StaticSendPacketOverride( void * context, netcode_address_t * to, const uint8_t * packetData, int packetBytes )
+    {
+        Client * client = (Client*) context;
+        const Address address = ClientAddressFromNetcode( *to );
+        if ( address.IsValid() )
+            client->GetAdapter().SendPacket( address, packetData, packetBytes );
+    }
+
+    int Client::StaticReceivePacketOverride( void * context, netcode_address_t * from, uint8_t * packetData, int maxPacketBytes )
+    {
+        Client * client = (Client*) context;
+        Address address;
+        const int packetBytes = client->GetAdapter().ReceivePacket( address, packetData, maxPacketBytes );
+        if ( packetBytes <= 0 || packetBytes > maxPacketBytes || !ClientAddressToNetcode( address, *from ) )
+            return 0;
+        return packetBytes;
     }
 }

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -31,6 +31,34 @@
 
 namespace yojimbo
 {
+    static Address ServerAddressFromNetcode( const netcode_address_t & address )
+    {
+        if ( address.type == NETCODE_ADDRESS_IPV4 )
+            return Address( address.data.ipv4, address.port );
+        if ( address.type == NETCODE_ADDRESS_IPV6 )
+            return Address( address.data.ipv6, address.port );
+        return Address();
+    }
+
+    static bool ServerAddressToNetcode( const Address & address, netcode_address_t & result )
+    {
+        memset( &result, 0, sizeof( result ) );
+        result.port = address.GetPort();
+        if ( address.GetType() == ADDRESS_IPV4 )
+        {
+            result.type = NETCODE_ADDRESS_IPV4;
+            memcpy( result.data.ipv4, address.GetAddress4(), sizeof( result.data.ipv4 ) );
+            return true;
+        }
+        if ( address.GetType() == ADDRESS_IPV6 )
+        {
+            result.type = NETCODE_ADDRESS_IPV6;
+            memcpy( result.data.ipv6, address.GetAddress6(), sizeof( result.data.ipv6 ) );
+            return true;
+        }
+        return false;
+    }
+
     Server::Server( Allocator & allocator, const uint8_t privateKey[], const Address & address, const ClientServerConfig & config, Adapter & adapter, double time )
         : BaseServer( allocator, config, adapter, time )
     {
@@ -67,6 +95,12 @@ namespace yojimbo
         netcodeConfig.callback_context = this;
         netcodeConfig.connect_disconnect_callback = StaticConnectDisconnectCallbackFunction;
         netcodeConfig.send_loopback_packet_callback = StaticSendLoopbackPacketCallbackFunction;
+        if ( GetAdapter().UseCustomPacketIO() )
+        {
+            netcodeConfig.override_send_and_receive = 1;
+            netcodeConfig.send_packet_override = StaticSendPacketOverride;
+            netcodeConfig.receive_packet_override = StaticReceivePacketOverride;
+        }
 
         m_server = netcode_server_create(addressString, &netcodeConfig, GetTime());
 
@@ -78,7 +112,8 @@ namespace yojimbo
 
         netcode_server_start( m_server, maxClients );
 
-        m_boundAddress.SetPort( netcode_server_get_port( m_server ) );
+        if ( !GetAdapter().UseCustomPacketIO() )
+            m_boundAddress.SetPort( netcode_server_get_port( m_server ) );
     }
 
     void Server::Stop()
@@ -315,5 +350,23 @@ namespace yojimbo
     {
         Server * server = (Server*) context;
         server->SendLoopbackPacketCallbackFunction( clientIndex, packetData, packetBytes, packetSequence );
+    }
+
+    void Server::StaticSendPacketOverride( void * context, netcode_address_t * to, const uint8_t * packetData, int packetBytes )
+    {
+        Server * server = (Server*) context;
+        const Address address = ServerAddressFromNetcode( *to );
+        if ( address.IsValid() )
+            server->GetAdapter().SendPacket( address, packetData, packetBytes );
+    }
+
+    int Server::StaticReceivePacketOverride( void * context, netcode_address_t * from, uint8_t * packetData, int maxPacketBytes )
+    {
+        Server * server = (Server*) context;
+        Address address;
+        const int packetBytes = server->GetAdapter().ReceivePacket( address, packetData, maxPacketBytes );
+        if ( packetBytes <= 0 || packetBytes > maxPacketBytes || !ServerAddressToNetcode( address, *from ) )
+            return 0;
+        return packetBytes;
     }
 }


### PR DESCRIPTION
## Summary

Expose netcode.io's existing packet send/receive overrides through the yojimbo `Adapter` so applications can carry encrypted yojimbo datagrams over a custom transport (for example, an ICE/TURN route) without changing yojimbo's connection, channel, encryption, or fragmentation behavior.

The extension is opt-in:

- `Adapter::UseCustomPacketIO()` defaults to `false`, preserving native UDP for all existing adapters.
- `Adapter::SendPacket` and `ReceivePacket` forward complete netcode.io datagrams using `yojimbo::Address`.
- `Client` and `Server` install the existing netcode callbacks only when the adapter opts in.
- Supplied local addresses remain stable when socket creation is bypassed.

A focused in-memory test completes a client/server handshake and exchanges reliable and unreliable messages using TEST-NET-3 addresses without opening native sockets.

## Validation

- MSVC x64 Debug: `custom_packet_io_test` passes
- MSVC x64 Release: `custom_packet_io_test` passes
- existing adapter behavior remains source-compatible and native UDP remains the default