### PR TITLE
Custom packet I/O hardening: CI-run the test, export MaxAdapterPacketBytes, dedupe address conversion, teardown reentrancy, contract docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,13 @@ jobs:
           cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug
           cmake --build build-debug -j
           ./bin/test
+          ./bin/custom_packet_io_test
       - name: Build & test (release)
         run: |
           cmake -B build-release -DCMAKE_BUILD_TYPE=Release
           cmake --build build-release -j
           ./bin/test
+          ./bin/custom_packet_io_test
 
   windows:
     name: build & test (windows MSVC x64, ${{ matrix.config }})
@@ -54,6 +56,11 @@ jobs:
         run: |
           $exe = Get-ChildItem -Recurse -Filter test.exe | Select-Object -First 1
           if (-not $exe) { Write-Error "test.exe not found"; exit 1 }
+          Write-Host "Running $($exe.FullName)"
+          & $exe.FullName
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $exe = Get-ChildItem -Recurse -Filter custom_packet_io_test.exe | Select-Object -First 1
+          if (-not $exe) { Write-Error "custom_packet_io_test.exe not found"; exit 1 }
           Write-Host "Running $($exe.FullName)"
           & $exe.FullName
           exit $LASTEXITCODE

--- a/custom_packet_io_test.cpp
+++ b/custom_packet_io_test.cpp
@@ -96,6 +96,51 @@ private:
     int m_receivedPackets;
 };
 
+/**
+    Hostile adapter for the teardown-reentrancy regression: once armed, every teardown-time
+    SendPacket re-enters the owning object's own Disconnect/Stop from inside the callback.
+    The stop-in-progress guards in Client::Disconnect and Server::Stop must make those
+    reentrant calls harmless no-ops — without them the inner call tears down the allocator
+    the live netcode object was allocated from (leak assert in debug, use-after-free beyond).
+ */
+
+class ReentrantTeardownAdapter : public MemoryPacketAdapter
+{
+public:
+    explicit ReentrantTeardownAdapter( const Address & localAddress )
+        : MemoryPacketAdapter( localAddress ), m_client( NULL ), m_server( NULL ), m_teardown( false ), m_reentrantCalls( 0 )
+    {
+    }
+
+    void BeginHostileTeardown( Client * client, Server * server )
+    {
+        m_client = client;
+        m_server = server;
+        m_teardown = true;
+    }
+
+    void SendPacket( const Address & to, const uint8_t * packetData, int packetBytes ) YOJIMBO_OVERRIDE
+    {
+        if ( m_teardown )
+        {
+            ++m_reentrantCalls;
+            if ( m_client )
+                m_client->Disconnect();
+            if ( m_server )
+                m_server->Stop();
+        }
+        MemoryPacketAdapter::SendPacket( to, packetData, packetBytes );
+    }
+
+    int ReentrantCalls() const { return m_reentrantCalls; }
+
+private:
+    Client * m_client;
+    Server * m_server;
+    bool m_teardown;
+    int m_reentrantCalls;
+};
+
 static bool Require( bool condition, const char * message )
 {
     if ( condition )
@@ -192,11 +237,104 @@ int main()
         client.Disconnect();
         server.Stop();
     }
+
+    // Scenario 2: hostile reentrant teardown. Connect and exchange messages as above, then tear
+    // down with adapters that call the owning object's Disconnect/Stop from inside its own
+    // teardown-time SendPacket callback. The test completing cleanly (no assert, no crash, no
+    // leak) is the proof that teardown is reentrancy-safe.
+    {
+        const Address clientAddress( "203.0.113.2", 41230 );
+        const Address serverAddress( "203.0.113.1", 41230 );
+        ReentrantTeardownAdapter clientAdapter( clientAddress );
+        ReentrantTeardownAdapter serverAdapter( serverAddress );
+        clientAdapter.Connect( serverAdapter );
+        serverAdapter.Connect( clientAdapter );
+
+        ClientServerConfig config;
+        config.numChannels = 2;
+        config.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+        config.channel[1].type = CHANNEL_TYPE_UNRELIABLE_UNORDERED;
+
+        uint8_t privateKey[KeyBytes];
+        memset( privateKey, 0, sizeof( privateKey ) );
+        double time = 100.0;
+
+        Server server( GetDefaultAllocator(), privateKey, serverAddress, config, serverAdapter, time );
+        server.Start( 1 );
+        Client client( GetDefaultAllocator(), clientAddress, config, clientAdapter, time );
+        client.InsecureConnect( privateKey, 1, serverAddress );
+
+        for ( int i = 0; i < 256 && !client.IsConnected(); ++i )
+        {
+            client.SendPackets();
+            server.SendPackets();
+            client.ReceivePackets();
+            server.ReceivePackets();
+            time += 0.1;
+            client.AdvanceTime( time );
+            server.AdvanceTime( time );
+        }
+
+        ok &= Require( client.IsConnected(), "client did not connect before the hostile teardown" );
+        ok &= Require( server.GetNumConnectedClients() == 1, "server did not admit the client before the hostile teardown" );
+
+        TestMessage * toServer = (TestMessage*) client.CreateMessage( TEST_MESSAGE );
+        TestMessage * toClient = (TestMessage*) server.CreateMessage( 0, TEST_MESSAGE );
+        ok &= Require( toServer != NULL && toClient != NULL, "could not allocate hostile-teardown test messages" );
+        if ( toServer && toClient )
+        {
+            toServer->sequence = 33;
+            toClient->sequence = 44;
+            client.SendMessage( 0, toServer );
+            server.SendMessage( 0, 1, toClient );
+
+            Message * fromClient = NULL;
+            Message * fromServer = NULL;
+            for ( int i = 0; i < 256 && ( !fromClient || !fromServer ); ++i )
+            {
+                client.SendPackets();
+                server.SendPackets();
+                client.ReceivePackets();
+                server.ReceivePackets();
+                if ( !fromClient )
+                    fromClient = server.ReceiveMessage( 0, 0 );
+                if ( !fromServer )
+                    fromServer = client.ReceiveMessage( 1 );
+                time += 0.1;
+                client.AdvanceTime( time );
+                server.AdvanceTime( time );
+            }
+
+            ok &= Require( fromClient && fromServer, "messages did not cross before the hostile teardown" );
+            if ( fromClient )
+                server.ReleaseMessage( 0, fromClient );
+            if ( fromServer )
+                client.ReleaseMessage( fromServer );
+        }
+
+        // Arm the adapters, then tear down. Stop the server first, while the client is still
+        // connected, so netcode_server_stop actually sends disconnect packets (the reentrancy
+        // window). The client has not processed those packets, so its own disconnect also
+        // sends packets and re-enters on the client side.
+        serverAdapter.BeginHostileTeardown( NULL, &server );
+        clientAdapter.BeginHostileTeardown( &client, NULL );
+        server.Stop();
+        client.Disconnect();
+
+        // Prove the hostile path actually ran — a teardown that never fired SendPacket would
+        // pass without testing anything.
+        ok &= Require( serverAdapter.ReentrantCalls() > 0, "server teardown did not exercise the reentrant Stop path" );
+        ok &= Require( clientAdapter.ReentrantCalls() > 0, "client teardown did not exercise the reentrant Disconnect path" );
+
+        // Teardown completed and the guards cleared: calling again must still be a safe no-op.
+        server.Stop();
+        client.Disconnect();
+    }
     ShutdownYojimbo();
 
     if ( !ok )
         return 1;
 
-    printf( "OK: custom packet I/O handshake passed without native sockets\n" );
+    printf( "OK: custom packet I/O handshake and hostile reentrant teardown passed without native sockets\n" );
     return 0;
 }

--- a/custom_packet_io_test.cpp
+++ b/custom_packet_io_test.cpp
@@ -23,7 +23,6 @@
 */
 
 #include "yojimbo.h"
-#include "netcode.h"
 #include "shared.h"
 
 #include <deque>
@@ -36,7 +35,7 @@ struct MemoryPacket
 {
     Address from;
     int bytes;
-    uint8_t data[NETCODE_MAX_PACKET_SIZE];
+    uint8_t data[MaxAdapterPacketBytes];
 };
 
 class MemoryPacketAdapter : public TestAdapter
@@ -52,14 +51,14 @@ public:
         m_peer = &peer;
     }
 
-    bool UseCustomPacketIO() const
+    bool UseCustomPacketIO() const YOJIMBO_OVERRIDE
     {
         return true;
     }
 
-    void SendPacket( const Address & to, const uint8_t * packetData, int packetBytes )
+    void SendPacket( const Address & to, const uint8_t * packetData, int packetBytes ) YOJIMBO_OVERRIDE
     {
-        if ( !m_peer || to != m_peer->m_localAddress || packetBytes <= 0 || packetBytes > NETCODE_MAX_PACKET_SIZE )
+        if ( !m_peer || to != m_peer->m_localAddress || packetBytes <= 0 || packetBytes > MaxAdapterPacketBytes )
             return;
 
         MemoryPacket packet;
@@ -70,7 +69,7 @@ public:
         ++m_sentPackets;
     }
 
-    int ReceivePacket( Address & from, uint8_t * packetData, int maxPacketBytes )
+    int ReceivePacket( Address & from, uint8_t * packetData, int maxPacketBytes ) YOJIMBO_OVERRIDE
     {
         if ( m_packets.empty() )
             return 0;

--- a/include/yojimbo_adapter.h
+++ b/include/yojimbo_adapter.h
@@ -32,6 +32,17 @@ namespace yojimbo
     class Address;
 
     /**
+        Complete netcode.io datagrams passed to and from the adapter are at most this many bytes
+        (netcode's internal NETCODE_MAX_PACKET_BYTES). Size custom transport buffers to THIS
+        constant, not to the payload-size constants — a full datagram carries netcode framing
+        and encryption overhead on top of the payload.
+        @see Adapter::SendPacket
+        @see Adapter::ReceivePacket
+     */
+
+    const int MaxAdapterPacketBytes = 1300;
+
+    /**
         Specifies the message factory and callbacks for clients and servers.
         An instance of this class is passed into the client and server constructors.
         You can share the same adapter across a client/server pair if you have local multiplayer, eg. loopback.
@@ -83,7 +94,12 @@ namespace yojimbo
 
         /**
             Send one complete netcode.io datagram through the custom transport.
-            Called only when UseCustomPacketIO returns true.
+            Called only when UseCustomPacketIO returns true. packetBytes is never larger than
+            MaxAdapterPacketBytes, so buffers sized to that constant always fit the datagram.
+            An adapter with UseCustomPacketIO() == true must be dedicated to a single Client
+            or Server instance — never share it between two objects. The loopback-style
+            sharing described in the class documentation above does not extend to custom
+            packet I/O.
          */
 
         virtual void SendPacket( const Address & to, const uint8_t * packetData, int packetBytes )
@@ -98,6 +114,10 @@ namespace yojimbo
             Receive one complete netcode.io datagram from the custom transport.
             Set from to the stable transport-visible source address and return the byte count.
             Return zero when no packet is available.
+            This function MUST be non-blocking: netcode calls it in a loop each update and
+            drains packets until it returns zero, so a blocking implementation stalls the
+            client or server. maxPacketBytes is MaxAdapterPacketBytes — size transport-side
+            receive buffers to that constant.
          */
 
         virtual int ReceivePacket( Address & from, uint8_t * packetData, int maxPacketBytes )

--- a/include/yojimbo_client.h
+++ b/include/yojimbo_client.h
@@ -141,6 +141,12 @@ namespace yojimbo
 
         void ProcessLoopbackPacket( const uint8_t * packetData, int packetBytes, uint64_t packetSequence );
 
+        /**
+            Gets the local address the client socket is bound to (with the actual port, when port 0 was passed in).
+            Under custom packet I/O (Adapter::UseCustomPacketIO) there is no socket: this is the
+            constructor-supplied synthetic address, unchanged.
+         */
+
         const Address & GetAddress() const { return m_boundAddress; }
 
     private:
@@ -174,7 +180,7 @@ namespace yojimbo
         ClientServerConfig m_config;                    ///< Client/server configuration.
         netcode_client_t * m_client;                    ///< netcode client data.
         Address m_address;                              ///< Original address passed to ctor.
-        Address m_boundAddress;                         ///< Address after socket bind, eg. with valid port
+        Address m_boundAddress;                         ///< Address after socket bind, eg. with valid port. Custom packet I/O: stays the ctor-supplied synthetic address (no socket bind).
         uint64_t m_clientId;                            ///< The globally unique client id (set on each call to connect)
     };
 }

--- a/include/yojimbo_client.h
+++ b/include/yojimbo_client.h
@@ -182,6 +182,7 @@ namespace yojimbo
         Address m_address;                              ///< Original address passed to ctor.
         Address m_boundAddress;                         ///< Address after socket bind, eg. with valid port. Custom packet I/O: stays the ctor-supplied synthetic address (no socket bind).
         uint64_t m_clientId;                            ///< The globally unique client id (set on each call to connect)
+        bool m_disconnecting;                           ///< True while Disconnect tears the client down. Makes a reentrant Disconnect from an adapter callback during teardown a harmless no-op.
     };
 }
 

--- a/include/yojimbo_server.h
+++ b/include/yojimbo_server.h
@@ -161,6 +161,7 @@ namespace yojimbo
         Address m_address;                                  // original address passed to ctor
         Address m_boundAddress;                             // address after socket bind, eg. valid port. custom packet I/O: stays the ctor-supplied synthetic address (no socket bind)
         uint8_t m_privateKey[KeyBytes];
+        bool m_stopping;                                    // true while Stop tears the server down. makes a reentrant Stop from an adapter callback during teardown a harmless no-op
     };
 }
 

--- a/include/yojimbo_server.h
+++ b/include/yojimbo_server.h
@@ -130,6 +130,12 @@ namespace yojimbo
 
         void ProcessLoopbackPacket( int clientIndex, const uint8_t * packetData, int packetBytes, uint64_t packetSequence );
 
+        /**
+            Gets the local address the server socket is bound to (with the actual port, when port 0 was passed in).
+            Under custom packet I/O (Adapter::UseCustomPacketIO) there is no socket: this is the
+            constructor-supplied synthetic address, unchanged.
+         */
+
         const Address & GetAddress() const { return m_boundAddress; }
 
     private:
@@ -153,7 +159,7 @@ namespace yojimbo
         ClientServerConfig m_config;
         netcode_server_t * m_server;
         Address m_address;                                  // original address passed to ctor
-        Address m_boundAddress;                             // address after socket bind, eg. valid port
+        Address m_boundAddress;                             // address after socket bind, eg. valid port. custom packet I/O: stays the ctor-supplied synthetic address (no socket bind)
         uint8_t m_privateKey[KeyBytes];
     };
 }

--- a/source/yojimbo_address_conversion.h
+++ b/source/yojimbo_address_conversion.h
@@ -1,0 +1,66 @@
+/*
+    Yojimbo Client/Server Network Library.
+
+    Copyright © 2016 - 2026, Más Bandwidth LLC.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+           in the documentation and/or other materials provided with the distribution.
+
+        3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived
+           from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+    USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef YOJIMBO_ADDRESS_CONVERSION_H
+#define YOJIMBO_ADDRESS_CONVERSION_H
+
+// Internal header, shared by yojimbo_client.cpp and yojimbo_server.cpp. Not installed:
+// it names netcode types, and netcode.h is not part of the yojimbo public interface.
+
+#include "yojimbo_address.h"
+#include "netcode.h"
+#include <string.h>
+
+namespace yojimbo
+{
+    inline Address AddressFromNetcode( const netcode_address_t & address )
+    {
+        if ( address.type == NETCODE_ADDRESS_IPV4 )
+            return Address( address.data.ipv4, address.port );
+        if ( address.type == NETCODE_ADDRESS_IPV6 )
+            return Address( address.data.ipv6, address.port );
+        return Address();
+    }
+
+    inline bool AddressToNetcode( const Address & address, netcode_address_t & result )
+    {
+        memset( &result, 0, sizeof( result ) );
+        result.port = address.GetPort();
+        if ( address.GetType() == ADDRESS_IPV4 )
+        {
+            result.type = NETCODE_ADDRESS_IPV4;
+            memcpy( result.data.ipv4, address.GetAddress4(), sizeof( result.data.ipv4 ) );
+            return true;
+        }
+        if ( address.GetType() == ADDRESS_IPV6 )
+        {
+            result.type = NETCODE_ADDRESS_IPV6;
+            memcpy( result.data.ipv6, address.GetAddress6(), sizeof( result.data.ipv6 ) );
+            return true;
+        }
+        return false;
+    }
+}
+
+#endif // #ifndef YOJIMBO_ADDRESS_CONVERSION_H

--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -31,6 +31,7 @@ namespace yojimbo
         m_clientId = 0;
         m_client = NULL;
         m_boundAddress = m_address;
+        m_disconnecting = false;
     }
 
     Client::~Client()
@@ -136,6 +137,14 @@ namespace yojimbo
 
     void Client::Disconnect()
     {
+        // Stop-in-progress guard: netcode_client_destroy (inside DestroyClient below) sends
+        // disconnect packets, so an adapter SendPacket callback can call Disconnect from inside
+        // this teardown. That reentrant call must be a harmless no-op — the outer call completes
+        // the teardown exactly once. Without this, the inner call reaches DestroyInternal and
+        // destroys the client allocator while the netcode client (allocated from it) still lives.
+        if ( m_disconnecting )
+            return;
+        m_disconnecting = true;
         // Record a deliberate local disconnect, but only if no more specific reason was already
         // recorded (connection error, netcode error state) — the first reason recorded wins.
         // Checked before BaseClient::Disconnect below, because that resets the client state.
@@ -147,6 +156,7 @@ namespace yojimbo
         DestroyClient();
         DestroyInternal();
         m_clientId = 0;
+        m_disconnecting = false;
     }
 
     void Client::SendPackets()
@@ -265,6 +275,11 @@ namespace yojimbo
 
     void Client::DisconnectLoopback()
     {
+        // Same stop-in-progress guard as Client::Disconnect: this is the same teardown shape,
+        // so a reentrant Disconnect/DisconnectLoopback from an adapter callback is a no-op.
+        if ( m_disconnecting )
+            return;
+        m_disconnecting = true;
         // Same recording rule as Client::Disconnect: a deliberate local disconnect, unless a more
         // specific reason was already recorded.
         if ( ( IsConnecting() || IsConnected() ) && GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_NONE )
@@ -276,6 +291,7 @@ namespace yojimbo
         DestroyClient();
         DestroyInternal();
         m_clientId = 0;
+        m_disconnecting = false;
     }
 
     bool Client::IsLoopback() const

--- a/source/yojimbo_client.cpp
+++ b/source/yojimbo_client.cpp
@@ -3,39 +3,12 @@
 #include "yojimbo_network_simulator.h"
 #include "yojimbo_adapter.h"
 #include "yojimbo_utils.h"
+#include "yojimbo_address_conversion.h"
 #include "netcode.h"
 #include "reliable.h"
 
 namespace yojimbo
 {
-    static Address ClientAddressFromNetcode( const netcode_address_t & address )
-    {
-        if ( address.type == NETCODE_ADDRESS_IPV4 )
-            return Address( address.data.ipv4, address.port );
-        if ( address.type == NETCODE_ADDRESS_IPV6 )
-            return Address( address.data.ipv6, address.port );
-        return Address();
-    }
-
-    static bool ClientAddressToNetcode( const Address & address, netcode_address_t & result )
-    {
-        memset( &result, 0, sizeof( result ) );
-        result.port = address.GetPort();
-        if ( address.GetType() == ADDRESS_IPV4 )
-        {
-            result.type = NETCODE_ADDRESS_IPV4;
-            memcpy( result.data.ipv4, address.GetAddress4(), sizeof( result.data.ipv4 ) );
-            return true;
-        }
-        if ( address.GetType() == ADDRESS_IPV6 )
-        {
-            result.type = NETCODE_ADDRESS_IPV6;
-            memcpy( result.data.ipv6, address.GetAddress6(), sizeof( result.data.ipv6 ) );
-            return true;
-        }
-        return false;
-    }
-
     // Map a netcode client error state to the disconnect reason we record for this client.
     // This is where "server is full" vs "update your client" vs "network problem" comes from.
     static int ClientDisconnectReasonForNetcodeState( int netcodeState )
@@ -331,17 +304,18 @@ namespace yojimbo
         netcodeConfig.callback_context              = this;
         netcodeConfig.state_change_callback         = StaticStateChangeCallbackFunction;
         netcodeConfig.send_loopback_packet_callback = StaticSendLoopbackPacketCallbackFunction;
-        if ( GetAdapter().UseCustomPacketIO() )
+        const bool useCustomPacketIO = GetAdapter().UseCustomPacketIO();
+        if ( useCustomPacketIO )
         {
             netcodeConfig.override_send_and_receive = 1;
             netcodeConfig.send_packet_override = StaticSendPacketOverride;
             netcodeConfig.receive_packet_override = StaticReceivePacketOverride;
         }
         m_client = netcode_client_create(addressString, &netcodeConfig, GetTime());
-        
+
         if ( m_client )
         {
-            if ( !GetAdapter().UseCustomPacketIO() )
+            if ( !useCustomPacketIO )
                 m_boundAddress.SetPort( netcode_client_get_port( m_client ) );
         }
     }
@@ -351,8 +325,12 @@ namespace yojimbo
         if ( m_client )
         {
             m_boundAddress = m_address;
-            netcode_client_destroy( m_client );
+            // Clear the member before destroying, so an adapter that calls Disconnect from
+            // inside a teardown-time SendPacket callback can't re-enter here and destroy
+            // the same netcode client twice.
+            netcode_client_t * client = m_client;
             m_client = NULL;
+            netcode_client_destroy( client );
         }
     }
 
@@ -401,7 +379,7 @@ namespace yojimbo
     void Client::StaticSendPacketOverride( void * context, netcode_address_t * to, const uint8_t * packetData, int packetBytes )
     {
         Client * client = (Client*) context;
-        const Address address = ClientAddressFromNetcode( *to );
+        const Address address = AddressFromNetcode( *to );
         if ( address.IsValid() )
             client->GetAdapter().SendPacket( address, packetData, packetBytes );
     }
@@ -411,7 +389,7 @@ namespace yojimbo
         Client * client = (Client*) context;
         Address address;
         const int packetBytes = client->GetAdapter().ReceivePacket( address, packetData, maxPacketBytes );
-        if ( packetBytes <= 0 || packetBytes > maxPacketBytes || !ClientAddressToNetcode( address, *from ) )
+        if ( packetBytes <= 0 || packetBytes > maxPacketBytes || !AddressToNetcode( address, *from ) )
             return 0;
         return packetBytes;
     }

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -41,6 +41,7 @@ namespace yojimbo
         m_boundAddress = address;
         m_config = config;
         m_server = NULL;
+        m_stopping = false;
     }
 
     Server::~Server()
@@ -92,6 +93,14 @@ namespace yojimbo
 
     void Server::Stop()
     {
+        // Stop-in-progress guard: netcode_server_stop below sends disconnect packets and fires
+        // OnServerClientDisconnected, so an adapter callback can call Stop from inside this
+        // teardown. That reentrant call must be a harmless no-op — the outer call completes the
+        // teardown exactly once. Without this, the inner call reaches BaseServer::Stop and
+        // destroys the global allocator while the netcode server (allocated from it) still lives.
+        if ( m_stopping )
+            return;
+        m_stopping = true;
         if ( m_server )
         {
             m_boundAddress = m_address;
@@ -105,6 +114,7 @@ namespace yojimbo
             netcode_server_destroy( server );
         }
         BaseServer::Stop();
+        m_stopping = false;
     }
 
     void Server::DisconnectClient( int clientIndex )

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -26,39 +26,12 @@
 #include "yojimbo_connection.h"
 #include "yojimbo_adapter.h"
 #include "yojimbo_network_simulator.h"
+#include "yojimbo_address_conversion.h"
 #include "reliable.h"
 #include "netcode.h"
 
 namespace yojimbo
 {
-    static Address ServerAddressFromNetcode( const netcode_address_t & address )
-    {
-        if ( address.type == NETCODE_ADDRESS_IPV4 )
-            return Address( address.data.ipv4, address.port );
-        if ( address.type == NETCODE_ADDRESS_IPV6 )
-            return Address( address.data.ipv6, address.port );
-        return Address();
-    }
-
-    static bool ServerAddressToNetcode( const Address & address, netcode_address_t & result )
-    {
-        memset( &result, 0, sizeof( result ) );
-        result.port = address.GetPort();
-        if ( address.GetType() == ADDRESS_IPV4 )
-        {
-            result.type = NETCODE_ADDRESS_IPV4;
-            memcpy( result.data.ipv4, address.GetAddress4(), sizeof( result.data.ipv4 ) );
-            return true;
-        }
-        if ( address.GetType() == ADDRESS_IPV6 )
-        {
-            result.type = NETCODE_ADDRESS_IPV6;
-            memcpy( result.data.ipv6, address.GetAddress6(), sizeof( result.data.ipv6 ) );
-            return true;
-        }
-        return false;
-    }
-
     Server::Server( Allocator & allocator, const uint8_t privateKey[], const Address & address, const ClientServerConfig & config, Adapter & adapter, double time )
         : BaseServer( allocator, config, adapter, time )
     {
@@ -95,7 +68,8 @@ namespace yojimbo
         netcodeConfig.callback_context = this;
         netcodeConfig.connect_disconnect_callback = StaticConnectDisconnectCallbackFunction;
         netcodeConfig.send_loopback_packet_callback = StaticSendLoopbackPacketCallbackFunction;
-        if ( GetAdapter().UseCustomPacketIO() )
+        const bool useCustomPacketIO = GetAdapter().UseCustomPacketIO();
+        if ( useCustomPacketIO )
         {
             netcodeConfig.override_send_and_receive = 1;
             netcodeConfig.send_packet_override = StaticSendPacketOverride;
@@ -112,7 +86,7 @@ namespace yojimbo
 
         netcode_server_start( m_server, maxClients );
 
-        if ( !GetAdapter().UseCustomPacketIO() )
+        if ( !useCustomPacketIO )
             m_boundAddress.SetPort( netcode_server_get_port( m_server ) );
     }
 
@@ -121,9 +95,14 @@ namespace yojimbo
         if ( m_server )
         {
             m_boundAddress = m_address;
-            netcode_server_stop( m_server );
-            netcode_server_destroy( m_server );
+            // Clear the member before stopping, so an adapter that calls Stop from inside a
+            // teardown-time SendPacket callback (disconnect packets sent by netcode_server_stop)
+            // can't re-enter here and stop/destroy the same netcode server twice.
+            // ConnectDisconnectCallbackFunction handles m_server being NULL during this window.
+            netcode_server_t * server = m_server;
             m_server = NULL;
+            netcode_server_stop( server );
+            netcode_server_destroy( server );
         }
         BaseServer::Stop();
     }
@@ -312,7 +291,11 @@ namespace yojimbo
             // Record it before the adapter callback, so OnServerClientDisconnected can query it.
             if ( GetClientDisconnectReason( clientIndex ) == YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_NONE )
             {
-                const int netcodeReason = netcode_server_client_disconnect_reason( m_server, clientIndex );
+                // m_server is NULL while Stop tears the netcode server down (cleared before
+                // netcode_server_stop, see Server::Stop). Disconnects delivered during that
+                // window are always netcode SERVER_DISCONNECT, never TIMED_OUT.
+                const int netcodeReason = m_server ? netcode_server_client_disconnect_reason( m_server, clientIndex )
+                                                   : NETCODE_SERVER_CLIENT_DISCONNECT_REASON_SERVER_DISCONNECT;
                 SetClientDisconnectReason( clientIndex, netcodeReason == NETCODE_SERVER_CLIENT_DISCONNECT_REASON_TIMED_OUT
                                                             ? YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_TIMED_OUT
                                                             : YOJIMBO_SERVER_CLIENT_DISCONNECT_REASON_DISCONNECTED );
@@ -355,7 +338,7 @@ namespace yojimbo
     void Server::StaticSendPacketOverride( void * context, netcode_address_t * to, const uint8_t * packetData, int packetBytes )
     {
         Server * server = (Server*) context;
-        const Address address = ServerAddressFromNetcode( *to );
+        const Address address = AddressFromNetcode( *to );
         if ( address.IsValid() )
             server->GetAdapter().SendPacket( address, packetData, packetBytes );
     }
@@ -365,7 +348,7 @@ namespace yojimbo
         Server * server = (Server*) context;
         Address address;
         const int packetBytes = server->GetAdapter().ReceivePacket( address, packetData, maxPacketBytes );
-        if ( packetBytes <= 0 || packetBytes > maxPacketBytes || !ServerAddressToNetcode( address, *from ) )
+        if ( packetBytes <= 0 || packetBytes > maxPacketBytes || !AddressToNetcode( address, *from ) )
             return 0;
         return packetBytes;
     }


### PR DESCRIPTION
Reviewed cleanup on top of #328, authorized by Glenn. Two adversarial reviews (security + correctness) ran over the merged PR; this lands the fixes:

- custom_packet_io_test now actually RUNS in CI (all three jobs) — it was compiled but never executed.
- MaxAdapterPacketBytes (1300) exported in yojimbo_adapter.h; the example adapter sized its buffers to the 1200 payload constant, which drops or overflows on full-size datagrams — fixed, and the contract docs now state the constant, the non-blocking requirement on ReceivePacket, and that a custom-IO adapter must be dedicated to a single Client/Server instance.
- Address<->netcode conversion helpers deduplicated into source/yojimbo_address_conversion.h (internal, not installed).
- Teardown reentrancy, fully closed (second commit): netcode pointer NULLed before destroy in Client::DestroyClient / Server::Stop (the server disconnect callback handles the NULL window — reason there is provably always SERVER_DISCONNECT), AND a stop-in-progress guard on Client::Disconnect / Client::DisconnectLoopback / Server::Stop so a reentrant Disconnect/Stop from any adapter callback during teardown is a harmless no-op instead of destroying the allocator the live netcode object was allocated from. Proven by a hostile-adapter regression scenario in custom_packet_io_test that re-enters the owner's teardown from inside its own teardown-time SendPacket: without the guard it dies in the debug leak assert (verified), with it debug, release and ASan+UBSan are clean.
- UseCustomPacketIO read once per create; stale bound-address doc comments fixed.

Deliberately NOT here (design call, flagged separately): the shared-adapter question (Adapter docs say client/server-shareable, soak.cpp shares one, custom IO breaks under sharing — doc note added but a harder guard is a design decision).

Tests: debug + release, ./bin/test ALL TESTS PASS, ./bin/custom_packet_io_test OK (both scenarios), both configs; ASan+UBSan run of custom_packet_io_test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)