### PR TITLE
Build the wire strict: -ffp-contract=off on every target that compiles serialize.h

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,6 +23,28 @@ The default is a debug build. For an optimized build, pass the build type:
     cmake -B build -DCMAKE_BUILD_TYPE=Release
     cmake --build build -j
 
+## Floating point: yojimbo requires -ffp-contract=off
+
+yojimbo's wire arithmetic lives in `serialize.h`, whose compressed float quantizes with two
+distinct roundings on write and on read: the product must round to float32 *before* the
+constant is added. A compiler allowed to contract fuses the multiply and the add into a
+single FMA and rounds once, which shifts the encoded integer and the decoded float by one
+ulp — a change to what goes on the wire.
+
+This build sets the right flag on every target it compiles, so nothing is required of you to
+build yojimbo itself:
+
+  - GCC/Clang: `-ffp-contract=off`. Not merely the absence of `-ffast-math` — GCC's default
+    is `-ffp-contract=fast`, which contracts across statement boundaries, and clang's default
+    `=on` still fuses within a single expression.
+  - MSVC: `/fp:precise`.
+
+**If you compile `serialize.h` in your own translation units, set the same flag there.** The
+flag is `PRIVATE` to yojimbo's targets and deliberately does not leak into your build, so
+this one is yours to set. It is easy to miss because the symptom is architecture-dependent:
+FMA is in the aarch64 baseline and absent from the x86-64 one, so an unflagged build is
+typically wrong on arm64 and accidentally right on amd64.
+
 ## Building on Windows
 
 Install [CMake](https://cmake.org/download/) and Visual Studio (the free

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,38 @@ if(NOT YOJIMBO_SYSTEM_TLSF)
     set_target_properties(tlsf PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
+# --- strict floating point ------------------------------------------------------------------
+
+# yojimbo's wire arithmetic lives in serialize.h, and serialize's compressed float quantizes
+# with two DISTINCT roundings on write and on read -- the product must round to float32 before
+# the constant is added. A compiler permitted to contract fuses those into a single FMA and
+# rounds once, which moves the encoded integer and the decoded float by one ulp. That is a
+# change to yojimbo's traffic, not a test-suite detail.
+#
+# It is architecture-dependent, which is why it stayed hidden: FMA is in the aarch64 baseline
+# and absent from the x86-64 one, so the same source and the same flags emit a fused multiply
+# add on arm64 and none on amd64. Debian package builds were green on every amd64 leg and red
+# on every arm64 leg (mas-bandwidth/yojimbo#332) -- and the green legs were green because of an
+# instruction set rather than because the build was right.
+#
+# So every target here that compiles serialize.h builds strict, exactly as serialize's own
+# CMakeLists.txt does for its executables:
+#   - GCC/Clang: -ffp-contract=off. Not merely "no -ffast-math" -- GCC's default is
+#     -ffp-contract=fast, which contracts ACROSS statements, and clang's default =on still
+#     fuses within a single expression.
+#   - MSVC: /fp:precise, which since VS 2022 does not imply contraction.
+#
+# This is Glenn's standing estate policy (2026-08-24): "generally speaking, network libraries
+# we work on require -ffp-contract=off". The flag is the floor. It is PRIVATE so nothing leaks
+# into consumers' own flags; consumers that compile serialize.h themselves need it too, and
+# BUILDING.md states that as a requirement.
+
+if(MSVC)
+    set(YOJIMBO_STRICT_FP_FLAGS /fp:precise)
+else()
+    set(YOJIMBO_STRICT_FP_FLAGS -ffp-contract=off)
+endif()
+
 # --- yojimbo library ----------------------------------------------------------------------
 
 # Static by default; -DBUILD_SHARED_LIBS=ON builds it shared (the built-in objects are
@@ -186,6 +218,7 @@ else()
     add_library(yojimbo ${YOJIMBO_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/tlsf/tlsf.c")
 endif()
 target_include_directories(yojimbo PUBLIC ${YOJIMBO_INCLUDE_DIRS})
+target_compile_options(yojimbo PRIVATE ${YOJIMBO_STRICT_FP_FLAGS})
 set_target_properties(yojimbo PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR})
@@ -233,10 +266,12 @@ if(YOJIMBO_BUILD_TESTS)
     foreach(app client server loopback soak test)
         add_executable(${app} ${app}.cpp)
         target_link_libraries(${app} PRIVATE yojimbo)
+        target_compile_options(${app} PRIVATE ${YOJIMBO_STRICT_FP_FLAGS})
     endforeach()
 
     add_executable(custom_packet_io_test custom_packet_io_test.cpp)
     target_link_libraries(custom_packet_io_test PRIVATE yojimbo)
+    target_compile_options(custom_packet_io_test PRIVATE ${YOJIMBO_STRICT_FP_FLAGS})
 
     # serialize is header-only; its self-tests are gated on this and called from test.cpp.
     target_compile_definitions(test PRIVATE SERIALIZE_ENABLE_TESTS=1)


### PR DESCRIPTION
serialize's compressed float quantizes with two distinct roundings on write and on read: the product must round to float32 before the constant is added. A compiler permitted to contract fuses the multiply and the add into a single FMA and rounds once, which moves the encoded integer and the decoded float by one ulp. That is a change to yojimbo's traffic rather than a test-suite annoyance.

serialize's own `CMakeLists.txt` has set `-ffp-contract=off` for its executables all along, and documents at length why. yojimbo set it nowhere — `grep -n 'fp-contract' CMakeLists.txt` returned nothing before this change.

## Why it stayed hidden

FMA is in the aarch64 baseline and absent from the x86-64 one, so the same source under the same flags emits a fused multiply-add on arm64 and none on amd64. The Debian package builds were red on every arm64 leg and green on every amd64 leg. The green legs are the ones worth worrying about: they were green because of an instruction set, not because the build was right, and `-march=native` or a future baseline would flip them with nothing else changing.

## What was measured

On an arm64 bench (Apple M3 Ultra, gcc 16, Release), building yojimbo's own `test` target against a current `serialize.h`:

| build | exit | result |
|---|---|---|
| before, default flags | 1 | `check failed: ( !fp_contraction_crosses_statements ), function serialize_test` |
| after, this change | 0 | `*** ALL TESTS PASS ***` |

The red was run and seen before the fix was written. The flag was then confirmed on the actual compile lines of both `yojimbo.dir` and `test.dir` rather than inferred from the CMake source.

Apple clang 21 is green both before and after — its default `=on` does not cross statement boundaries, so this bench needed gcc to reproduce the failure at all. **The MSVC leg (`/fp:precise`) is not reachable from this bench and is unverified here.**

Note on the reproduction: yojimbo currently vendors serialize 1.6.0, which predates the guard that refuses a contracting build, so the stock tree passes on gcc/arm64 today — silently, with contraction live in the wire path. The red above was produced by putting a current `serialize.h` under yojimbo's build. That vendored copy being eight minor versions behind is a separate finding and is filed separately.

## Scope

`PRIVATE` on the library and on each sample/test executable, so nothing leaks into consumers' own flags — matching serialize's non-leaking stance. `BUILDING.md` gains a section stating the same requirement for consumers who compile `serialize.h` in their own translation units, since the flag deliberately does not propagate to them.

Enacts Glenn's standing estate policy (2026-08-24): *"generally speaking, network libraries we work on require -ffp-contract=off."*

Closes #332.
