### PR TITLE
A no-op build prints nothing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,17 @@
 # section below).
 
 cmake_minimum_required(VERSION 3.16)
+
+# A no-op build prints nothing (rowan-new#110). The per-target "Built target" lines are
+# the only output a rebuild with nothing to do produces, and they carry no information; a
+# real build still prints its [ x%] progress lines, and errors are untouched. This sits
+# above project() because CMAKE_TARGET_MESSAGES initializes the TARGET_MESSAGES global
+# property there and has no effect if set after it, and under a top-level test so a consumer
+# that pulls this library in through FetchContent keeps its own messages.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CMAKE_TARGET_MESSAGES OFF)
+endif()
+
 project(Yojimbo VERSION 1.11.0 LANGUAGES C CXX)
 
 option(YOJIMBO_SYSTEM_SODIUM


### PR DESCRIPTION
One line does it:

    set(CMAKE_TARGET_MESSAGES OFF)

It sits above project(), wrapped in a top-level test (this repo has no *_TOP_LEVEL
guard variable of its own), so it applies only when this repo is the top level
project and a consumer that pulls the library in through FetchContent or
add_subdirectory keeps its own "Built target" messages.

Above project(), not after it: CMAKE_TARGET_MESSAGES initializes the TARGET_MESSAGES
global property at the project() call and has no effect if set later -- placed after
project(), a no-op rebuild still printed all 11 lines.

Before / after, on a tree with nothing to do:

    $ cmake --build build | wc -l
    11   # before
    0   # after

A real build is unchanged: it still prints its [ x%] progress lines. Errors are
untouched -- a deliberate syntax error in a source file still fails loudly with the
compiler diagnostic and a non-zero exit (verified, then reverted).

Tests: ./bin/test -> *** ALL TESTS PASS ***

Refs mas-bandwidth/rowan-new#110.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
