### PR TITLE
yojimbo 1.12.1: vendor netcode 1.4.5 and reliable 1.4.2 (Y9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,19 +123,20 @@ jobs:
             -DCMAKE_PREFIX_PATH="$HOME/yojimbo-install;$HOME/deps"
           cmake --build consumer-build -j
           ctest --test-dir consumer-build --output-on-failure
-      # A system-deps install must refuse a netcode inside the advisory range SECURITY.md
-      # records, at configure time (SEC-04). Break the installed netcode's version down to
-      # 1.3.2 and check the consumer's find_package fails.
+      # A system-deps install must refuse a netcode below the manifest floor, at configure time
+      # (SEC-04). The floor is 1.4.5, so the version to knock the installed netcode down to is
+      # 1.4.4: the newest netcode yojimbo now refuses, and the one an existing prefix is most
+      # likely to be holding.
       - name: The netcode floor is enforced for consumers
         run: |
           set -euo pipefail
           cp "$HOME/deps/include/netcode.h" "$HOME/netcode.h.orig"
-          sed -i 's/#define NETCODE_VERSION_MINOR.*/#define NETCODE_VERSION_MINOR 3/; s/#define NETCODE_VERSION_PATCH.*/#define NETCODE_VERSION_PATCH 2/' "$HOME/deps/include/netcode.h"
+          sed -i 's/#define NETCODE_VERSION_MINOR.*/#define NETCODE_VERSION_MINOR 4/; s/#define NETCODE_VERSION_PATCH.*/#define NETCODE_VERSION_PATCH 4/' "$HOME/deps/include/netcode.h"
           if cmake -B floor-build -S tools/consumer -DCMAKE_PREFIX_PATH="$HOME/yojimbo-install;$HOME/deps" > floor.log 2>&1; then
-            echo "expected find_package(Yojimbo) to refuse netcode 1.3.2"; cat floor.log; exit 1
+            echo "expected find_package(Yojimbo) to refuse netcode 1.4.4"; cat floor.log; exit 1
           fi
           # CMake wraps message() text, so flatten the log before matching the sentence.
-          tr '\n' ' ' < floor.log | tr -s ' ' | grep -q "yojimbo requires 1.4.0 or later"
+          tr '\n' ' ' < floor.log | tr -s ' ' | grep -q "yojimbo requires 1.4.5 or later"
           cp "$HOME/netcode.h.orig" "$HOME/deps/include/netcode.h"
 
   bundled-install-consumer:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -104,7 +104,7 @@ crypto).
 The three arrive as versioned imported targets: their versions are read from the installed
 headers and checked at configure time against the floors in `dependencies.manifest`, which is
 also where the versions vendored here and the tags CI installs are recorded. An installed
-netcode older than 1.4.0 is refused, not warned about — see SECURITY.md.
+netcode older than 1.4.5 is refused, not warned about — see SECURITY.md.
 
     cmake -B build -DYOJIMBO_SYSTEM_DEPS=ON
     cmake --build build -j

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ DECISIONS THAT READ AS BUGS (they are not — do not "fix" them)
 
 SECURITY: yojimbo 1.6.3 and earlier vendor a netcode missing the AEAD nonce-reuse fix
 (netcode 1.4.0); 1.7.0 was the first with it. See netcode's SECURITY.md.
+1.12.1 vendors netcode 1.4.5, which spends a connect token on the connection it admits and
+refuses tokens that predate the server's start. See SECURITY.md.
 
 THE WRITE/READ RULE — read this BEFORE reporting any assert as a missing bounds check
 Glenn, 2026-07-26: "intention is on write, user is responsible to not crash or do undefined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(CMAKE_TARGET_MESSAGES OFF)
 endif()
 
-project(Yojimbo VERSION 1.12.0 LANGUAGES C CXX)
+project(Yojimbo VERSION 1.12.1 LANGUAGES C CXX)
 
 option(YOJIMBO_SYSTEM_SODIUM
     "Link the system-installed libsodium instead of the bundled subset in sodium/" OFF)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,9 +33,9 @@ against a clean prefix for both installs.
 
 Here serialize, reliable and netcode come from their own packages: their headers are not
 installed, and `YojimboConfig.cmake` requires them instead, checking the installed versions
-against the floors in `dependencies.manifest` — currently netcode 1.4.0 or later (see
-SECURITY.md), reliable 1.4.0 or later and serialize 1.15.0 or later. A prefix holding a netcode
-inside a published advisory range fails at configure time rather than at runtime.
+against the floors in `dependencies.manifest` — currently netcode 1.4.5 or later (see
+SECURITY.md), reliable 1.4.2 or later and serialize 1.15.0 or later. A prefix holding a netcode
+below the floor fails at configure time rather than at runtime.
 
 `-DYOJIMBO_SYSTEM_SODIUM=ON` links the system libsodium instead of the bundled subset, and
 `-DYOJIMBO_SYSTEM_TLSF=ON` the system tlsf. `YojimboConfig.cmake` records which of these the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,41 @@ Out of scope: bugs in your own game code built on top of yojimbo, denial-of-serv
 requires an already-authenticated malicious peer flooding traffic, and issues in build
 tooling or example/test code that are not reachable at runtime.
 
+## Connect token handling changed in 1.12.1
+
+**yojimbo 1.12.1 vendors netcode 1.4.5.** That netcode tightens what the server accepts as a
+connect token, and the change is visible to anything built on yojimbo, so it is written down
+here rather than left in a version bump.
+
+A connect token is now good for exactly one connection. The server records a token as spent
+the moment it accepts the client holding it, and refuses that token from then on, from any
+address, whether or not the client is still connected. Before, a token stayed usable until it
+expired, so anyone who obtained a copy of a token in flight could ride it back in after the
+client it was minted for had left. The retry behavior a real client depends on is unchanged:
+retransmitted connection requests during a single handshake still work, because the token is
+not spent until the handshake completes.
+
+The server also refuses connect tokens that could have been issued before it started, which
+closes the gap where tokens minted for a previous run of a server stayed valid across a
+restart. This needs to know how long a lifetime your backend issues tokens with:
+`ClientServerConfig::maxConnectTokenLifetime`, in seconds, defaults to 30, which is netcode's
+default. Set it to your own backend's lifetime: the matcher under `matcher/` issues 45 second
+tokens, so a deployment running that sets 45. Setting it higher than your backend actually
+issues refuses legitimate tokens for the first few seconds after a server starts; setting it
+lower narrows the window this closes without breaking anything.
+
+Finally, every buffer holding a key is erased before it is reset or freed, so a key does not
+outlive its use in process memory.
+
+### What this asks of you
+
+If your game reuses a connect token to reconnect a dropped client, it stops working: ask the
+matchmaker for a fresh token instead, as you did for the first connection. If your backend
+issues connect tokens with a lifetime other than 30 seconds, set `maxConnectTokenLifetime` to
+match: 45 for the matcher in this repository. Nothing on the wire moved, so 1.12.1 talks to
+earlier versions exactly as before. What changed is which connect tokens a 1.12.1 server
+accepts, and your matchmaker does not have to change to keep issuing them.
+
 ## Known issue: AEAD nonce reuse in vendored netcode (fixed in 1.7.0)
 
 **Advisory: [GHSA-hqp3-fj6v-hrpc](https://github.com/mas-bandwidth/yojimbo/security/advisories/GHSA-hqp3-fj6v-hrpc)** (published 2026-07-26; a CVE has been requested and is pending assignment).

--- a/USAGE.md
+++ b/USAGE.md
@@ -79,6 +79,8 @@ Note that the adapter will have a null `GameServer` pointer when used on the cli
 
 A note on configuration: the config must be **identical on the client and the server**, or they won't be able to communicate. In debug builds, the config is validated automatically when the server starts and when the client connects — an invalid value asserts with an error naming the field and the required value. One thing to watch out for: `maxPacketFragments` is derived from `maxPacketSize` inside the `ClientServerConfig` constructor, so if you increase `maxPacketSize` in your own config, update `maxPacketFragments` to match (the validation catches this if you forget). In release builds validation compiles away entirely — correct configuration is your responsibility.
 
+One config field is server-only and worth setting deliberately: `maxConnectTokenLifetime`. It is the longest lifetime, in seconds, that your matchmaker issues connect tokens with, and it defaults to 30 seconds, netcode's default. The server refuses any connect token whose expiry, minus this lifetime, falls before the moment the server started, so a token minted before a restart cannot be spent after one. Set it to the lifetime your own backend actually issues. Setting it higher than your backend's lifetime refuses legitimate connect tokens for the first few seconds after the server starts; setting it lower lets tokens issued shortly before the restart through. Zero or less means the default. The matcher under `matcher/` issues 45 second connect tokens, so set this to 45 if you run it as-is.
+
 Let's take a look at the `TestMessage` class and briefly cover basic serialization:
 
 ```cpp
@@ -268,6 +270,8 @@ if (m_client.IsDisconnected() || m_client.ConnectionFailed()) {
 ```
 
 The reason is cleared back to `YOJIMBO_CLIENT_DISCONNECT_REASON_NONE` whenever a new connect attempt starts. Connecting to a server that isn't running reports `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT` after the connection timeout, for both secure and insecure connects. `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECT_TOKEN_EXPIRED` means the connect token's expiry passed before the client could connect — for example, the player sat on a menu too long after matchmaking — and the fix is to request a fresh token and retry.
+
+A connect token is good for one connection. Once the server has accepted a client with it, the token is spent: presenting it again is refused, from any address, whether or not that client is still connected. A client that drops and wants back in asks the matchmaker for a fresh token, exactly as it did the first time. This is why `Client::InsecureConnect` generates a new token on every call, and why holding onto a token to skip a matchmaker round trip does not work.
 
 For testing purposes, let's also send a `TestMessage` when the player presses a key:
 

--- a/dependencies.manifest
+++ b/dependencies.manifest
@@ -8,14 +8,15 @@
 #              vendored build compiles
 #   minimum    the floor a system-installed copy must meet, enforced at configure time
 #
-# netcode's floor is 1.4.0: SECURITY.md records the advisory affecting netcode 1.3.5 and
-# earlier, so linking an older system netcode is refused rather than warned about. serialize
-# and reliable floor at the vendored version because yojimbo's sources are written against it
-# and both define wire formats.
+# netcode's floor is 1.4.5: SECURITY.md records the connect token handling that lands there,
+# and yojimbo's server config passes max_connect_token_lifetime, a field netcode 1.4.4 and
+# earlier do not have. Linking an older system netcode is refused rather than warned about.
+# serialize and reliable floor at the vendored version because yojimbo's sources are written
+# against it and both define wire formats.
 #
 # The vendored column is checked against the vendored headers at configure time, so this file
 # cannot drift from the tree it describes.
 
 serialize  1.15.0  v1.15.0  1.15.0
-reliable   1.4.0   v1.4.0   1.4.0
-netcode    1.4.3   v1.4.3   1.4.0
+reliable   1.4.2   v1.4.2   1.4.2
+netcode    1.4.5   v1.4.5   1.4.5

--- a/fuzz/fuzz_netcode.c
+++ b/fuzz/fuzz_netcode.c
@@ -64,6 +64,7 @@ int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )
                                          g_packet_key,
                                          FUZZ_PROTOCOL_ID,
                                          FUZZ_TIMESTAMP,
+                                         0,                 // minimum expire timestamp: zero, so no connect token is refused for predating a server start and the fuzzer keeps reaching the parser
                                          g_private_key,
                                          allowed_packets,
                                          &replay_protection,

--- a/fuzz/fuzz_reliable.c
+++ b/fuzz/fuzz_reliable.c
@@ -10,6 +10,7 @@
 #include "reliable.h"
 #include <stdint.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 static struct reliable_endpoint_t * g_endpoint = NULL;
@@ -36,6 +37,8 @@ static void ensure_init( void )
     config.transmit_packet_function = fuzz_transmit_packet;
     config.process_packet_function = fuzz_process_packet;
     g_endpoint = reliable_endpoint_create( &config, g_time );
+    if ( !g_endpoint )
+        abort();    /* creation is fallible in every build: a NULL here is a broken target, not an input finding */
 }
 
 int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )

--- a/include/yojimbo_config.h
+++ b/include/yojimbo_config.h
@@ -33,7 +33,7 @@
 
 #define YOJIMBO_MAJOR_VERSION 1
 #define YOJIMBO_MINOR_VERSION 12
-#define YOJIMBO_PATCH_VERSION 0
+#define YOJIMBO_PATCH_VERSION 1
 
 #if !defined(YOJIMBO_DEBUG) && !defined(YOJIMBO_RELEASE)
 #if defined(NDEBUG)
@@ -238,6 +238,7 @@ namespace yojimbo
         int ackedPacketsBufferSize;                             ///< Number of packet entries in the acked packet buffer. Consider your packet send rate and aim to have at least a few seconds worth of entries.
         int receivedPacketsBufferSize;                          ///< Number of packet entries in the received packet sequence buffer. Consider your packet send rate and aim to have at least a few seconds worth of entries.
         float rttSmoothingFactor;                               ///< Round-Trip Time (RTT) smoothing factor over time.
+        int maxConnectTokenLifetime;                            ///< The longest lifetime in seconds your backend issues connect tokens with. Server only. The server refuses any connect token whose expiry, minus this lifetime, is earlier than the time the server started, so a token that could have been issued before a restart cannot be presented after it. Set it to the lifetime your matchmaker actually issues: too large refuses legitimate connect tokens until the difference has elapsed, too small lets tokens issued shortly before the server started through. Zero or less takes DefaultMaxConnectTokenLifetime.
 
         ClientServerConfig()
         {
@@ -255,6 +256,7 @@ namespace yojimbo
             ackedPacketsBufferSize = 256;
             receivedPacketsBufferSize = 256;
             rttSmoothingFactor = 0.0025f;
+            maxConnectTokenLifetime = DefaultMaxConnectTokenLifetime;
         }
 
         /**

--- a/include/yojimbo_constants.h
+++ b/include/yojimbo_constants.h
@@ -37,6 +37,8 @@ namespace yojimbo
 
     const int ConnectTokenBytes = 2048;                             ///< Size of the encrypted connect token data return from the matchmaker. Must equal size of NETCODE_CONNECT_TOKEN_BYTE (2048).
 
+    const int DefaultMaxConnectTokenLifetime = 30;                  ///< Default for ClientServerConfig::maxConnectTokenLifetime (seconds). Must equal NETCODE_DEFAULT_MAX_CONNECT_TOKEN_LIFETIME (30). The matcher under matcher/ issues 45 second connect tokens, so a deployment running it as-is sets maxConnectTokenLifetime to 45.
+
     const int InsecureConnectTokenExpirySeconds = 60;               ///< Expiry for insecure connect tokens (seconds). Kept well above the connection timeout so a failed insecure connect reports "connection request timed out" like a secure connect token from a matchmaker would, rather than hitting token expiry first.
 
     const int ConservativeMessageHeaderBits = 32;                   ///< Conservative number of bits per-message header.

--- a/netcode/netcode.c
+++ b/netcode/netcode.c
@@ -276,10 +276,12 @@ int netcode_parse_address( NETCODE_CONST char * address_string_in, struct netcod
     if ( inet_pton( AF_INET6, address_string, &sockaddr6 ) == 1 )
     {
         address->type = NETCODE_ADDRESS_IPV6;
+        uint16_t ipv6_network_order[8];
+        memcpy( ipv6_network_order, &sockaddr6, sizeof( ipv6_network_order ) );
         int i;
         for ( i = 0; i < 8; i++ )
         {
-            address->data.ipv6[i] = ntohs( ( (uint16_t*) &sockaddr6 ) [i] );
+            address->data.ipv6[i] = ntohs( ipv6_network_order[i] );
         }
         return NETCODE_OK;
     }
@@ -309,10 +311,11 @@ int netcode_parse_address( NETCODE_CONST char * address_string_in, struct netcod
     if ( inet_pton( AF_INET, address_string, &sockaddr4.sin_addr ) == 1 )
     {
         address->type = NETCODE_ADDRESS_IPV4;
-        address->data.ipv4[3] = (uint8_t) ( ( sockaddr4.sin_addr.s_addr & 0xFF000000 ) >> 24 );
-        address->data.ipv4[2] = (uint8_t) ( ( sockaddr4.sin_addr.s_addr & 0x00FF0000 ) >> 16 );
-        address->data.ipv4[1] = (uint8_t) ( ( sockaddr4.sin_addr.s_addr & 0x0000FF00 ) >> 8  );
-        address->data.ipv4[0] = (uint8_t) ( ( sockaddr4.sin_addr.s_addr & 0x000000FF )       );
+        uint32_t ipv4_host_order = ntohl( sockaddr4.sin_addr.s_addr );
+        address->data.ipv4[0] = (uint8_t) ( ( ipv4_host_order >> 24 ) & 0xFF );
+        address->data.ipv4[1] = (uint8_t) ( ( ipv4_host_order >> 16 ) & 0xFF );
+        address->data.ipv4[2] = (uint8_t) ( ( ipv4_host_order >> 8  ) & 0xFF );
+        address->data.ipv4[3] = (uint8_t) ( ( ipv4_host_order       ) & 0xFF );
         return NETCODE_OK;
     }
 
@@ -332,7 +335,9 @@ char * netcode_address_to_string( struct netcode_address_t * address, char * buf
             int i;
             for ( i = 0; i < 8; i++ )
                 ipv6_network_order[i] = htons( address->data.ipv6[i] );
-            inet_ntop( AF_INET6, (void*) ipv6_network_order, buffer, NETCODE_MAX_ADDRESS_STRING_LENGTH );
+            struct in6_addr sockaddr6;
+            memcpy( &sockaddr6, ipv6_network_order, sizeof( ipv6_network_order ) );
+            inet_ntop( AF_INET6, &sockaddr6, buffer, NETCODE_MAX_ADDRESS_STRING_LENGTH );
             return buffer;
         }
         else
@@ -342,7 +347,9 @@ char * netcode_address_to_string( struct netcode_address_t * address, char * buf
             int i;
             for ( i = 0; i < 8; i++ )
                 ipv6_network_order[i] = htons( address->data.ipv6[i] );
-            inet_ntop( AF_INET6, (void*) ipv6_network_order, address_string, INET6_ADDRSTRLEN );
+            struct in6_addr sockaddr6;
+            memcpy( &sockaddr6, ipv6_network_order, sizeof( ipv6_network_order ) );
+            inet_ntop( AF_INET6, &sockaddr6, address_string, INET6_ADDRSTRLEN );
             snprintf( buffer, NETCODE_MAX_ADDRESS_STRING_LENGTH, "[%s]:%d", address_string, address->port );
             return buffer;
         }
@@ -572,10 +579,12 @@ static socklen_t netcode_address_to_sockaddr( NETCODE_CONST struct netcode_addre
         struct sockaddr_in6 * addr_ipv6 = (struct sockaddr_in6*) sockaddr;
         addr_ipv6->sin6_family = AF_INET6;
         int i;
+        uint16_t ipv6_network_order[8];
         for ( i = 0; i < 8; i++ )
         {
-            ( (uint16_t*) &addr_ipv6->sin6_addr ) [i] = htons( address->data.ipv6[i] );
+            ipv6_network_order[i] = htons( address->data.ipv6[i] );
         }
+        memcpy( &addr_ipv6->sin6_addr, ipv6_network_order, sizeof( ipv6_network_order ) );
         addr_ipv6->sin6_port = htons( address->port );
         return sizeof( struct sockaddr_in6 );
     }
@@ -583,10 +592,10 @@ static socklen_t netcode_address_to_sockaddr( NETCODE_CONST struct netcode_addre
     {
         struct sockaddr_in * addr_ipv4 = (struct sockaddr_in*) sockaddr;
         addr_ipv4->sin_family = AF_INET;
-        addr_ipv4->sin_addr.s_addr = ( ( (uint32_t) address->data.ipv4[0] ) )        |
-                                     ( ( (uint32_t) address->data.ipv4[1] ) << 8 )   |
-                                     ( ( (uint32_t) address->data.ipv4[2] ) << 16 )  |
-                                     ( ( (uint32_t) address->data.ipv4[3] ) << 24 );
+        addr_ipv4->sin_addr.s_addr = htonl( ( ( (uint32_t) address->data.ipv4[0] ) << 24 ) |
+                                            ( ( (uint32_t) address->data.ipv4[1] ) << 16 ) |
+                                            ( ( (uint32_t) address->data.ipv4[2] ) << 8  ) |
+                                            ( ( (uint32_t) address->data.ipv4[3] )       ) );
         addr_ipv4->sin_port = htons( address->port );
         return sizeof( struct sockaddr_in );
     }
@@ -601,10 +610,12 @@ static int netcode_sockaddr_to_address( NETCODE_CONST struct sockaddr_storage * 
     {
         NETCODE_CONST struct sockaddr_in6 * addr_ipv6 = (NETCODE_CONST struct sockaddr_in6*) sockaddr;
         address->type = NETCODE_ADDRESS_IPV6;
+        uint16_t ipv6_network_order[8];
+        memcpy( ipv6_network_order, &addr_ipv6->sin6_addr, sizeof( ipv6_network_order ) );
         int i;
         for ( i = 0; i < 8; i++ )
         {
-            address->data.ipv6[i] = ntohs( ( (NETCODE_CONST uint16_t*) &addr_ipv6->sin6_addr ) [i] );
+            address->data.ipv6[i] = ntohs( ipv6_network_order[i] );
         }
         address->port = ntohs( addr_ipv6->sin6_port );
         return NETCODE_OK;
@@ -613,10 +624,11 @@ static int netcode_sockaddr_to_address( NETCODE_CONST struct sockaddr_storage * 
     {
         NETCODE_CONST struct sockaddr_in * addr_ipv4 = (NETCODE_CONST struct sockaddr_in*) sockaddr;
         address->type = NETCODE_ADDRESS_IPV4;
-        address->data.ipv4[0] = (uint8_t) ( ( addr_ipv4->sin_addr.s_addr & 0x000000FF ) );
-        address->data.ipv4[1] = (uint8_t) ( ( addr_ipv4->sin_addr.s_addr & 0x0000FF00 ) >> 8 );
-        address->data.ipv4[2] = (uint8_t) ( ( addr_ipv4->sin_addr.s_addr & 0x00FF0000 ) >> 16 );
-        address->data.ipv4[3] = (uint8_t) ( ( addr_ipv4->sin_addr.s_addr & 0xFF000000 ) >> 24 );
+        uint32_t ipv4_host_order = ntohl( addr_ipv4->sin_addr.s_addr );
+        address->data.ipv4[0] = (uint8_t) ( ( ipv4_host_order >> 24 ) & 0xFF );
+        address->data.ipv4[1] = (uint8_t) ( ( ipv4_host_order >> 16 ) & 0xFF );
+        address->data.ipv4[2] = (uint8_t) ( ( ipv4_host_order >> 8  ) & 0xFF );
+        address->data.ipv4[3] = (uint8_t) ( ( ipv4_host_order       ) & 0xFF );
         address->port = ntohs( addr_ipv4->sin_port );
         return NETCODE_OK;
     }
@@ -1524,6 +1536,104 @@ int netcode_sequence_number_bytes_required( uint64_t sequence )
     return 8 - i;
 }
 
+#if NETCODE_ENABLE_NONCE_AUDIT
+
+/*
+    Test-only instrumentation, compiled in by the NETCODE_NONCE_AUDIT build option.
+
+    Records the key and nonce of every packet netcode_write_packet encrypts and counts how
+    many times a pair repeats. A repeated key and nonce pair under AEAD is what a connect
+    token used for two sessions produces, so the whole test suite running with zero repeats
+    is the property worth pinning. Not built into the library.
+*/
+
+#define NETCODE_NONCE_AUDIT_MAX_RECORDS ( 1 << 18 )
+#define NETCODE_NONCE_AUDIT_HASH_SIZE ( 1 << 19 )
+#define NETCODE_NONCE_AUDIT_NONCE_BYTES 12
+
+struct netcode_nonce_audit_record_t
+{
+    uint8_t key[NETCODE_KEY_BYTES];
+    uint8_t nonce[NETCODE_NONCE_AUDIT_NONCE_BYTES];
+};
+
+static struct netcode_nonce_audit_record_t netcode_nonce_audit_records[NETCODE_NONCE_AUDIT_MAX_RECORDS];
+static int netcode_nonce_audit_hash[NETCODE_NONCE_AUDIT_HASH_SIZE];
+static int netcode_nonce_audit_hash_initialized;
+static int netcode_nonce_audit_num_records;
+static int netcode_nonce_audit_num_repeats;
+static int netcode_nonce_audit_overflowed;
+
+static void netcode_nonce_audit_write_packet( uint8_t * key, uint8_t * nonce )
+{
+    if ( !netcode_nonce_audit_hash_initialized )
+    {
+        int i;
+        for ( i = 0; i < NETCODE_NONCE_AUDIT_HASH_SIZE; i++ )
+        {
+            netcode_nonce_audit_hash[i] = -1;
+        }
+        netcode_nonce_audit_hash_initialized = 1;
+    }
+
+    uint64_t hash = 0xCBF29CE484222325ULL;
+    int i;
+    for ( i = 0; i < NETCODE_KEY_BYTES; i++ )
+    {
+        hash ^= key[i];
+        hash *= 0x00000100000001B3ULL;
+    }
+    for ( i = 0; i < NETCODE_NONCE_AUDIT_NONCE_BYTES; i++ )
+    {
+        hash ^= nonce[i];
+        hash *= 0x00000100000001B3ULL;
+    }
+
+    int slot = (int) ( hash & ( NETCODE_NONCE_AUDIT_HASH_SIZE - 1 ) );
+
+    while ( netcode_nonce_audit_hash[slot] != -1 )
+    {
+        struct netcode_nonce_audit_record_t * record = &netcode_nonce_audit_records[netcode_nonce_audit_hash[slot]];
+        if ( memcmp( record->key, key, NETCODE_KEY_BYTES ) == 0 && memcmp( record->nonce, nonce, NETCODE_NONCE_AUDIT_NONCE_BYTES ) == 0 )
+        {
+            netcode_nonce_audit_num_repeats++;
+            printf( "NONCE AUDIT: repeated key and nonce pair: key %.2x%.2x%.2x%.2x.. sequence %d\n", 
+                key[0], key[1], key[2], key[3], (int) nonce[4] );
+            return;
+        }
+        slot = ( slot + 1 ) & ( NETCODE_NONCE_AUDIT_HASH_SIZE - 1 );
+    }
+
+    if ( netcode_nonce_audit_num_records == NETCODE_NONCE_AUDIT_MAX_RECORDS )
+    {
+        netcode_nonce_audit_overflowed = 1;
+        return;
+    }
+
+    struct netcode_nonce_audit_record_t * record = &netcode_nonce_audit_records[netcode_nonce_audit_num_records];
+    memcpy( record->key, key, NETCODE_KEY_BYTES );
+    memcpy( record->nonce, nonce, NETCODE_NONCE_AUDIT_NONCE_BYTES );
+    netcode_nonce_audit_hash[slot] = netcode_nonce_audit_num_records;
+    netcode_nonce_audit_num_records++;
+}
+
+int netcode_nonce_audit_num_pairs()
+{
+    return netcode_nonce_audit_num_records;
+}
+
+int netcode_nonce_audit_repeats()
+{
+    return netcode_nonce_audit_num_repeats;
+}
+
+int netcode_nonce_audit_overflow()
+{
+    return netcode_nonce_audit_overflowed;
+}
+
+#endif // #if NETCODE_ENABLE_NONCE_AUDIT
+
 int netcode_write_packet( void * packet, uint8_t * buffer, int buffer_length, uint64_t sequence, uint8_t * write_packet_key, uint64_t protocol_id )
 {
     netcode_assert( packet );
@@ -1662,6 +1772,10 @@ int netcode_write_packet( void * packet, uint8_t * buffer, int buffer_length, ui
             netcode_write_uint64( &p, sequence );
         }
 
+        #if NETCODE_ENABLE_NONCE_AUDIT
+        netcode_nonce_audit_write_packet( write_packet_key, nonce );
+        #endif // #if NETCODE_ENABLE_NONCE_AUDIT
+
         if ( netcode_encrypt_aead( encrypted_start, 
                                    encrypted_finish - encrypted_start, 
                                    additional_data, sizeof( additional_data ), 
@@ -1731,6 +1845,7 @@ void * netcode_read_packet( uint8_t * buffer,
                             uint8_t * read_packet_key, 
                             uint64_t protocol_id, 
                             uint64_t current_timestamp, 
+                            uint64_t min_connect_token_expire_timestamp, 
                             uint8_t * private_key, 
                             uint8_t * allowed_packets, 
                             struct netcode_replay_protection_t * replay_protection, 
@@ -1811,6 +1926,15 @@ void * netcode_read_packet( uint8_t * buffer,
         if ( packet_connect_token_expire_timestamp <= current_timestamp )
         {
             netcode_printf( NETCODE_LOG_LEVEL_DEBUG, "ignored connection request packet. connect token expired\n" );
+            return NULL;
+        }
+
+        // a connect token that could have been issued before the server started is refused: its keys
+        // were already used to encrypt packets under sequence numbers that start again from zero.
+
+        if ( packet_connect_token_expire_timestamp < min_connect_token_expire_timestamp )
+        {
+            netcode_printf( NETCODE_LOG_LEVEL_DEBUG, "ignored connection request packet. connect token predates the server start\n" );
             return NULL;
         }
 
@@ -2326,19 +2450,6 @@ void netcode_packet_queue_init( struct netcode_packet_queue_t * queue,
     memset( queue->packet_sequence, 0, sizeof( queue->packet_sequence ) );
 }
 
-void netcode_packet_queue_clear( struct netcode_packet_queue_t * queue )
-{
-    int i;
-    for ( i = 0; i < queue->num_packets; i++ )
-    {
-        queue->free_function( queue->allocator_context, queue->packet_data[i] );
-    }
-    queue->num_packets = 0;
-    queue->start_index = 0;
-    memset( queue->packet_data, 0, sizeof( queue->packet_data ) );
-    memset( queue->packet_sequence, 0, sizeof( queue->packet_sequence ) );
-}
-
 int netcode_packet_queue_push( struct netcode_packet_queue_t * queue, void * packet_data, uint64_t packet_sequence )
 {
     netcode_assert( queue );
@@ -2365,6 +2476,18 @@ void * netcode_packet_queue_pop( struct netcode_packet_queue_t * queue, uint64_t
     queue->start_index = ( queue->start_index + 1 ) % NETCODE_PACKET_QUEUE_SIZE;
     queue->num_packets--;
     return packet;
+}
+
+void netcode_packet_queue_clear( struct netcode_packet_queue_t * queue )
+{
+    netcode_assert( queue );
+    while ( queue->num_packets > 0 )
+    {
+        queue->free_function( queue->allocator_context, netcode_packet_queue_pop( queue, NULL ) );
+    }
+    queue->start_index = 0;
+    memset( queue->packet_data, 0, sizeof( queue->packet_data ) );
+    memset( queue->packet_sequence, 0, sizeof( queue->packet_sequence ) );
 }
 
 // ----------------------------------------------------------------
@@ -2859,8 +2982,8 @@ struct netcode_client_t * netcode_client_create_dual( NETCODE_CONST char * addre
     client->challenge_token_sequence = 0;
     client->loopback = 0;
     memset( &client->server_address, 0, sizeof( struct netcode_address_t ) );
-    memset( &client->connect_token, 0, sizeof( struct netcode_connect_token_t ) );
-    memset( &client->context, 0, sizeof( struct netcode_context_t ) );
+    sodium_memzero( &client->connect_token, sizeof( struct netcode_connect_token_t ) );
+    sodium_memzero( &client->context, sizeof( struct netcode_context_t ) );
     memset( client->challenge_token_data, 0, NETCODE_CHALLENGE_TOKEN_BYTES );
 
     netcode_packet_queue_init( &client->packet_receive_queue, config->allocator_context, config->allocate_function, config->free_function );
@@ -2928,20 +3051,12 @@ void netcode_client_reset_connection_data( struct netcode_client_t * client, int
     client->connect_start_time = 0.0;
     client->server_address_index = 0;
     memset( &client->server_address, 0, sizeof( struct netcode_address_t ) );
-    memset( &client->connect_token, 0, sizeof( struct netcode_connect_token_t ) );
-    memset( &client->context, 0, sizeof( struct netcode_context_t ) );
+    sodium_memzero( &client->connect_token, sizeof( struct netcode_connect_token_t ) );
+    sodium_memzero( &client->context, sizeof( struct netcode_context_t ) );
 
     netcode_client_set_state( client, client_state );
 
     netcode_client_reset_before_next_connect( client );
-
-    while ( 1 )
-    {
-        void * packet = netcode_packet_queue_pop( &client->packet_receive_queue, NULL );
-        if ( !packet )
-            break;
-        client->config.free_function( client->config.allocator_context, packet );
-    }
 
     netcode_packet_queue_clear( &client->packet_receive_queue );
 }
@@ -3107,6 +3222,7 @@ void netcode_client_process_packet( struct netcode_client_t * client, struct net
                                          client->context.read_packet_key, 
                                          client->connect_token.protocol_id, 
                                          current_timestamp, 
+                                         0, 
                                          NULL, 
                                          allowed_packets, 
                                          &client->replay_protection, 
@@ -3570,6 +3686,7 @@ struct netcode_encryption_manager_t
     double last_access_time[NETCODE_MAX_ENCRYPTION_MAPPINGS];
     struct netcode_address_t address[NETCODE_MAX_ENCRYPTION_MAPPINGS];
     int client_index[NETCODE_MAX_ENCRYPTION_MAPPINGS];
+    int connect_token_entry_index[NETCODE_MAX_ENCRYPTION_MAPPINGS];
     uint8_t send_key[NETCODE_KEY_BYTES*NETCODE_MAX_ENCRYPTION_MAPPINGS];
     uint8_t receive_key[NETCODE_KEY_BYTES*NETCODE_MAX_ENCRYPTION_MAPPINGS];
 };
@@ -3586,14 +3703,15 @@ void netcode_encryption_manager_reset( struct netcode_encryption_manager_t * enc
     for ( i = 0; i < NETCODE_MAX_ENCRYPTION_MAPPINGS; i++ )
     {
         encryption_manager->client_index[i] = -1;
+        encryption_manager->connect_token_entry_index[i] = -1;
         encryption_manager->expire_time[i] = -1.0;
         encryption_manager->last_access_time[i] = -1000.0;
         memset( &encryption_manager->address[i], 0, sizeof( struct netcode_address_t ) );
     }
 
     memset( encryption_manager->timeout, 0, sizeof( encryption_manager->timeout ) );    
-    memset( encryption_manager->send_key, 0, sizeof( encryption_manager->send_key ) );
-    memset( encryption_manager->receive_key, 0, sizeof( encryption_manager->receive_key ) );
+    sodium_memzero( encryption_manager->send_key, sizeof( encryption_manager->send_key ) );
+    sodium_memzero( encryption_manager->receive_key, sizeof( encryption_manager->receive_key ) );
 }
 
 int netcode_encryption_manager_entry_expired( struct netcode_encryption_manager_t * encryption_manager, int index, double time )
@@ -3608,7 +3726,8 @@ int netcode_encryption_manager_add_encryption_mapping( struct netcode_encryption
                                                        uint8_t * receive_key, 
                                                        double time, 
                                                        double expire_time,
-                                                       int timeout )
+                                                       int timeout,
+                                                       int connect_token_entry_index )
 {
     int i;
     for ( i = 0; i < encryption_manager->num_encryption_mappings; i++ )
@@ -3618,6 +3737,7 @@ int netcode_encryption_manager_add_encryption_mapping( struct netcode_encryption
             encryption_manager->timeout[i] = timeout;
             encryption_manager->expire_time[i] = expire_time;
             encryption_manager->last_access_time[i] = time;
+            encryption_manager->connect_token_entry_index[i] = connect_token_entry_index;
             memcpy( encryption_manager->send_key + i * NETCODE_KEY_BYTES, send_key, NETCODE_KEY_BYTES );
             memcpy( encryption_manager->receive_key + i * NETCODE_KEY_BYTES, receive_key, NETCODE_KEY_BYTES );
             return 1;
@@ -3633,6 +3753,7 @@ int netcode_encryption_manager_add_encryption_mapping( struct netcode_encryption
             encryption_manager->address[i] = *address;
             encryption_manager->expire_time[i] = expire_time;
             encryption_manager->last_access_time[i] = time;
+            encryption_manager->connect_token_entry_index[i] = connect_token_entry_index;
             memcpy( encryption_manager->send_key + i * NETCODE_KEY_BYTES, send_key, NETCODE_KEY_BYTES );
             memcpy( encryption_manager->receive_key + i * NETCODE_KEY_BYTES, receive_key, NETCODE_KEY_BYTES );
             if ( i + 1 > encryption_manager->num_encryption_mappings )
@@ -3656,9 +3777,10 @@ int netcode_encryption_manager_remove_encryption_mapping( struct netcode_encrypt
         {
             encryption_manager->expire_time[i] = -1.0;
             encryption_manager->last_access_time[i] = -1000.0;
+            encryption_manager->connect_token_entry_index[i] = -1;
             memset( &encryption_manager->address[i], 0, sizeof( struct netcode_address_t ) );
-            memset( encryption_manager->send_key + i * NETCODE_KEY_BYTES, 0, NETCODE_KEY_BYTES );
-            memset( encryption_manager->receive_key + i * NETCODE_KEY_BYTES, 0, NETCODE_KEY_BYTES );
+            sodium_memzero( encryption_manager->send_key + i * NETCODE_KEY_BYTES, NETCODE_KEY_BYTES );
+            sodium_memzero( encryption_manager->receive_key + i * NETCODE_KEY_BYTES, NETCODE_KEY_BYTES );
 
             if ( i + 1 == encryption_manager->num_encryption_mappings )
             {
@@ -3744,13 +3866,32 @@ int netcode_encryption_manager_get_timeout( struct netcode_encryption_manager_t 
     return encryption_manager->timeout[index];
 }
 
+int netcode_encryption_manager_get_connect_token_entry_index( struct netcode_encryption_manager_t * encryption_manager, int index )
+{
+    netcode_assert( encryption_manager );
+    if ( index == -1 )
+        return -1;
+    netcode_assert( index >= 0 );
+    netcode_assert( index < encryption_manager->num_encryption_mappings );
+    return encryption_manager->connect_token_entry_index[index];
+}
+
 // ----------------------------------------------------------------
 
 #define NETCODE_MAX_CONNECT_TOKEN_ENTRIES ( NETCODE_MAX_CLIENTS * 8 )
 
+#define NETCODE_CONNECT_TOKEN_ENTRY_FREE        0
+#define NETCODE_CONNECT_TOKEN_ENTRY_PENDING     1
+#define NETCODE_CONNECT_TOKEN_ENTRY_CONSUMED    2
+
+#define NETCODE_CONNECT_TOKEN_ENTRY_REFUSED     -1
+#define NETCODE_CONNECT_TOKEN_HISTORY_FULL      -2
+
 struct netcode_connect_token_entry_t
 {
-    double time;
+    int state;
+    double time;                    // server time the entry was created. never refreshed afterwards
+    uint64_t expire_timestamp;      // when the connect token expires, and with it this entry
     uint8_t mac[NETCODE_MAC_BYTES];
     struct netcode_address_t address;
 };
@@ -3760,60 +3901,100 @@ void netcode_connect_token_entries_reset( struct netcode_connect_token_entry_t *
     int i;
     for ( i = 0; i < NETCODE_MAX_CONNECT_TOKEN_ENTRIES; i++ )
     {
+        connect_token_entries[i].state = NETCODE_CONNECT_TOKEN_ENTRY_FREE;
         connect_token_entries[i].time = -1000.0;
+        connect_token_entries[i].expire_timestamp = 0;
         memset( connect_token_entries[i].mac, 0, NETCODE_MAC_BYTES );
         memset( &connect_token_entries[i].address, 0, sizeof( struct netcode_address_t ) );
     }
 }
 
+/*
+    Returns the index of the entry that admits this connection request, or one of
+    NETCODE_CONNECT_TOKEN_ENTRY_REFUSED and NETCODE_CONNECT_TOKEN_HISTORY_FULL.
+
+    An entry is created pending the first time a connect token is seen, and becomes consumed
+    when the client that presented it is installed in a client slot. A pending entry admits
+    a retransmitted connection request from the address that created it, so a handshake that
+    loses a packet still completes. A consumed entry admits nothing, whatever the address, so
+    the keys inside a connect token encrypt exactly one session.
+
+    An entry lives until its connect token expires. A history whose entries all hold unexpired
+    connect tokens refuses a new connect token instead of evicting one, because evicting is
+    how a flood of connect tokens would reopen a token that has already been used.
+*/
+
 int netcode_connect_token_entries_find_or_add( struct netcode_connect_token_entry_t * connect_token_entries, 
                                                struct netcode_address_t * address, 
                                                uint8_t * mac, 
+                                               uint64_t expire_timestamp, 
+                                               uint64_t current_timestamp, 
                                                double time )
 {
     netcode_assert( connect_token_entries );
     netcode_assert( address );
     netcode_assert( mac );
 
-    // find the matching entry for the token mac and the oldest token entry. constant time worst case. This is intentional!
+    // find the matching entry for the token mac and the first entry free to take a new token. 
+    // constant time worst case. This is intentional!
 
     int matching_token_index = -1;
-    int oldest_token_index = -1;
-    double oldest_token_time = 0.0;
+    int free_token_index = -1;
 
     int i;
     for ( i = 0; i < NETCODE_MAX_CONNECT_TOKEN_ENTRIES; i++ )
     {
-        if ( memcmp( mac, connect_token_entries[i].mac, NETCODE_MAC_BYTES ) == 0 )
-            matching_token_index = i;
-        
-        if ( oldest_token_index == -1 || connect_token_entries[i].time < oldest_token_time )
+        if ( connect_token_entries[i].state != NETCODE_CONNECT_TOKEN_ENTRY_FREE && 
+             memcmp( mac, connect_token_entries[i].mac, NETCODE_MAC_BYTES ) == 0 )
         {
-            oldest_token_time = connect_token_entries[i].time;
-            oldest_token_index = i;
+            matching_token_index = i;
+        }
+
+        if ( free_token_index == -1 && 
+             ( connect_token_entries[i].state == NETCODE_CONNECT_TOKEN_ENTRY_FREE || 
+               connect_token_entries[i].expire_timestamp <= current_timestamp ) )
+        {
+            free_token_index = i;
         }
     }
 
-    // if no entry is found with the mac, this is a new connect token. replace the oldest token entry.
-
-    netcode_assert( oldest_token_index != -1 );
+    // if no entry is found with the mac, this is a new connect token
 
     if ( matching_token_index == -1 )
     {
-        connect_token_entries[oldest_token_index].time = time;
-        connect_token_entries[oldest_token_index].address = *address;
-        memcpy( connect_token_entries[oldest_token_index].mac, mac, NETCODE_MAC_BYTES );
-        return 1;
+        if ( free_token_index == -1 )
+            return NETCODE_CONNECT_TOKEN_HISTORY_FULL;
+
+        connect_token_entries[free_token_index].state = NETCODE_CONNECT_TOKEN_ENTRY_PENDING;
+        connect_token_entries[free_token_index].time = time;
+        connect_token_entries[free_token_index].expire_timestamp = expire_timestamp;
+        connect_token_entries[free_token_index].address = *address;
+        memcpy( connect_token_entries[free_token_index].mac, mac, NETCODE_MAC_BYTES );
+        return free_token_index;
     }
 
-    // allow connect tokens we have already seen from the same address
+    // a pending entry admits the address that created it, and nothing else. a consumed entry admits nothing.
+    // the entry time is set when the entry is created and is never refreshed.
 
     netcode_assert( matching_token_index >= 0 );
     netcode_assert( matching_token_index < NETCODE_MAX_CONNECT_TOKEN_ENTRIES );
-    if ( netcode_address_equal( &connect_token_entries[matching_token_index].address, address ) )
-        return 1;
 
-    return 0;
+    if ( connect_token_entries[matching_token_index].state == NETCODE_CONNECT_TOKEN_ENTRY_PENDING && 
+         netcode_address_equal( &connect_token_entries[matching_token_index].address, address ) )
+    {
+        return matching_token_index;
+    }
+
+    return NETCODE_CONNECT_TOKEN_ENTRY_REFUSED;
+}
+
+void netcode_connect_token_entries_consume( struct netcode_connect_token_entry_t * connect_token_entries, int index )
+{
+    netcode_assert( connect_token_entries );
+    netcode_assert( index >= 0 );
+    netcode_assert( index < NETCODE_MAX_CONNECT_TOKEN_ENTRIES );
+
+    connect_token_entries[index].state = NETCODE_CONNECT_TOKEN_ENTRY_CONSUMED;
 }
 
 typedef uint64_t netcode_fnv_t;
@@ -3861,6 +4042,7 @@ uint64_t netcode_hash_data( NETCODE_CONST uint8_t * data, size_t size )
 void netcode_default_server_config( struct netcode_server_config_t * config )
 {
     netcode_assert( config );
+    config->max_connect_token_lifetime = NETCODE_DEFAULT_MAX_CONNECT_TOKEN_LIFETIME;
     config->allocator_context = NULL;
     config->allocate_function = netcode_default_allocate_function;
     config->free_function = netcode_default_free_function;
@@ -3886,6 +4068,7 @@ struct netcode_server_t
     int num_connected_clients;
     uint64_t global_sequence;
     uint64_t challenge_sequence;
+    uint64_t min_connect_token_expire_timestamp;
     uint8_t challenge_key[NETCODE_KEY_BYTES];
     int client_connected[NETCODE_MAX_CLIENTS];
     int client_timeout[NETCODE_MAX_CLIENTS];
@@ -3970,6 +4153,8 @@ struct netcode_server_t * netcode_server_create_dual( NETCODE_CONST char * serve
         config_copy.allocate_function = netcode_default_allocate_function;
     if ( !config_copy.free_function )
         config_copy.free_function = netcode_default_free_function;
+    if ( config_copy.max_connect_token_lifetime <= 0 )
+        config_copy.max_connect_token_lifetime = NETCODE_DEFAULT_MAX_CONNECT_TOKEN_LIFETIME;
     config = &config_copy;
 
     struct netcode_address_t server_address1;
@@ -4089,6 +4274,8 @@ void netcode_server_destroy( struct netcode_server_t * server )
     netcode_socket_destroy( &server->socket_holder.ipv4 );
     netcode_socket_destroy( &server->socket_holder.ipv6 );
 
+    sodium_memzero( server->config.private_key, NETCODE_KEY_BYTES );
+
     server->config.free_function( server->config.allocator_context, server );
 }
 
@@ -4119,6 +4306,13 @@ void netcode_server_start( struct netcode_server_t * server, int max_clients )
     server->num_connected_clients = 0;
     server->challenge_sequence = 0;
     netcode_generate_key( server->challenge_key );
+
+    // a connect token issued before this server started carries keys that already encrypted
+    // packets at sequence numbers this run starts again from. the earliest expire timestamp a
+    // connect token issued after the start can carry is the start time plus the maximum
+    // lifetime the backend issues, so anything earlier than that is refused.
+
+    server->min_connect_token_expire_timestamp = (uint64_t) time( NULL ) + (uint64_t) server->config.max_connect_token_lifetime;
 
     // global packets (challenge, denied) encrypt with the same per-token server to client
     // keys as per-client packets, whose sequences start at zero, so the global sequence
@@ -4208,14 +4402,6 @@ void netcode_server_send_client_packet( struct netcode_server_t * server, void *
 
 static void netcode_server_reset_client_slot( struct netcode_server_t * server, int client_index )
 {
-    while ( 1 )
-    {
-        void * packet = netcode_packet_queue_pop( &server->client_packet_queue[client_index], NULL );
-        if ( !packet )
-            break;
-        server->config.free_function( server->config.allocator_context, packet );
-    }
-
     netcode_packet_queue_clear( &server->client_packet_queue[client_index] );
 
     server->client_connected[client_index] = 0;
@@ -4347,7 +4533,7 @@ void netcode_server_stop( struct netcode_server_t * server )
 
     server->global_sequence = 0;
     server->challenge_sequence = 0;
-    memset( server->challenge_key, 0, NETCODE_KEY_BYTES );
+    sodium_memzero( server->challenge_key, NETCODE_KEY_BYTES );
 
     netcode_connect_token_entries_reset( server->connect_token_entries );
 
@@ -4387,11 +4573,10 @@ int netcode_server_find_client_index_by_address( struct netcode_server_t * serve
 
 void netcode_server_process_connection_request_packet( struct netcode_server_t * server, 
                                                        struct netcode_address_t * from, 
-                                                       struct netcode_connection_request_packet_t * packet )
+                                                       struct netcode_connection_request_packet_t * packet, 
+                                                       uint64_t current_timestamp )
 {
     netcode_assert( server );
-
-    (void) from;
 
     struct netcode_connect_token_private_t connect_token_private;
     if ( netcode_read_connect_token_private( packet->connect_token_data, NETCODE_CONNECT_TOKEN_PRIVATE_BYTES, &connect_token_private ) != NETCODE_OK )
@@ -4431,10 +4616,20 @@ void netcode_server_process_connection_request_packet( struct netcode_server_t *
         return;
     }
 
-    if ( !netcode_connect_token_entries_find_or_add( server->connect_token_entries, 
-                                                     from, 
-                                                     packet->connect_token_data + NETCODE_CONNECT_TOKEN_PRIVATE_BYTES - NETCODE_MAC_BYTES, 
-                                                     server->time ) )
+    int connect_token_entry_index = netcode_connect_token_entries_find_or_add( server->connect_token_entries, 
+                                                                               from, 
+                                                                               packet->connect_token_data + NETCODE_CONNECT_TOKEN_PRIVATE_BYTES - NETCODE_MAC_BYTES, 
+                                                                               packet->connect_token_expire_timestamp, 
+                                                                               current_timestamp, 
+                                                                               server->time );
+
+    if ( connect_token_entry_index == NETCODE_CONNECT_TOKEN_HISTORY_FULL )
+    {
+        netcode_printf( NETCODE_LOG_LEVEL_DEBUG, "server ignored connection request. connect token history is full\n" );
+        return;
+    }
+
+    if ( connect_token_entry_index == NETCODE_CONNECT_TOKEN_ENTRY_REFUSED )
     {
         netcode_printf( NETCODE_LOG_LEVEL_DEBUG, "server ignored connection request. connect token has already been used\n" );
         return;
@@ -4460,7 +4655,8 @@ void netcode_server_process_connection_request_packet( struct netcode_server_t *
                                                              connect_token_private.client_to_server_key, 
                                                              server->time, 
                                                              expire_time,
-                                                             connect_token_private.timeout_seconds ) )
+                                                             connect_token_private.timeout_seconds,
+                                                             connect_token_entry_index ) )
     {
         netcode_printf( NETCODE_LOG_LEVEL_DEBUG, "server ignored connection request. failed to add encryption mapping\n" );
         return;
@@ -4545,6 +4741,14 @@ void netcode_server_connect_client( struct netcode_server_t * server,
     server->client_last_packet_send_time[client_index] = server->time;
     server->client_last_packet_receive_time[client_index] = server->time;
     memcpy( server->client_user_data[client_index], user_data, NETCODE_USER_DATA_BYTES );
+
+    // the connect token that got this client here is spent: its history entry admits nothing from now on
+
+    int connect_token_entry_index = netcode_encryption_manager_get_connect_token_entry_index( &server->encryption_manager, encryption_index );
+    if ( connect_token_entry_index >= 0 )
+    {
+        netcode_connect_token_entries_consume( server->connect_token_entries, connect_token_entry_index );
+    }
 
     char address_string[NETCODE_MAX_ADDRESS_STRING_LENGTH];
 
@@ -4632,6 +4836,7 @@ void netcode_server_process_packet_internal( struct netcode_server_t * server,
                                              struct netcode_address_t * from, 
                                              void * packet, 
                                              uint64_t sequence, 
+                                             uint64_t current_timestamp, 
                                              int encryption_index, 
                                              int client_index )
 {
@@ -4651,7 +4856,7 @@ void netcode_server_process_packet_internal( struct netcode_server_t * server,
             {
                 char from_address_string[NETCODE_MAX_ADDRESS_STRING_LENGTH];
                 netcode_printf( NETCODE_LOG_LEVEL_DEBUG, "server received connection request from %s\n", netcode_address_to_string( from, from_address_string ) );
-                netcode_server_process_connection_request_packet( server, from, (struct netcode_connection_request_packet_t*) packet );
+                netcode_server_process_connection_request_packet( server, from, (struct netcode_connection_request_packet_t*) packet, current_timestamp );
             }
         }
         break;
@@ -4781,6 +4986,7 @@ void netcode_server_read_and_process_packet( struct netcode_server_t * server,
                                          read_packet_key, 
                                          server->config.protocol_id, 
                                          current_timestamp, 
+                                         server->min_connect_token_expire_timestamp, 
                                          server->config.private_key, 
                                          allowed_packets, 
                                          ( client_index != -1 ) ? &server->client_replay_protection[client_index] : NULL, 
@@ -4790,7 +4996,7 @@ void netcode_server_read_and_process_packet( struct netcode_server_t * server,
     if ( !packet )
         return;
 
-    netcode_server_process_packet_internal( server, from, packet, sequence, encryption_index, client_index );
+    netcode_server_process_packet_internal( server, from, packet, sequence, current_timestamp, encryption_index, client_index );
 }
 
 void netcode_server_receive_packets( struct netcode_server_t * server )
@@ -6263,7 +6469,7 @@ static void test_connection_request_packet()
     memset( allowed_packets, 1, sizeof( allowed_packets ) );
 
     struct netcode_connection_request_packet_t * output_packet = (struct netcode_connection_request_packet_t*) 
-        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), connect_token_key, allowed_packets, NULL, NULL, NULL );
+        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), 0, connect_token_key, allowed_packets, NULL, NULL, NULL );
 
     check( output_packet );
 
@@ -6307,7 +6513,7 @@ void test_connection_denied_packet()
     memset( allowed_packet_types, 1, sizeof( allowed_packet_types ) );
 
     struct netcode_connection_denied_packet_t * output_packet = (struct netcode_connection_denied_packet_t*) 
-        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), NULL, allowed_packet_types, NULL, NULL, NULL );
+        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), 0, NULL, allowed_packet_types, NULL, NULL, NULL );
 
     check( output_packet );
 
@@ -6348,7 +6554,7 @@ void test_connection_challenge_packet()
     memset( allowed_packet_types, 1, sizeof( allowed_packet_types ) );
 
     struct netcode_connection_challenge_packet_t * output_packet = (struct netcode_connection_challenge_packet_t*) 
-        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), NULL, allowed_packet_types, NULL, NULL, NULL );
+        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), 0, NULL, allowed_packet_types, NULL, NULL, NULL );
 
     check( output_packet );
 
@@ -6391,7 +6597,7 @@ void test_connection_response_packet()
     memset( allowed_packet_types, 1, sizeof( allowed_packet_types ) );
 
     struct netcode_connection_response_packet_t * output_packet = (struct netcode_connection_response_packet_t*) 
-        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), NULL, allowed_packet_types, NULL, NULL, NULL );
+        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), 0, NULL, allowed_packet_types, NULL, NULL, NULL );
 
     check( output_packet );
 
@@ -6434,7 +6640,7 @@ void test_connection_keep_alive_packet()
     memset( allowed_packet_types, 1, sizeof( allowed_packet_types ) );
     
     struct netcode_connection_keep_alive_packet_t * output_packet = (struct netcode_connection_keep_alive_packet_t*) 
-        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), NULL, allowed_packet_types, NULL, NULL, NULL );
+        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), 0, NULL, allowed_packet_types, NULL, NULL, NULL );
 
     check( output_packet );
 
@@ -6478,7 +6684,7 @@ void test_connection_payload_packet()
     memset( allowed_packet_types, 1, sizeof( allowed_packet_types ) );
 
     struct netcode_connection_payload_packet_t * output_packet = (struct netcode_connection_payload_packet_t*) 
-        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), NULL, allowed_packet_types, NULL, NULL, NULL );
+        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), 0, NULL, allowed_packet_types, NULL, NULL, NULL );
 
     check( output_packet );
 
@@ -6520,7 +6726,7 @@ void test_connection_disconnect_packet()
     memset( allowed_packet_types, 1, sizeof( allowed_packet_types ) );
 
     struct netcode_connection_disconnect_packet_t * output_packet = (struct netcode_connection_disconnect_packet_t*) 
-        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), NULL, allowed_packet_types, NULL, NULL, NULL );
+        netcode_read_packet( buffer, bytes_written, &sequence, packet_key, TEST_PROTOCOL_ID, time( NULL ), 0, NULL, allowed_packet_types, NULL, NULL, NULL );
 
     check( output_packet );
 
@@ -6666,7 +6872,8 @@ void test_encryption_manager()
                                                                   encryption_mapping[i].receive_key, 
                                                                   time, 
                                                                   -1.0,
-                                                                  TEST_TIMEOUT_SECONDS ) );
+                                                                  TEST_TIMEOUT_SECONDS,
+                                                                  -1 ) );
 
         encryption_index = netcode_encryption_manager_find_encryption_mapping( &encryption_manager, &encryption_mapping[i].address, time );
 
@@ -6728,7 +6935,8 @@ void test_encryption_manager()
                                                               encryption_mapping[0].receive_key, 
                                                               time, 
                                                               -1.0,
-                                                              TEST_TIMEOUT_SECONDS ) );
+                                                              TEST_TIMEOUT_SECONDS,
+                                                              -1 ) );
     
     check( netcode_encryption_manager_add_encryption_mapping( &encryption_manager, 
                                                               &encryption_mapping[NUM_ENCRYPTION_MAPPINGS-1].address, 
@@ -6736,7 +6944,8 @@ void test_encryption_manager()
                                                               encryption_mapping[NUM_ENCRYPTION_MAPPINGS-1].receive_key, 
                                                               time, 
                                                               -1.0,
-                                                              TEST_TIMEOUT_SECONDS ) );
+                                                              TEST_TIMEOUT_SECONDS,
+                                                              -1 ) );
 
     // all encryption mappings should be able to be looked up by address again
 
@@ -6786,7 +6995,8 @@ void test_encryption_manager()
                                                                   encryption_mapping[i].receive_key, 
                                                                   time, 
                                                                   -1.0,
-                                                                  TEST_TIMEOUT_SECONDS ) );
+                                                                  TEST_TIMEOUT_SECONDS,
+                                                                  -1 ) );
 
         encryption_index = netcode_encryption_manager_find_encryption_mapping( &encryption_manager, &encryption_mapping[i].address, time );
 
@@ -6823,7 +7033,8 @@ void test_encryption_manager()
                                                               encryption_mapping[0].receive_key, 
                                                               time, 
                                                               time + 1.0,
-                                                              TEST_TIMEOUT_SECONDS ) );
+                                                              TEST_TIMEOUT_SECONDS,
+                                                              -1 ) );
 
     int encryption_index = netcode_encryption_manager_find_encryption_mapping( &encryption_manager, &encryption_mapping[0].address, time );
 
@@ -9045,6 +9256,410 @@ void test_client_reconnect()
     netcode_network_simulator_destroy( network_simulator );
 }
 
+void test_connect_token_entries()
+{
+    struct netcode_connect_token_entry_t connect_token_entries[NETCODE_MAX_CONNECT_TOKEN_ENTRIES];
+
+    netcode_connect_token_entries_reset( connect_token_entries );
+
+    struct netcode_address_t address_a;
+    struct netcode_address_t address_b;
+
+    check( netcode_parse_address( "[::1]:50000", &address_a ) == NETCODE_OK );
+    check( netcode_parse_address( "[::1]:50001", &address_b ) == NETCODE_OK );
+
+    uint64_t current_timestamp = 1000;
+    uint64_t expire_timestamp = current_timestamp + 30;
+
+    uint8_t mac[NETCODE_MAC_BYTES];
+    memset( mac, 0, NETCODE_MAC_BYTES );
+
+    // a connect token the history has not seen creates a pending entry
+
+    mac[0] = 1;
+
+    int index = netcode_connect_token_entries_find_or_add( connect_token_entries, &address_a, mac, expire_timestamp, current_timestamp, 100.0 );
+
+    check( index >= 0 );
+    check( connect_token_entries[index].state == NETCODE_CONNECT_TOKEN_ENTRY_PENDING );
+    check( connect_token_entries[index].time == 100.0 );
+
+    // a pending entry admits a retransmitted connection request from the address that created it,
+    // and the entry time is not refreshed
+
+    check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_a, mac, expire_timestamp, current_timestamp, 200.0 ) == index );
+    check( connect_token_entries[index].time == 100.0 );
+
+    // a pending entry refuses every other address
+
+    check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_b, mac, expire_timestamp, current_timestamp, 200.0 ) == NETCODE_CONNECT_TOKEN_ENTRY_REFUSED );
+
+    // a consumed entry admits nothing, including the address that used the connect token
+
+    netcode_connect_token_entries_consume( connect_token_entries, index );
+
+    check( connect_token_entries[index].state == NETCODE_CONNECT_TOKEN_ENTRY_CONSUMED );
+    check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_a, mac, expire_timestamp, current_timestamp, 300.0 ) == NETCODE_CONNECT_TOKEN_ENTRY_REFUSED );
+    check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_b, mac, expire_timestamp, current_timestamp, 300.0 ) == NETCODE_CONNECT_TOKEN_ENTRY_REFUSED );
+
+    // a history whose entries all hold unexpired connect tokens refuses a new connect token
+    // instead of evicting one
+
+    int i;
+    for ( i = 1; i < NETCODE_MAX_CONNECT_TOKEN_ENTRIES; i++ )
+    {
+        memset( mac, 0, NETCODE_MAC_BYTES );
+        mac[0] = (uint8_t) ( i + 1 );
+        mac[1] = (uint8_t) ( ( i + 1 ) >> 8 );
+        check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_a, mac, expire_timestamp, current_timestamp, 400.0 ) >= 0 );
+    }
+
+    memset( mac, 0, NETCODE_MAC_BYTES );
+    mac[0] = 0xFF;
+    mac[1] = 0xFF;
+
+    check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_a, mac, expire_timestamp, current_timestamp, 500.0 ) == NETCODE_CONNECT_TOKEN_HISTORY_FULL );
+
+    // the consumed entry is still refusing its connect token, and was not evicted by the flood
+
+    memset( mac, 0, NETCODE_MAC_BYTES );
+    mac[0] = 1;
+
+    check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_a, mac, expire_timestamp, current_timestamp, 500.0 ) == NETCODE_CONNECT_TOKEN_ENTRY_REFUSED );
+
+    // entries live until their connect token expires. once they have, the history takes new connect tokens again
+
+    memset( mac, 0, NETCODE_MAC_BYTES );
+    mac[0] = 0xFF;
+    mac[1] = 0xFF;
+
+    check( netcode_connect_token_entries_find_or_add( connect_token_entries, &address_a, mac, expire_timestamp, expire_timestamp, 600.0 ) >= 0 );
+}
+
+/*
+    A client and a server wired directly to each other through the send and receive overrides.
+    Packets are handed straight to the other side, so the handshake is exercised with no sockets,
+    no network simulator and no randomness at all. The wire can drop the first packets the server
+    sends, which is what makes the client retransmit its connection request, and it keeps a copy
+    of the first payload packet the client sends so it can be replayed later.
+*/
+
+struct test_wire_t
+{
+    struct netcode_client_t * client;
+    struct netcode_server_t * server;
+    struct netcode_address_t client_address;
+    struct netcode_address_t server_address;
+    int shutting_down;
+    int drop_server_packets;
+    int num_connection_requests;
+    uint8_t payload_packet[NETCODE_MAX_PACKET_BYTES];
+    int payload_packet_bytes;
+};
+
+static struct test_wire_t test_wire;
+
+static void test_wire_client_send_packet( void * context, struct netcode_address_t * to, NETCODE_CONST uint8_t * packet_data, int packet_bytes )
+{
+    (void) context;
+    (void) to;
+
+    // the wire is down once either end is being destroyed. the disconnect packets they send
+    // on the way out have nowhere to go, exactly as an application shutting down would find
+
+    if ( test_wire.shutting_down )
+        return;
+
+    if ( packet_data[0] == NETCODE_CONNECTION_REQUEST_PACKET )
+    {
+        test_wire.num_connection_requests++;
+    }
+
+    if ( ( packet_data[0] & 0xF ) == NETCODE_CONNECTION_PAYLOAD_PACKET && test_wire.payload_packet_bytes == 0 )
+    {
+        memcpy( test_wire.payload_packet, packet_data, packet_bytes );
+        test_wire.payload_packet_bytes = packet_bytes;
+    }
+
+    netcode_server_process_packet( test_wire.server, &test_wire.client_address, (uint8_t*) packet_data, packet_bytes );
+}
+
+static void test_wire_server_send_packet( void * context, struct netcode_address_t * to, NETCODE_CONST uint8_t * packet_data, int packet_bytes )
+{
+    (void) context;
+    (void) to;
+
+    if ( test_wire.shutting_down )
+        return;
+
+    if ( test_wire.drop_server_packets > 0 )
+    {
+        test_wire.drop_server_packets--;
+        return;
+    }
+
+    netcode_client_process_packet( test_wire.client, &test_wire.server_address, (uint8_t*) packet_data, packet_bytes );
+}
+
+static int test_wire_receive_packet( void * context, struct netcode_address_t * from, uint8_t * packet_data, int max_packet_bytes )
+{
+    (void) context;
+    (void) from;
+    (void) packet_data;
+    (void) max_packet_bytes;
+    return 0;
+}
+
+static void test_wire_create( int drop_server_packets )
+{
+    memset( &test_wire, 0, sizeof( test_wire ) );
+
+    test_wire.drop_server_packets = drop_server_packets;
+
+    check( netcode_parse_address( "[::1]:50000", &test_wire.client_address ) == NETCODE_OK );
+    check( netcode_parse_address( "[::1]:40000", &test_wire.server_address ) == NETCODE_OK );
+
+    struct netcode_client_config_t client_config;
+    netcode_default_client_config( &client_config );
+    client_config.override_send_and_receive = 1;
+    client_config.send_packet_override = test_wire_client_send_packet;
+    client_config.receive_packet_override = test_wire_receive_packet;
+
+    test_wire.client = netcode_client_create( "[::1]:50000", &client_config, 0.0 );
+
+    check( test_wire.client );
+
+    struct netcode_server_config_t server_config;
+    netcode_default_server_config( &server_config );
+    server_config.protocol_id = TEST_PROTOCOL_ID;
+    server_config.override_send_and_receive = 1;
+    server_config.send_packet_override = test_wire_server_send_packet;
+    server_config.receive_packet_override = test_wire_receive_packet;
+    memcpy( &server_config.private_key, private_key, NETCODE_KEY_BYTES );
+
+    test_wire.server = netcode_server_create( "[::1]:40000", &server_config, 0.0 );
+
+    check( test_wire.server );
+
+    netcode_server_start( test_wire.server, 1 );
+}
+
+static void test_wire_destroy()
+{
+    test_wire.shutting_down = 1;
+    netcode_server_destroy( test_wire.server );
+    netcode_client_destroy( test_wire.client );
+    memset( &test_wire, 0, sizeof( test_wire ) );
+}
+
+static void test_wire_connect_client( uint8_t * connect_token, double * time, double delta_time )
+{
+    netcode_client_connect( test_wire.client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_client_update( test_wire.client, *time );
+
+        netcode_server_update( test_wire.server, *time );
+
+        if ( netcode_client_state( test_wire.client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        *time += delta_time;
+    }
+}
+
+static void test_wire_generate_connect_token( uint8_t * connect_token, uint64_t client_id, int expire_seconds )
+{
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t user_data[NETCODE_USER_DATA_BYTES];
+    netcode_random_bytes( user_data, NETCODE_USER_DATA_BYTES );
+
+    check( netcode_generate_connect_token( 1, &server_address, &server_address, expire_seconds, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, private_key, user_data, connect_token ) );
+}
+
+void test_client_server_connection_request_retransmission()
+{
+    // the first three packets the server sends are dropped, so the client retransmits its
+    // connection request into a handshake the server already has a pending history entry for
+
+    test_wire_create( 3 );
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    test_wire_generate_connect_token( connect_token, TEST_CLIENT_ID, TEST_CONNECT_TOKEN_EXPIRY );
+
+    test_wire_connect_client( connect_token, &time, delta_time );
+
+    check( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_server_client_connected( test_wire.server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( test_wire.server ) == 1 );
+    check( test_wire.num_connection_requests >= 4 );
+
+    test_wire_destroy();
+}
+
+void test_client_server_replay_across_sessions()
+{
+    test_wire_create( 0 );
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    // connect a first session and keep a copy of a payload packet the client sends in it
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    test_wire_generate_connect_token( connect_token, TEST_CLIENT_ID, TEST_CONNECT_TOKEN_EXPIRY );
+
+    test_wire_connect_client( connect_token, &time, delta_time );
+
+    check( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTED );
+
+    uint8_t payload[NETCODE_MAX_PACKET_SIZE];
+    int i;
+    for ( i = 0; i < NETCODE_MAX_PACKET_SIZE; i++ )
+    {
+        payload[i] = (uint8_t) i;
+    }
+
+    netcode_client_send_packet( test_wire.client, payload, NETCODE_MAX_PACKET_SIZE );
+
+    check( test_wire.payload_packet_bytes > 0 );
+
+    // disconnect, then connect a second session with a new connect token
+
+    netcode_server_disconnect_client( test_wire.server, 0 );
+
+    while ( netcode_client_state( test_wire.client ) > NETCODE_CLIENT_STATE_DISCONNECTED )
+    {
+        netcode_client_update( test_wire.client, time );
+        netcode_server_update( test_wire.server, time );
+        time += delta_time;
+    }
+
+    uint8_t second_connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    test_wire_generate_connect_token( second_connect_token, TEST_CLIENT_ID, TEST_CONNECT_TOKEN_EXPIRY );
+
+    test_wire_connect_client( second_connect_token, &time, delta_time );
+
+    check( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTED );
+
+    // drain anything the second session has delivered so far
+
+    while ( 1 )
+    {
+        int packet_bytes;
+        uint64_t packet_sequence;
+        void * packet = netcode_server_receive_packet( test_wire.server, 0, &packet_bytes, &packet_sequence );
+        if ( !packet )
+            break;
+        netcode_server_free_packet( test_wire.server, packet );
+    }
+
+    // the datagram from the first session is refused by the second
+
+    netcode_server_process_packet( test_wire.server, &test_wire.client_address, test_wire.payload_packet, test_wire.payload_packet_bytes );
+
+    int packet_bytes;
+    uint64_t packet_sequence;
+
+    check( netcode_server_receive_packet( test_wire.server, 0, &packet_bytes, &packet_sequence ) == NULL );
+
+    test_wire_destroy();
+}
+
+void test_client_reconnect_with_used_connect_token()
+{
+    test_wire_create( 0 );
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    test_wire_generate_connect_token( connect_token, TEST_CLIENT_ID, TEST_CONNECT_TOKEN_EXPIRY );
+
+    test_wire_connect_client( connect_token, &time, delta_time );
+
+    check( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_server_num_connected_clients( test_wire.server ) == 1 );
+
+    // disconnect the client server side and wait until the client sees it
+
+    netcode_server_disconnect_client( test_wire.server, 0 );
+
+    while ( netcode_client_state( test_wire.client ) > NETCODE_CLIENT_STATE_DISCONNECTED )
+    {
+        netcode_client_update( test_wire.client, time );
+        netcode_server_update( test_wire.server, time );
+        time += delta_time;
+    }
+
+    check( netcode_server_num_connected_clients( test_wire.server ) == 0 );
+
+    // the connect token is spent. presenting it again, from the same address that used it,
+    // connects nothing: the client runs out of connection request retries instead
+
+    test_wire_connect_client( connect_token, &time, delta_time );
+
+    check( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTION_REQUEST_TIMED_OUT );
+    check( netcode_server_num_connected_clients( test_wire.server ) == 0 );
+
+    test_wire_destroy();
+}
+
+void test_client_error_connect_token_predates_server_start()
+{
+    test_wire_create( 0 );
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    // a connect token with a shorter lifetime than the server's configured maximum expires
+    // earlier than any connect token the backend could have issued after the server started,
+    // which is exactly the shape of a connect token issued before it started
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    test_wire_generate_connect_token( connect_token, TEST_CLIENT_ID, NETCODE_DEFAULT_MAX_CONNECT_TOKEN_LIFETIME - 10 );
+
+    test_wire_connect_client( connect_token, &time, delta_time );
+
+    check( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTION_REQUEST_TIMED_OUT );
+    check( netcode_server_num_connected_clients( test_wire.server ) == 0 );
+
+    // a connect token with the full lifetime connects
+
+    test_wire_generate_connect_token( connect_token, TEST_CLIENT_ID, TEST_CONNECT_TOKEN_EXPIRY );
+
+    test_wire_connect_client( connect_token, &time, delta_time );
+
+    check( netcode_client_state( test_wire.client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_server_num_connected_clients( test_wire.server ) == 1 );
+
+    test_wire_destroy();
+}
+
+#if NETCODE_ENABLE_NONCE_AUDIT
+
+void test_nonce_audit()
+{
+    // every packet every test above encrypted was recorded by key and nonce. a repeat is a
+    // connect token encrypting two sessions, which is what the connect token lifecycle prevents
+
+    printf( "\n    %d key and nonce pairs recorded\n    ", netcode_nonce_audit_num_pairs() );
+
+    check( netcode_nonce_audit_num_pairs() > 0 );
+    check( netcode_nonce_audit_overflow() == 0 );
+    check( netcode_nonce_audit_repeats() == 0 );
+}
+
+#endif // #if NETCODE_ENABLE_NONCE_AUDIT
+
 struct test_loopback_context_t
 {
     struct netcode_client_t * client;
@@ -9732,11 +10347,19 @@ void netcode_test()
         RUN_TEST( test_server_side_disconnect );
         RUN_TEST( test_server_client_disconnect_reason );
         RUN_TEST( test_client_reconnect );
+        RUN_TEST( test_connect_token_entries );
+        RUN_TEST( test_client_server_connection_request_retransmission );
+        RUN_TEST( test_client_server_replay_across_sessions );
+        RUN_TEST( test_client_reconnect_with_used_connect_token );
+        RUN_TEST( test_client_error_connect_token_predates_server_start );
         RUN_TEST( test_disable_timeout );
         RUN_TEST( test_loopback );
 #if NETCODE_PACKET_TAGGING
         RUN_TEST( test_packet_tagging );
 #endif // #if NETCODE_PACKET_TAGGING
+#if NETCODE_ENABLE_NONCE_AUDIT
+        RUN_TEST( test_nonce_audit );
+#endif // #if NETCODE_ENABLE_NONCE_AUDIT
     }
 }
 

--- a/netcode/netcode.h
+++ b/netcode/netcode.h
@@ -32,10 +32,10 @@
 #ifndef NETCODE_H
 #define NETCODE_H
 
-#define NETCODE_VERSION_FULL    "1.4.3"
+#define NETCODE_VERSION_FULL    "1.4.5"
 #define NETCODE_VERSION_MAJOR   1
 #define NETCODE_VERSION_MINOR   4
-#define NETCODE_VERSION_PATCH   3
+#define NETCODE_VERSION_PATCH   5
 
 /*
     IMPORTANT: netcode is single-threaded by design and is not thread safe.
@@ -92,6 +92,7 @@
 #define NETCODE_MAC_BYTES 16
 #define NETCODE_USER_DATA_BYTES 256
 #define NETCODE_MAX_SERVERS_PER_CONNECT 32
+#define NETCODE_DEFAULT_MAX_CONNECT_TOKEN_LIFETIME 30
 
 #define NETCODE_CLIENT_STATE_CONNECT_TOKEN_EXPIRED              -6
 #define NETCODE_CLIENT_STATE_INVALID_CONNECT_TOKEN              -5
@@ -274,7 +275,19 @@ struct netcode_server_config_t
     int override_send_and_receive;
     void (*send_packet_override)(void*,struct netcode_address_t*,NETCODE_CONST uint8_t*,int);
     int (*receive_packet_override)(void*,struct netcode_address_t*,uint8_t*,int);
+    int max_connect_token_lifetime;
 };
+
+/*
+    max_connect_token_lifetime is the longest lifetime in seconds that the backend issues
+    connect tokens with, as passed to netcode_generate_connect_token. The server ignores any
+    connection request whose connect token expire timestamp minus this lifetime is earlier
+    than the time the server started, so a connect token that could have been issued before
+    the server started cannot be presented after it. Set it to the lifetime your backend
+    issues: a larger value rejects legitimate connect tokens until the difference has elapsed,
+    and a smaller value lets connect tokens issued shortly before the server started through.
+    A value of zero or less takes NETCODE_DEFAULT_MAX_CONNECT_TOKEN_LIFETIME instead.
+*/
 
 void netcode_default_server_config( struct netcode_server_config_t * config );
 

--- a/reliable/reliable.c
+++ b/reliable/reliable.c
@@ -30,6 +30,7 @@
 #include <stdarg.h>
 #include <inttypes.h>
 #include <float.h>
+#include <limits.h>
 #include <math.h>
 
 #ifndef RELIABLE_ENABLE_TESTS
@@ -45,6 +46,7 @@
 static void default_assert_handler( RELIABLE_CONST char * condition, RELIABLE_CONST char * function, RELIABLE_CONST char * file, int line )
 {
     printf( "assert failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
+    fflush( stdout );
     #if defined( __GNUC__ )
     __builtin_trap();
     #elif defined( _MSC_VER )
@@ -75,7 +77,7 @@ void reliable_set_assert_function( void (*function)( RELIABLE_CONST char *, RELI
 
 #if RELIABLE_ENABLE_LOGGING
 
-void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
+static void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
 {
     if ( level > log_level )
         return;
@@ -89,7 +91,7 @@ void reliable_printf( int level, RELIABLE_CONST char * format, ... )
 
 #else // #if RELIABLE_ENABLE_LOGGING
 
-void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
+static void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
 {
     (void) level;
     (void) format;
@@ -97,16 +99,35 @@ void reliable_printf( int level, RELIABLE_CONST char * format, ... )
 
 #endif // #if RELIABLE_ENABLE_LOGGING
 
-void * reliable_default_allocate_function( void * context, size_t bytes )
+static void * reliable_default_allocate_function( void * context, size_t bytes )
 {
     (void) context;
     return malloc( bytes );
 }
 
-void reliable_default_free_function( void * context, void * pointer )
+static void reliable_default_free_function( void * context, void * pointer )
 {
     (void) context;
     free( pointer );
+}
+
+// multiplies an element count by an element size for an allocation. returns 0 if the count is
+// negative or the product does not fit in a size_t, so a config that would wrap the arithmetic
+// is refused instead of allocating a buffer smaller than the code goes on to use
+
+static int reliable_checked_size( int count, size_t element_bytes, size_t * result )
+{
+    reliable_assert( result );
+    if ( count <= 0 || element_bytes == 0 )
+    {
+        return 0;
+    }
+    if ( (size_t) count > SIZE_MAX / element_bytes )
+    {
+        return 0;
+    }
+    *result = ( (size_t) count ) * element_bytes;
+    return 1;
 }
 
 // ------------------------------------------------------------------
@@ -122,13 +143,13 @@ void reliable_term(void)
 
 // ---------------------------------------------------------------
 
-int reliable_sequence_greater_than( uint16_t s1, uint16_t s2 )
+static int reliable_sequence_greater_than( uint16_t s1, uint16_t s2 )
 {
     return ( ( s1 > s2 ) && ( s1 - s2 <= 32768 ) ) || 
            ( ( s1 < s2 ) && ( s2 - s1  > 32768 ) );
 }
 
-int reliable_sequence_less_than( uint16_t s1, uint16_t s2 )
+static int reliable_sequence_less_than( uint16_t s1, uint16_t s2 )
 {
     return reliable_sequence_greater_than( s2, s1 );
 }
@@ -147,7 +168,9 @@ struct reliable_sequence_buffer_t
     uint8_t * entry_data;
 };
 
-struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_entries, 
+static void reliable_sequence_buffer_destroy( struct reliable_sequence_buffer_t * sequence_buffer );
+
+static struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_entries, 
                                                                      int entry_stride, 
                                                                      void * allocator_context, 
                                                                      void * (*allocate_function)(void*,size_t), 
@@ -166,10 +189,28 @@ struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_ent
         free_function = reliable_default_free_function;
     }
 
+    size_t entry_sequence_bytes;
+    size_t entry_data_bytes;
+
+    if ( !reliable_checked_size( num_entries, sizeof( uint32_t ), &entry_sequence_bytes ) )
+    {
+        return NULL;
+    }
+
+    if ( !reliable_checked_size( num_entries, (size_t) entry_stride, &entry_data_bytes ) )
+    {
+        return NULL;
+    }
+
     struct reliable_sequence_buffer_t * sequence_buffer = (struct reliable_sequence_buffer_t*)
         allocate_function( allocator_context, sizeof( struct reliable_sequence_buffer_t ) );
 
-    reliable_assert( sequence_buffer );
+    if ( sequence_buffer == NULL )
+    {
+        return NULL;
+    }
+
+    memset( sequence_buffer, 0, sizeof( struct reliable_sequence_buffer_t ) );
 
     sequence_buffer->allocator_context = allocator_context;
     sequence_buffer->allocate_function = allocate_function;
@@ -177,32 +218,43 @@ struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_ent
     sequence_buffer->sequence = 0;
     sequence_buffer->num_entries = num_entries;
     sequence_buffer->entry_stride = entry_stride;
-    sequence_buffer->entry_sequence = (uint32_t*) allocate_function( allocator_context, num_entries * sizeof( uint32_t ) );
-    sequence_buffer->entry_data = (uint8_t*) allocate_function( allocator_context, num_entries * entry_stride );
-    reliable_assert( sequence_buffer->entry_sequence );
-    reliable_assert( sequence_buffer->entry_data );
-    memset( sequence_buffer->entry_sequence, 0xFF, sizeof( uint32_t) * sequence_buffer->num_entries );
-    memset( sequence_buffer->entry_data, 0, num_entries * entry_stride );
+    sequence_buffer->entry_sequence = (uint32_t*) allocate_function( allocator_context, entry_sequence_bytes );
+    sequence_buffer->entry_data = (uint8_t*) allocate_function( allocator_context, entry_data_bytes );
+
+    if ( sequence_buffer->entry_sequence == NULL || sequence_buffer->entry_data == NULL )
+    {
+        reliable_sequence_buffer_destroy( sequence_buffer );
+        return NULL;
+    }
+
+    memset( sequence_buffer->entry_sequence, 0xFF, entry_sequence_bytes );
+    memset( sequence_buffer->entry_data, 0, entry_data_bytes );
 
     return sequence_buffer;
 }
 
-void reliable_sequence_buffer_destroy( struct reliable_sequence_buffer_t * sequence_buffer )
+static void reliable_sequence_buffer_destroy( struct reliable_sequence_buffer_t * sequence_buffer )
 {
     reliable_assert( sequence_buffer );
-    sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_sequence );
-    sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_data );
+    if ( sequence_buffer->entry_sequence )
+    {
+        sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_sequence );
+    }
+    if ( sequence_buffer->entry_data )
+    {
+        sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_data );
+    }
     sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer );
 }
 
-void reliable_sequence_buffer_reset( struct reliable_sequence_buffer_t * sequence_buffer )
+static void reliable_sequence_buffer_reset( struct reliable_sequence_buffer_t * sequence_buffer )
 {
     reliable_assert( sequence_buffer );
     sequence_buffer->sequence = 0;
     memset( sequence_buffer->entry_sequence, 0xFF, sizeof( uint32_t) * sequence_buffer->num_entries );
 }
 
-void reliable_sequence_buffer_remove_entries( struct reliable_sequence_buffer_t * sequence_buffer, 
+static void reliable_sequence_buffer_remove_entries( struct reliable_sequence_buffer_t * sequence_buffer, 
                                               int start_sequence, 
                                               int finish_sequence, 
                                               void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
@@ -242,12 +294,12 @@ void reliable_sequence_buffer_remove_entries( struct reliable_sequence_buffer_t 
     }
 }
 
-int reliable_sequence_buffer_test_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static int reliable_sequence_buffer_test_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     return reliable_sequence_less_than( sequence, sequence_buffer->sequence - ((uint16_t)sequence_buffer->num_entries) ) ? ((uint16_t)0) : ((uint16_t)1);
 }
 
-void * reliable_sequence_buffer_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static void * reliable_sequence_buffer_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     if ( reliable_sequence_less_than( sequence, sequence_buffer->sequence - ((uint16_t)sequence_buffer->num_entries) ) )
@@ -264,7 +316,7 @@ void * reliable_sequence_buffer_insert( struct reliable_sequence_buffer_t * sequ
     return sequence_buffer->entry_data + index * sequence_buffer->entry_stride;
 }
 
-void reliable_sequence_buffer_advance( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static void reliable_sequence_buffer_advance( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     if ( reliable_sequence_greater_than( sequence + 1, sequence_buffer->sequence ) )
@@ -274,7 +326,7 @@ void reliable_sequence_buffer_advance( struct reliable_sequence_buffer_t * seque
     }
 }
 
-void * reliable_sequence_buffer_insert_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
+static void * reliable_sequence_buffer_insert_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
                                                      uint16_t sequence, 
                                                      void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
 {
@@ -299,7 +351,7 @@ void * reliable_sequence_buffer_insert_with_cleanup( struct reliable_sequence_bu
     return sequence_buffer->entry_data + index * sequence_buffer->entry_stride;
 }
 
-void reliable_sequence_buffer_advance_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer,
+static void reliable_sequence_buffer_advance_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer,
                                                     uint16_t sequence,
                                                     void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
 {
@@ -311,13 +363,7 @@ void reliable_sequence_buffer_advance_with_cleanup( struct reliable_sequence_buf
     }
 }
 
-void reliable_sequence_buffer_remove( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
-{
-    reliable_assert( sequence_buffer );
-    sequence_buffer->entry_sequence[ sequence % sequence_buffer->num_entries ] = 0xFFFFFFFF;
-}
-
-void reliable_sequence_buffer_remove_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
+static void reliable_sequence_buffer_remove_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
                                                    uint16_t sequence, 
                                                    void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
 {
@@ -330,19 +376,13 @@ void reliable_sequence_buffer_remove_with_cleanup( struct reliable_sequence_buff
     }
 }
 
-int reliable_sequence_buffer_available( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
-{
-    reliable_assert( sequence_buffer );
-    return sequence_buffer->entry_sequence[ sequence % sequence_buffer->num_entries ] == 0xFFFFFFFF;
-}
-
-int reliable_sequence_buffer_exists( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static int reliable_sequence_buffer_exists( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     return sequence_buffer->entry_sequence[ sequence % sequence_buffer->num_entries ] == (uint32_t) sequence;
 }
 
-void * reliable_sequence_buffer_find( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static void * reliable_sequence_buffer_find( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     int index = sequence % sequence_buffer->num_entries;
@@ -350,7 +390,7 @@ void * reliable_sequence_buffer_find( struct reliable_sequence_buffer_t * sequen
 
 }
 
-void * reliable_sequence_buffer_at_index( struct reliable_sequence_buffer_t * sequence_buffer, int index )
+static void * reliable_sequence_buffer_at_index( struct reliable_sequence_buffer_t * sequence_buffer, int index )
 {
     reliable_assert( sequence_buffer );
     reliable_assert( index >= 0 );
@@ -358,7 +398,7 @@ void * reliable_sequence_buffer_at_index( struct reliable_sequence_buffer_t * se
     return sequence_buffer->entry_sequence[index] != 0xFFFFFFFF ? ( sequence_buffer->entry_data + index * sequence_buffer->entry_stride ) : NULL;
 }
 
-void reliable_sequence_buffer_generate_ack_bits( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t * ack, uint32_t * ack_bits )
+static void reliable_sequence_buffer_generate_ack_bits( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t * ack, uint32_t * ack_bits )
 {
     reliable_assert( sequence_buffer );
     reliable_assert( ack );
@@ -378,50 +418,27 @@ void reliable_sequence_buffer_generate_ack_bits( struct reliable_sequence_buffer
 
 // ---------------------------------------------------------------
 
-void reliable_write_uint8( uint8_t ** p, uint8_t value )
+static void reliable_write_uint8( uint8_t ** p, uint8_t value )
 {
     **p = value;
     ++(*p);
 }
 
-void reliable_write_uint16( uint8_t ** p, uint16_t value )
+static void reliable_write_uint16( uint8_t ** p, uint16_t value )
 {
     (*p)[0] = value & 0xFF;
     (*p)[1] = value >> 8;
     *p += 2;
 }
 
-void reliable_write_uint32( uint8_t ** p, uint32_t value )
-{
-    (*p)[0] = value & 0xFF;
-    (*p)[1] = ( value >> 8  ) & 0xFF;
-    (*p)[2] = ( value >> 16 ) & 0xFF;
-    (*p)[3] = value >> 24;
-    *p += 4;
-}
-
-void reliable_write_uint64( uint8_t ** p, uint64_t value )
-{
-    (*p)[0] = value & 0xFF;
-    (*p)[1] = ( value >> 8  ) & 0xFF;
-    (*p)[2] = ( value >> 16 ) & 0xFF;
-    (*p)[3] = ( value >> 24 ) & 0xFF;
-    (*p)[4] = ( value >> 32 ) & 0xFF;
-    (*p)[5] = ( value >> 40 ) & 0xFF;
-    (*p)[6] = ( value >> 48 ) & 0xFF;
-    (*p)[7] = value >> 56;
-    *p += 8;
-}
-
-
-uint8_t reliable_read_uint8( uint8_t ** p )
+static uint8_t reliable_read_uint8( uint8_t ** p )
 {
     uint8_t value = **p;
     ++(*p);
     return value;
 }
 
-uint16_t reliable_read_uint16( uint8_t ** p )
+static uint16_t reliable_read_uint16( uint8_t ** p )
 {
     uint16_t value;
     value = (*p)[0];
@@ -429,33 +446,6 @@ uint16_t reliable_read_uint16( uint8_t ** p )
     *p += 2;
     return value;
 }
-
-uint32_t reliable_read_uint32( uint8_t ** p )
-{
-    uint32_t value;
-    value  = (*p)[0];
-    value |= ( ( (uint32_t)( (*p)[1] ) ) << 8 );
-    value |= ( ( (uint32_t)( (*p)[2] ) ) << 16 );
-    value |= ( ( (uint32_t)( (*p)[3] ) ) << 24 );
-    *p += 4;
-    return value;
-}
-
-uint64_t reliable_read_uint64( uint8_t ** p )
-{
-    uint64_t value;
-    value  = (*p)[0];
-    value |= ( ( (uint64_t)( (*p)[1] ) ) << 8  );
-    value |= ( ( (uint64_t)( (*p)[2] ) ) << 16 );
-    value |= ( ( (uint64_t)( (*p)[3] ) ) << 24 );
-    value |= ( ( (uint64_t)( (*p)[4] ) ) << 32 );
-    value |= ( ( (uint64_t)( (*p)[5] ) ) << 40 );
-    value |= ( ( (uint64_t)( (*p)[6] ) ) << 48 );
-    value |= ( ( (uint64_t)( (*p)[7] ) ) << 56 );
-    *p += 8;
-    return value;
-}
-
 
 // ---------------------------------------------------------------
 
@@ -472,7 +462,7 @@ struct reliable_fragment_reassembly_data_t
     uint8_t fragment_received[256];
 };
 
-void reliable_fragment_reassembly_data_cleanup( void * data, void * allocator_context, void (*free_function)(void*,void*) )
+static void reliable_fragment_reassembly_data_cleanup( void * data, void * allocator_context, void (*free_function)(void*,void*) )
 
 {
     reliable_assert( free_function );
@@ -556,20 +546,83 @@ void reliable_default_config( struct reliable_config_t * config )
     config->packet_header_size = 28;                    // note: UDP over IPv4 = 20 + 8 bytes, UDP over IPv6 = 40 + 8 bytes
 }
 
+// checks the config a caller hands to reliable_endpoint_create. every field is range checked
+// and the two relationships between fields are checked: a fragment threshold above the maximum
+// packet size can never fire, and a fragment count that does not cover the maximum packet size
+// means a large packet has nowhere to go. logs what is wrong and returns 0 to refuse the config
+
+static int reliable_config_valid( struct reliable_config_t * config )
+{
+    if ( config == NULL )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[reliable] config is NULL\n" );
+        return 0;
+    }
+
+    if ( config->max_packet_size <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] max_packet_size must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->fragment_above <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] fragment_above must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->fragment_size <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] fragment_size must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->max_fragments <= 0 || config->max_fragments > 256 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] max_fragments must be between 1 and 256\n", config->name );
+        return 0;
+    }
+
+    if ( config->ack_buffer_size <= 0 || config->sent_packets_buffer_size <= 0 || 
+         config->received_packets_buffer_size <= 0 || config->fragment_reassembly_buffer_size <= 0 || 
+         config->rtt_history_size <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] buffer sizes must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->transmit_packet_function == NULL || config->process_packet_function == NULL )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] transmit and process packet functions are required\n", config->name );
+        return 0;
+    }
+
+    if ( config->fragment_above > config->max_packet_size )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] fragment_above (%d) is above max_packet_size (%d)\n", 
+                         config->name, config->fragment_above, config->max_packet_size );
+        return 0;
+    }
+
+    // max_fragments * fragment_size must cover max_packet_size. written as a division of the
+    // two values already known to be positive, so neither side can overflow
+
+    if ( config->max_fragments <= ( config->max_packet_size - 1 ) / config->fragment_size )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] max_fragments (%d) times fragment_size (%d) does not cover max_packet_size (%d)\n",
+                         config->name, config->max_fragments, config->fragment_size, config->max_packet_size );
+        return 0;
+    }
+
+    return 1;
+}
+
 struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t * config, double time )
 {
-    reliable_assert( config );
-    reliable_assert( config->max_packet_size > 0 );
-    reliable_assert( config->fragment_above > 0 );
-    reliable_assert( config->max_fragments > 0 );
-    reliable_assert( config->max_fragments <= 256 );
-    reliable_assert( config->fragment_size > 0 );
-    reliable_assert( config->ack_buffer_size > 0 );
-    reliable_assert( config->sent_packets_buffer_size > 0 );
-    reliable_assert( config->received_packets_buffer_size > 0 );
-    reliable_assert( config->transmit_packet_function != NULL );
-    reliable_assert( config->process_packet_function != NULL );
-    reliable_assert( config->rtt_history_size > 0 );
+    if ( !reliable_config_valid( config ) )
+    {
+        return NULL;
+    }
 
     void * allocator_context = config->allocator_context;
     void * (*allocate_function)(void*,size_t) = config->allocate_function;
@@ -585,9 +638,46 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
         free_function = reliable_default_free_function;
     }
 
+    // every size the endpoint allocates, computed up front so an overflowing config is refused
+    // before anything is allocated
+
+    size_t acks_bytes;
+    size_t rtt_history_bytes;
+
+    if ( !reliable_checked_size( config->ack_buffer_size, sizeof( uint16_t ), &acks_bytes ) )
+    {
+        return NULL;
+    }
+
+    if ( !reliable_checked_size( config->rtt_history_size, sizeof( float ), &rtt_history_bytes ) )
+    {
+        return NULL;
+    }
+
+    // scratch buffer for outgoing packets, so the send path doesn't allocate. sized for whichever is larger: a regular packet or a fragment
+
+    if ( config->max_packet_size > INT_MAX - RELIABLE_MAX_PACKET_HEADER_BYTES || 
+         config->fragment_size > INT_MAX - RELIABLE_FRAGMENT_HEADER_BYTES - RELIABLE_MAX_PACKET_HEADER_BYTES )
+    {
+        return NULL;
+    }
+
+    int transmit_buffer_size = config->max_packet_size + RELIABLE_MAX_PACKET_HEADER_BYTES;
+    int fragment_transmit_buffer_size = RELIABLE_FRAGMENT_HEADER_BYTES + RELIABLE_MAX_PACKET_HEADER_BYTES + config->fragment_size;
+    if ( fragment_transmit_buffer_size > transmit_buffer_size )
+    {
+        transmit_buffer_size = fragment_transmit_buffer_size;
+    }
+
+    // from here on every allocation is checked and the failure path hands back everything
+    // already taken, in every build, so the caller only ever sees a complete endpoint or NULL
+
     struct reliable_endpoint_t * endpoint = (struct reliable_endpoint_t*) allocate_function( allocator_context, sizeof( struct reliable_endpoint_t ) );
 
-    reliable_assert( endpoint );
+    if ( endpoint == NULL )
+    {
+        return NULL;
+    }
 
     memset( endpoint, 0, sizeof( struct reliable_endpoint_t ) );
 
@@ -597,10 +687,7 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
     endpoint->config = *config;
     endpoint->time = time;
 
-    endpoint->acks = (uint16_t*) allocate_function( allocator_context, config->ack_buffer_size * sizeof(uint16_t) );
-
-    reliable_assert( endpoint->acks );
-
+    endpoint->acks = (uint16_t*) allocate_function( allocator_context, acks_bytes );
 
     endpoint->sent_packets = reliable_sequence_buffer_create( config->sent_packets_buffer_size, 
                                                               sizeof( struct reliable_sent_packet_data_t ), 
@@ -620,29 +707,28 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
                                                                      allocate_function, 
                                                                      free_function );
 
-    endpoint->rtt_history_buffer = (float*) allocate_function( allocator_context, config->rtt_history_size * sizeof(float) );
+    endpoint->rtt_history_buffer = (float*) allocate_function( allocator_context, rtt_history_bytes );
 
-    reliable_assert( endpoint->rtt_history_buffer );
+    endpoint->transmit_buffer = (uint8_t*) allocate_function( allocator_context, (size_t) transmit_buffer_size );
 
-    // scratch buffer for outgoing packets, so the send path doesn't allocate. sized for whichever is larger: a regular packet or a fragment
-
-    int transmit_buffer_size = config->max_packet_size + RELIABLE_MAX_PACKET_HEADER_BYTES;
-    int fragment_transmit_buffer_size = RELIABLE_FRAGMENT_HEADER_BYTES + RELIABLE_MAX_PACKET_HEADER_BYTES + config->fragment_size;
-    if ( fragment_transmit_buffer_size > transmit_buffer_size )
+    if ( endpoint->acks == NULL || 
+         endpoint->sent_packets == NULL || 
+         endpoint->received_packets == NULL || 
+         endpoint->fragment_reassembly == NULL || 
+         endpoint->rtt_history_buffer == NULL || 
+         endpoint->transmit_buffer == NULL )
     {
-        transmit_buffer_size = fragment_transmit_buffer_size;
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] failed to allocate endpoint\n", config->name );
+        reliable_endpoint_destroy( endpoint );
+        return NULL;
     }
-
-    endpoint->transmit_buffer = (uint8_t*) allocate_function( allocator_context, transmit_buffer_size );
-
-    reliable_assert( endpoint->transmit_buffer );
 
     for ( int i = 0; i < config->rtt_history_size; i++ )
     {
         endpoint->rtt_history_buffer[i] = -1.0f;
     }
 
-    memset( endpoint->acks, 0, config->ack_buffer_size * sizeof(uint16_t) );
+    memset( endpoint->acks, 0, acks_bytes );
 
     return endpoint;
 }
@@ -650,35 +736,55 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
 void reliable_endpoint_destroy( struct reliable_endpoint_t * endpoint )
 {
     reliable_assert( endpoint );
-    reliable_assert( endpoint->acks );
-    reliable_assert( endpoint->sent_packets );
-    reliable_assert( endpoint->received_packets );
-    reliable_assert( endpoint->fragment_reassembly );
-    reliable_assert( endpoint->rtt_history_buffer );
-    reliable_assert( endpoint->transmit_buffer );
 
-    int i;
-    for ( i = 0; i < endpoint->config.fragment_reassembly_buffer_size; ++i )
+    // every member is checked rather than asserted, because reliable_endpoint_create hands a
+    // partly built endpoint to this function to unwind an allocation failure
+
+    if ( endpoint->fragment_reassembly )
     {
-        struct reliable_fragment_reassembly_data_t * reassembly_data = (struct reliable_fragment_reassembly_data_t*) 
-            reliable_sequence_buffer_at_index( endpoint->fragment_reassembly, i );
-
-        if ( reassembly_data && reassembly_data->packet_data )
+        int i;
+        for ( i = 0; i < endpoint->config.fragment_reassembly_buffer_size; ++i )
         {
-            endpoint->free_function( endpoint->allocator_context, reassembly_data->packet_data );
-            reassembly_data->packet_data = NULL;
+            struct reliable_fragment_reassembly_data_t * reassembly_data = (struct reliable_fragment_reassembly_data_t*) 
+                reliable_sequence_buffer_at_index( endpoint->fragment_reassembly, i );
+
+            if ( reassembly_data && reassembly_data->packet_data )
+            {
+                endpoint->free_function( endpoint->allocator_context, reassembly_data->packet_data );
+                reassembly_data->packet_data = NULL;
+            }
         }
     }
 
-    endpoint->free_function( endpoint->allocator_context, endpoint->acks );
+    if ( endpoint->acks )
+    {
+        endpoint->free_function( endpoint->allocator_context, endpoint->acks );
+    }
 
-    reliable_sequence_buffer_destroy( endpoint->sent_packets );
-    reliable_sequence_buffer_destroy( endpoint->received_packets );
-    reliable_sequence_buffer_destroy( endpoint->fragment_reassembly );
+    if ( endpoint->sent_packets )
+    {
+        reliable_sequence_buffer_destroy( endpoint->sent_packets );
+    }
 
-    endpoint->free_function( endpoint->allocator_context, endpoint->rtt_history_buffer );
+    if ( endpoint->received_packets )
+    {
+        reliable_sequence_buffer_destroy( endpoint->received_packets );
+    }
 
-    endpoint->free_function( endpoint->allocator_context, endpoint->transmit_buffer );
+    if ( endpoint->fragment_reassembly )
+    {
+        reliable_sequence_buffer_destroy( endpoint->fragment_reassembly );
+    }
+
+    if ( endpoint->rtt_history_buffer )
+    {
+        endpoint->free_function( endpoint->allocator_context, endpoint->rtt_history_buffer );
+    }
+
+    if ( endpoint->transmit_buffer )
+    {
+        endpoint->free_function( endpoint->allocator_context, endpoint->transmit_buffer );
+    }
 
     endpoint->free_function( endpoint->allocator_context, endpoint );
 }
@@ -689,7 +795,7 @@ uint16_t reliable_endpoint_next_packet_sequence( struct reliable_endpoint_t * en
     return endpoint->sequence;
 }
 
-int reliable_write_packet_header( uint8_t * packet_data, uint16_t sequence, uint16_t ack, uint32_t ack_bits )
+static int reliable_write_packet_header( uint8_t * packet_data, uint16_t sequence, uint16_t ack, uint32_t ack_bits )
 {
     uint8_t * p = packet_data;
 
@@ -864,7 +970,7 @@ void reliable_endpoint_send_packet( struct reliable_endpoint_t * endpoint, uint8
     endpoint->counters[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_SENT]++;
 }
 
-int reliable_read_packet_header( RELIABLE_CONST char * name, uint8_t * packet_data, int packet_bytes, uint16_t * sequence, uint16_t * ack, uint32_t * ack_bits )
+static int reliable_read_packet_header( RELIABLE_CONST char * name, uint8_t * packet_data, int packet_bytes, uint16_t * sequence, uint16_t * ack, uint32_t * ack_bits )
 {
     if ( packet_bytes < 3 )
     {
@@ -948,7 +1054,7 @@ int reliable_read_packet_header( RELIABLE_CONST char * name, uint8_t * packet_da
     return (int) ( p - packet_data );
 }
 
-int reliable_read_fragment_header( char * name, 
+static int reliable_read_fragment_header( char * name, 
                                    uint8_t * packet_data, 
                                    int packet_bytes, 
                                    int max_fragments, 
@@ -1051,7 +1157,7 @@ int reliable_read_fragment_header( char * name,
     return (int) ( p - packet_data );
 }
 
-void reliable_store_fragment_data( struct reliable_fragment_reassembly_data_t * reassembly_data, 
+static void reliable_store_fragment_data( struct reliable_fragment_reassembly_data_t * reassembly_data, 
                                    uint16_t sequence, 
                                    uint16_t ack, 
                                    uint32_t ack_bits, 
@@ -1349,7 +1455,7 @@ void reliable_endpoint_free_packet( struct reliable_endpoint_t * endpoint, void 
     endpoint->free_function( endpoint->allocator_context, packet );
 }
 
-uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks )
+RELIABLE_CONST uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks )
 {
     reliable_assert( endpoint );
     reliable_assert( num_acks );
@@ -1370,8 +1476,29 @@ void reliable_endpoint_reset( struct reliable_endpoint_t * endpoint )
     endpoint->num_acks = 0;
     endpoint->sequence = 0;
 
+    // every value a getter can return goes back to what it was at create, so the header's
+    // promise holds for the statistics as well as for the buffers
+
+    endpoint->rtt = 0.0f;
+    endpoint->rtt_min = 0.0f;
+    endpoint->rtt_max = 0.0f;
+    endpoint->rtt_avg = 0.0f;
+    endpoint->jitter_avg_vs_min_rtt = 0.0f;
+    endpoint->jitter_max_vs_min_rtt = 0.0f;
+    endpoint->jitter_stddev_vs_avg_rtt = 0.0f;
+    endpoint->packet_loss = 0.0f;
+    endpoint->sent_bandwidth_kbps = 0.0f;
+    endpoint->received_bandwidth_kbps = 0.0f;
+    endpoint->acked_bandwidth_kbps = 0.0f;
+
     memset( endpoint->acks, 0, endpoint->config.ack_buffer_size * sizeof( uint16_t ) );
     memset( endpoint->counters, 0, RELIABLE_ENDPOINT_NUM_COUNTERS * sizeof( uint64_t ) );
+
+    int rtt_index;
+    for ( rtt_index = 0; rtt_index < endpoint->config.rtt_history_size; ++rtt_index )
+    {
+        endpoint->rtt_history_buffer[rtt_index] = -1.0f;
+    }
 
     int i;
     for ( i = 0; i < endpoint->config.fragment_reassembly_buffer_size; ++i )
@@ -1399,7 +1526,7 @@ void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double tim
 
     // calculate min and max rtt
     {
-        float min_rtt = 10000.0f;
+        float min_rtt = FLT_MAX;
         float max_rtt = 0.0f;
         float sum_rtt = 0.0f;
         int count = 0;
@@ -1420,18 +1547,19 @@ void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double tim
                 count++;
             }
         }
-        if ( min_rtt == 10000.0f )
-        {
-            min_rtt = 0.0f;
-        }
-        endpoint->rtt_min = min_rtt;
-        endpoint->rtt_max = max_rtt;
+        // the sample count, not the value of min_rtt, says whether the history is empty. a
+        // sentinel compared against a real rtt reports 0 for a link slow enough to reach it
+
         if ( count > 0 )
         {
+            endpoint->rtt_min = min_rtt;
+            endpoint->rtt_max = max_rtt;
             endpoint->rtt_avg = sum_rtt / (float)count;
         }
         else
         {
+            endpoint->rtt_min = 0.0f;
+            endpoint->rtt_max = 0.0f;
             endpoint->rtt_avg = 0.0f;
         }
     }
@@ -1754,6 +1882,7 @@ static void check_handler( RELIABLE_CONST char * condition,
                            int line )
 {
     printf( "check failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
+    fflush( stdout );
 #ifdef RELIABLE_DEBUG
     #if defined( __GNUC__ )
         __builtin_trap();
@@ -2093,7 +2222,7 @@ static void test_acks()
     uint8_t sender_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( sender_acked_packet, 0, sizeof( sender_acked_packet ) );
     int sender_num_acks;
-    uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
+    RELIABLE_CONST uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
     for ( i = 0; i < sender_num_acks; ++i )
     {
         if ( sender_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -2109,7 +2238,7 @@ static void test_acks()
     uint8_t receiver_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( receiver_acked_packet, 0, sizeof( receiver_acked_packet ) );
     int receiver_num_acks;
-    uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
+    RELIABLE_CONST uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
     for ( i = 0; i < receiver_num_acks; ++i )
     {
         if ( receiver_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -2172,7 +2301,7 @@ static void test_acks_packet_loss()
     uint8_t sender_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( sender_acked_packet, 0, sizeof( sender_acked_packet ) );
     int sender_num_acks;
-    uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
+    RELIABLE_CONST uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
     for ( i = 0; i < sender_num_acks; ++i )
     {
         if ( sender_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -2188,7 +2317,7 @@ static void test_acks_packet_loss()
     uint8_t receiver_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( receiver_acked_packet, 0, sizeof( receiver_acked_packet ) );
     int receiver_num_acks;
-    uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
+    RELIABLE_CONST uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
     for ( i = 0; i < receiver_num_acks; ++i )
     {
         if ( receiver_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -3031,6 +3160,760 @@ static void test_rtt()
     reliable_endpoint_destroy(context.receiver);
 }
 
+// a pair of endpoints wired to each other through test_transmit_packet_function
+
+struct test_pair_t
+{
+    struct test_context_t context;
+    struct reliable_config_t sender_config;
+    struct reliable_config_t receiver_config;
+};
+
+static void test_pair_configs( struct test_pair_t * pair )
+{
+    test_default_context( &pair->context );
+
+    reliable_default_config( &pair->sender_config );
+    reliable_default_config( &pair->receiver_config );
+
+    reliable_copy_string( pair->sender_config.name, "sender", sizeof( pair->sender_config.name ) );
+    pair->sender_config.context = &pair->context;
+    pair->sender_config.id = 0;
+    pair->sender_config.transmit_packet_function = &test_transmit_packet_function;
+    pair->sender_config.process_packet_function = &test_process_packet_function;
+
+    reliable_copy_string( pair->receiver_config.name, "receiver", sizeof( pair->receiver_config.name ) );
+    pair->receiver_config.context = &pair->context;
+    pair->receiver_config.id = 1;
+    pair->receiver_config.transmit_packet_function = &test_transmit_packet_function;
+    pair->receiver_config.process_packet_function = &test_process_packet_function;
+}
+
+static void test_pair_create( struct test_pair_t * pair, double time )
+{
+    pair->context.sender = reliable_endpoint_create( &pair->sender_config, time );
+    pair->context.receiver = reliable_endpoint_create( &pair->receiver_config, time );
+    check( pair->context.sender );
+    check( pair->context.receiver );
+}
+
+static void test_pair_destroy( struct test_pair_t * pair )
+{
+    reliable_endpoint_destroy( pair->context.sender );
+    reliable_endpoint_destroy( pair->context.receiver );
+}
+
+// RL-02: a round trip long enough to reach any fixed sentinel must still be reported
+
+static void test_rtt_min_large()
+{
+    double time = 100.0;
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, time );
+
+    uint8_t packet[8];
+    memset( packet, 0, sizeof( packet ) );
+
+    reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+
+    // ten seconds pass before the acknowledgment comes back, so the one rtt sample is 10,000 ms
+
+    time += 10.0;
+
+    reliable_endpoint_update( pair.context.sender, time );
+    reliable_endpoint_update( pair.context.receiver, time );
+
+    reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+    reliable_endpoint_update( pair.context.sender, time );
+
+    int num_acks;
+    reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+    check( num_acks == 1 );
+
+    check( reliable_endpoint_rtt_min( pair.context.sender ) == 10000.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) == 10000.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) == 10000.0f );
+    check( reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender ) == 0.0f );
+
+    // and an endpoint with no samples at all still reports zero
+
+    check( reliable_endpoint_rtt_min( pair.context.receiver ) == 0.0f );
+
+    test_pair_destroy( &pair );
+}
+
+// RL-03: reset clears every field a getter can return, the rtt history included
+
+static void test_endpoint_reset_clears_stats()
+{
+    double time = 100.0;
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, time );
+
+    // enough packets that the bandwidth window, which samples half the sent packets buffer,
+    // lands on packets that were actually sent
+
+    int i;
+    for ( i = 0; i < 300; ++i )
+    {
+        uint8_t packet[64];
+        memset( packet, 0, sizeof( packet ) );
+
+        // the reply comes back a step later, so the acknowledgment carries a real round trip
+
+        reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+
+        time += 0.1;
+        reliable_endpoint_update( pair.context.sender, time );
+        reliable_endpoint_update( pair.context.receiver, time );
+
+        reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+        time += 0.1;
+        reliable_endpoint_update( pair.context.sender, time );
+        reliable_endpoint_update( pair.context.receiver, time );
+
+        reliable_endpoint_clear_acks( pair.context.sender );
+        reliable_endpoint_clear_acks( pair.context.receiver );
+    }
+
+    check( reliable_endpoint_rtt( pair.context.sender ) > 0.0f );
+    check( reliable_endpoint_rtt_min( pair.context.sender ) > 0.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) > 0.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) > 0.0f );
+
+    float sent_bandwidth, received_bandwidth, acked_bandwidth;
+    reliable_endpoint_bandwidth( pair.context.sender, &sent_bandwidth, &received_bandwidth, &acked_bandwidth );
+    check( sent_bandwidth > 0.0f );
+    check( received_bandwidth > 0.0f );
+    check( acked_bandwidth > 0.0f );
+
+    reliable_endpoint_reset( pair.context.sender );
+
+    check( reliable_endpoint_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_min( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_stddev_vs_avg_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_packet_loss( pair.context.sender ) == 0.0f );
+
+    reliable_endpoint_bandwidth( pair.context.sender, &sent_bandwidth, &received_bandwidth, &acked_bandwidth );
+    check( sent_bandwidth == 0.0f );
+    check( received_bandwidth == 0.0f );
+    check( acked_bandwidth == 0.0f );
+
+    // the rtt history is part of the state, so recomputing the statistics after a reset must
+    // not resurrect the samples that were in it
+
+    time += 0.1;
+    reliable_endpoint_update( pair.context.sender, time );
+
+    check( reliable_endpoint_rtt_min( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_stddev_vs_avg_rtt( pair.context.sender ) == 0.0f );
+
+    test_pair_destroy( &pair );
+}
+
+// RL-06: a config the library cannot honor is refused instead of asserted
+
+static void test_endpoint_create_invalid_config()
+{
+    struct reliable_config_t valid;
+
+    reliable_default_config( &valid );
+    valid.transmit_packet_function = &test_transmit_packet_function;
+    valid.process_packet_function = &test_process_packet_function;
+
+    struct reliable_endpoint_t * endpoint = reliable_endpoint_create( &valid, 0.0 );
+    check( endpoint );
+    reliable_endpoint_destroy( endpoint );
+
+    check( reliable_endpoint_create( NULL, 0.0 ) == NULL );
+
+    struct reliable_config_t config;
+
+    // the two relationships between fields
+
+    config = valid;
+    config.fragment_above = config.max_packet_size + 1;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid;
+    config.max_fragments = 4;
+    config.fragment_size = 1024;
+    config.max_packet_size = 4 * 1024 + 1;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    // exactly covering is allowed, one fragment short is not
+
+    config = valid;
+    config.max_fragments = 4;
+    config.fragment_size = 1024;
+    config.max_packet_size = 4 * 1024;
+    config.fragment_above = 1024;
+    endpoint = reliable_endpoint_create( &config, 0.0 );
+    check( endpoint );
+    reliable_endpoint_destroy( endpoint );
+
+    // ranges
+
+    config = valid; config.max_packet_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.fragment_above = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.fragment_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.max_fragments = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.max_fragments = 257;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.ack_buffer_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.sent_packets_buffer_size = -1;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.received_packets_buffer_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.fragment_reassembly_buffer_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.rtt_history_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.transmit_packet_function = NULL;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.process_packet_function = NULL;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    // the size arithmetic behind every one of those buffers
+
+    size_t bytes = 0;
+
+    check( reliable_checked_size( 1, 4, &bytes ) );
+    check( bytes == 4 );
+
+    check( reliable_checked_size( 256, sizeof( uint16_t ), &bytes ) );
+    check( bytes == 512 );
+
+    check( !reliable_checked_size( 0, 4, &bytes ) );
+    check( !reliable_checked_size( -1, 4, &bytes ) );
+    check( !reliable_checked_size( 4, 0, &bytes ) );
+
+    // a product that does not fit in a size_t is refused rather than wrapped
+
+    check( !reliable_checked_size( 4, SIZE_MAX / 2, &bytes ) );
+    check( !reliable_checked_size( INT_MAX, SIZE_MAX / 3, &bytes ) );
+}
+
+// RL-06: every allocation failure returns NULL, in every build, having freed what it took
+
+#define TEST_FAILING_ALLOCATOR_SLOTS 64
+
+struct test_failing_allocate_context_t
+{
+    int fail_on;
+    int num_allocations;
+    void * active_allocations[TEST_FAILING_ALLOCATOR_SLOTS];
+};
+
+static void * test_failing_allocate_function( void * context, size_t bytes )
+{
+    struct test_failing_allocate_context_t * failing_context = (struct test_failing_allocate_context_t*) context;
+
+    if ( failing_context->num_allocations++ == failing_context->fail_on )
+    {
+        return NULL;
+    }
+
+    void * allocation = malloc( bytes );
+
+    int i;
+    for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+    {
+        if ( failing_context->active_allocations[i] == NULL )
+        {
+            failing_context->active_allocations[i] = allocation;
+            return allocation;
+        }
+    }
+
+    check( 0 );
+    return allocation;
+}
+
+static void test_failing_free_function( void * context, void * pointer )
+{
+    struct test_failing_allocate_context_t * failing_context = (struct test_failing_allocate_context_t*) context;
+
+    int i;
+    for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+    {
+        if ( failing_context->active_allocations[i] == pointer )
+        {
+            failing_context->active_allocations[i] = NULL;
+            free( pointer );
+            return;
+        }
+    }
+
+    check( 0 );
+}
+
+static void test_endpoint_create_allocation_failure()
+{
+    struct test_failing_allocate_context_t allocator;
+
+    struct reliable_config_t config;
+    reliable_default_config( &config );
+    config.transmit_packet_function = &test_transmit_packet_function;
+    config.process_packet_function = &test_process_packet_function;
+    config.allocator_context = &allocator;
+    config.allocate_function = &test_failing_allocate_function;
+    config.free_function = &test_failing_free_function;
+
+    // how many allocations a successful create makes
+
+    memset( &allocator, 0, sizeof( allocator ) );
+    allocator.fail_on = -1;
+
+    struct reliable_endpoint_t * endpoint = reliable_endpoint_create( &config, 0.0 );
+    check( endpoint );
+
+    const int num_allocations = allocator.num_allocations;
+    check( num_allocations > 1 );
+
+    reliable_endpoint_destroy( endpoint );
+
+    int i;
+    for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+    {
+        check( allocator.active_allocations[i] == NULL );
+    }
+
+    // fail each one in turn
+
+    int fail_on;
+    for ( fail_on = 0; fail_on < num_allocations; ++fail_on )
+    {
+        memset( &allocator, 0, sizeof( allocator ) );
+        allocator.fail_on = fail_on;
+
+        check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+        for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+        {
+            check( allocator.active_allocations[i] == NULL );
+        }
+    }
+}
+
+// RL-07: the sequence number crosses 65535 to 0
+
+static uint8_t test_wrap_acked[65536];
+
+static void test_sequence_wrap()
+{
+    double time = 100.0;
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, time );
+
+    memset( test_wrap_acked, 0, sizeof( test_wrap_acked ) );
+
+    const int num_iterations = 65536 + 64;
+
+    int i;
+    for ( i = 0; i < num_iterations; ++i )
+    {
+        uint8_t packet[8];
+        memset( packet, 0, sizeof( packet ) );
+
+        reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+        reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+        int num_acks;
+        RELIABLE_CONST uint16_t * acks = reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+
+        int j;
+        for ( j = 0; j < num_acks; ++j )
+        {
+            test_wrap_acked[acks[j]] = 1;
+        }
+
+        reliable_endpoint_clear_acks( pair.context.sender );
+        reliable_endpoint_clear_acks( pair.context.receiver );
+    }
+
+    check( reliable_endpoint_next_packet_sequence( pair.context.sender ) == (uint16_t) num_iterations );
+
+    // the sequences either side of the wrap were acked like any others
+
+    check( test_wrap_acked[65533] );
+    check( test_wrap_acked[65534] );
+    check( test_wrap_acked[65535] );
+    check( test_wrap_acked[0] );
+    check( test_wrap_acked[1] );
+    check( test_wrap_acked[2] );
+
+    for ( i = 0; i < 65536; ++i )
+    {
+        check( test_wrap_acked[i] );
+    }
+
+    check( reliable_endpoint_counters( pair.context.receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_RECEIVED] == (uint64_t) num_iterations );
+
+    test_pair_destroy( &pair );
+}
+
+// RL-07: fragment counts at both ends of the range, and a payload that is an exact multiple
+// of the fragment size
+
+struct test_fragment_context_t
+{
+    struct test_context_t base;
+    int num_processed;
+    int processed_bytes;
+    uint8_t processed[64 * 1024];
+};
+
+static int test_fragment_process_packet_function( void * _context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes )
+{
+    (void) id;
+    (void) sequence;
+
+    struct test_fragment_context_t * context = (struct test_fragment_context_t*) _context;
+
+    check( packet_bytes <= (int) sizeof( context->processed ) );
+
+    context->num_processed++;
+    context->processed_bytes = packet_bytes;
+    memcpy( context->processed, packet_data, packet_bytes );
+
+    return 1;
+}
+
+static void test_fragment_case( int fragment_size, int max_fragments, int packet_bytes, int expected_fragments )
+{
+    struct test_fragment_context_t context;
+    memset( &context, 0, sizeof( context ) );
+    context.base.allow_packets = -1;
+
+    struct reliable_config_t sender_config;
+    struct reliable_config_t receiver_config;
+
+    reliable_default_config( &sender_config );
+    reliable_default_config( &receiver_config );
+
+    sender_config.fragment_size = fragment_size;
+    sender_config.max_fragments = max_fragments;
+    sender_config.max_packet_size = fragment_size * max_fragments;
+    sender_config.fragment_above = fragment_size;
+    receiver_config = sender_config;
+
+    reliable_copy_string( sender_config.name, "sender", sizeof( sender_config.name ) );
+    sender_config.context = &context;
+    sender_config.id = 0;
+    sender_config.transmit_packet_function = &test_transmit_packet_function;
+    sender_config.process_packet_function = &test_fragment_process_packet_function;
+
+    reliable_copy_string( receiver_config.name, "receiver", sizeof( receiver_config.name ) );
+    receiver_config.context = &context;
+    receiver_config.id = 1;
+    receiver_config.transmit_packet_function = &test_transmit_packet_function;
+    receiver_config.process_packet_function = &test_fragment_process_packet_function;
+
+    context.base.sender = reliable_endpoint_create( &sender_config, 100.0 );
+    context.base.receiver = reliable_endpoint_create( &receiver_config, 100.0 );
+    check( context.base.sender );
+    check( context.base.receiver );
+
+    uint8_t * packet = (uint8_t*) malloc( packet_bytes );
+    check( packet );
+
+    int i;
+    for ( i = 0; i < packet_bytes; ++i )
+    {
+        packet[i] = (uint8_t) ( ( i * 31 ) + 7 );
+    }
+
+    reliable_endpoint_send_packet( context.base.sender, packet, packet_bytes );
+
+    check( context.num_processed == 1 );
+    check( context.processed_bytes == packet_bytes );
+    check( memcmp( context.processed, packet, packet_bytes ) == 0 );
+
+    const uint64_t fragments_sent = reliable_endpoint_counters( context.base.sender )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_SENT];
+    const uint64_t fragments_received = reliable_endpoint_counters( context.base.receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED];
+
+    if ( expected_fragments == 0 )
+    {
+        // below the threshold: sent whole, no fragments at all
+        check( fragments_sent == 0 );
+        check( fragments_received == 0 );
+    }
+    else
+    {
+        check( fragments_sent == (uint64_t) expected_fragments );
+        check( fragments_received == (uint64_t) expected_fragments );
+    }
+
+    free( packet );
+
+    reliable_endpoint_destroy( context.base.sender );
+    reliable_endpoint_destroy( context.base.receiver );
+}
+
+static void test_fragment_counts()
+{
+    // an exact multiple of the fragment size, where the last fragment is full rather than a remainder
+    test_fragment_case( 512, 16, 512 * 4, 4 );
+
+    // the largest packet the config allows, again an exact multiple
+    test_fragment_case( 512, 16, 512 * 16, 16 );
+
+    // one fragment: above the threshold by a single byte
+    test_fragment_case( 512, 16, 513, 2 );
+    test_fragment_case( 64, 256, 65, 2 );
+
+    // 256 fragments, the maximum the wire format can express
+    test_fragment_case( 64, 256, 64 * 256, 256 );
+    test_fragment_case( 64, 256, 64 * 255 + 1, 256 );
+
+    // at or below the threshold the packet is not fragmented
+    test_fragment_case( 512, 16, 512, 0 );
+    test_fragment_case( 512, 16, 1, 0 );
+}
+
+// RL-07: truncated packets and fragments are rejected rather than acted on
+
+struct test_truncation_context_t
+{
+    struct test_context_t base;
+    int num_processed;
+    int num_captured;
+    int captured_bytes[300];
+    uint8_t captured[300][1024];
+};
+
+static void test_truncation_transmit_packet_function( void * _context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes )
+{
+    (void) id;
+    (void) sequence;
+
+    struct test_truncation_context_t * context = (struct test_truncation_context_t*) _context;
+
+    if ( context->num_captured < (int) ARRAY_LENGTH( context->captured_bytes ) && packet_bytes <= (int) sizeof( context->captured[0] ) )
+    {
+        memcpy( context->captured[context->num_captured], packet_data, packet_bytes );
+        context->captured_bytes[context->num_captured] = packet_bytes;
+        context->num_captured++;
+    }
+}
+
+static int test_truncation_process_packet_function( void * _context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes )
+{
+    (void) id;
+    (void) sequence;
+    (void) packet_data;
+    (void) packet_bytes;
+
+    struct test_truncation_context_t * context = (struct test_truncation_context_t*) _context;
+    context->num_processed++;
+    return 1;
+}
+
+static void test_truncated_packets()
+{
+    struct test_truncation_context_t context;
+    memset( &context, 0, sizeof( context ) );
+    context.base.allow_packets = -1;
+
+    struct reliable_config_t config;
+    reliable_default_config( &config );
+    config.fragment_size = 256;
+    config.max_fragments = 16;
+    config.max_packet_size = 256 * 16;
+    config.fragment_above = 256;
+    config.context = &context;
+    config.id = 0;
+    config.transmit_packet_function = &test_truncation_transmit_packet_function;
+    config.process_packet_function = &test_truncation_process_packet_function;
+
+    struct reliable_endpoint_t * sender = reliable_endpoint_create( &config, 100.0 );
+    struct reliable_endpoint_t * receiver = reliable_endpoint_create( &config, 100.0 );
+    check( sender );
+    check( receiver );
+
+    // an unfragmented packet, captured on the wire
+
+    uint8_t packet[200];
+    memset( packet, 0xAB, sizeof( packet ) );
+    reliable_endpoint_send_packet( sender, packet, sizeof( packet ) );
+    check( context.num_captured == 1 );
+
+    const int whole_bytes = context.captured_bytes[0];
+
+    // every truncation of it shorter than the header is rejected, and none is processed
+
+    int truncated_bytes;
+    for ( truncated_bytes = 1; truncated_bytes < 4; ++truncated_bytes )
+    {
+        reliable_endpoint_receive_packet( receiver, context.captured[0], truncated_bytes );
+    }
+
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_INVALID] == 3 );
+    check( context.num_processed == 0 );
+
+    // the whole packet still arrives
+
+    reliable_endpoint_receive_packet( receiver, context.captured[0], whole_bytes );
+    check( context.num_processed == 1 );
+
+    // now a fragmented packet
+
+    context.num_captured = 0;
+
+    uint8_t large_packet[1024];
+    memset( large_packet, 0xCD, sizeof( large_packet ) );
+    reliable_endpoint_send_packet( sender, large_packet, sizeof( large_packet ) );
+    check( context.num_captured == 4 );
+
+    // a fragment truncated inside its header is rejected
+
+    for ( truncated_bytes = 1; truncated_bytes < RELIABLE_FRAGMENT_HEADER_BYTES; ++truncated_bytes )
+    {
+        reliable_endpoint_receive_packet( receiver, context.captured[1], truncated_bytes );
+    }
+
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED] == 0 );
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_INVALID] == RELIABLE_FRAGMENT_HEADER_BYTES - 1 );
+
+    // a fragment that is not the last one must carry exactly fragment_size bytes, so a
+    // truncated body is rejected too
+
+    reliable_endpoint_receive_packet( receiver, context.captured[1], context.captured_bytes[1] - 1 );
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED] == 0 );
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_INVALID] == RELIABLE_FRAGMENT_HEADER_BYTES );
+    check( context.num_processed == 1 );
+
+    // the intact fragments reassemble
+
+    int i;
+    for ( i = 0; i < context.num_captured; ++i )
+    {
+        reliable_endpoint_receive_packet( receiver, context.captured[i], context.captured_bytes[i] );
+    }
+
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED] == 4 );
+    check( context.num_processed == 2 );
+
+    reliable_endpoint_destroy( sender );
+    reliable_endpoint_destroy( receiver );
+}
+
+// every function reliable.h declares is called at least once by the suite. this test names
+// them all in one place so a new entry point cannot be added without being exercised
+
+static int test_surface_printf_calls = 0;
+
+static int test_surface_printf_function( RELIABLE_CONST char * format, ... )
+{
+    (void) format;
+    test_surface_printf_calls++;
+    return 0;
+}
+
+static void test_public_api_surface()
+{
+    check( reliable_init() == RELIABLE_OK );
+
+    reliable_set_assert_function( reliable_assert_function );
+
+    reliable_set_printf_function( &test_surface_printf_function );
+    reliable_log_level( RELIABLE_LOG_LEVEL_NONE );
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, 100.0 );
+
+    check( reliable_endpoint_next_packet_sequence( pair.context.sender ) == 0 );
+
+    uint8_t packet[64];
+    memset( packet, 0, sizeof( packet ) );
+
+    reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+    reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+    reliable_endpoint_receive_packet( pair.context.sender, packet, sizeof( packet ) );
+
+    reliable_endpoint_update( pair.context.sender, 100.1 );
+
+    int num_acks = 0;
+    RELIABLE_CONST uint16_t * acks = reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+    check( acks );
+    check( num_acks == 1 );
+    reliable_endpoint_clear_acks( pair.context.sender );
+    reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+    check( num_acks == 0 );
+
+    ( void ) reliable_endpoint_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_rtt_min( pair.context.sender );
+    ( void ) reliable_endpoint_rtt_max( pair.context.sender );
+    ( void ) reliable_endpoint_rtt_avg( pair.context.sender );
+    ( void ) reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_jitter_stddev_vs_avg_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_packet_loss( pair.context.sender );
+
+    float sent_bandwidth, received_bandwidth, acked_bandwidth;
+    reliable_endpoint_bandwidth( pair.context.sender, &sent_bandwidth, &received_bandwidth, &acked_bandwidth );
+
+    check( reliable_endpoint_counters( pair.context.sender )[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_SENT] == 1 );
+
+    reliable_endpoint_reset( pair.context.sender );
+    check( reliable_endpoint_next_packet_sequence( pair.context.sender ) == 0 );
+
+    void * owned = malloc( 32 );
+    check( owned );
+    reliable_endpoint_free_packet( pair.context.sender, owned );
+
+    char name[8];
+    reliable_copy_string( name, "abcdefghij", sizeof( name ) );
+    check( strcmp( name, "abcdefg" ) == 0 );
+
+    struct reliable_config_t defaults;
+    reliable_default_config( &defaults );
+    check( defaults.max_packet_size > 0 );
+
+    test_pair_destroy( &pair );
+
+    reliable_set_printf_function( ( int (*)( RELIABLE_CONST char *, ... ) ) printf );
+
+    reliable_term();
+    check( reliable_init() == RELIABLE_OK );
+}
+
 #define RUN_TEST( test_function )                                           \
     do                                                                      \
     {                                                                       \
@@ -3058,6 +3941,14 @@ void reliable_test()
         RUN_TEST( test_fragment_cleanup );
         RUN_TEST( test_rtt );
         RUN_TEST( test_endpoint_reset );
+        RUN_TEST( test_endpoint_reset_clears_stats );
+        RUN_TEST( test_rtt_min_large );
+        RUN_TEST( test_endpoint_create_invalid_config );
+        RUN_TEST( test_endpoint_create_allocation_failure );
+        RUN_TEST( test_sequence_wrap );
+        RUN_TEST( test_fragment_counts );
+        RUN_TEST( test_truncated_packets );
+        RUN_TEST( test_public_api_surface );
     }
 }
 

--- a/reliable/reliable.h
+++ b/reliable/reliable.h
@@ -32,10 +32,10 @@
 #ifndef RELIABLE_H
 #define RELIABLE_H
 
-#define RELIABLE_VERSION_FULL    "1.4.0"
+#define RELIABLE_VERSION_FULL    "1.4.2"
 #define RELIABLE_VERSION_MAJOR   1
 #define RELIABLE_VERSION_MINOR   4
-#define RELIABLE_VERSION_PATCH   0
+#define RELIABLE_VERSION_PATCH   2
 
 #include <stdint.h>
 #include <stddef.h>
@@ -95,6 +95,27 @@
 #define RELIABLE_OK         1
 #define RELIABLE_ERROR      0
 
+// the public surface. every function below carries RELIABLE_EXPORT and nothing else in the
+// library does, so a shared build exports exactly this header and a static build is unchanged.
+// the build system defines RELIABLE_SHARED for both the library and its consumers when
+// BUILD_SHARED_LIBS is on, and RELIABLE_BUILDING for the library itself.
+
+#if defined(RELIABLE_SHARED)
+    #if defined(_WIN32) || defined(__CYGWIN__)
+        #if defined(RELIABLE_BUILDING)
+            #define RELIABLE_EXPORT __declspec(dllexport)
+        #else
+            #define RELIABLE_EXPORT __declspec(dllimport)
+        #endif
+    #elif defined(__GNUC__)
+        #define RELIABLE_EXPORT __attribute__((visibility("default")))
+    #else
+        #define RELIABLE_EXPORT
+    #endif
+#else
+    #define RELIABLE_EXPORT
+#endif
+
 #ifdef __cplusplus
 #define RELIABLE_CONST const
 extern "C" {
@@ -108,11 +129,11 @@ extern "C" {
 
 // initialize the library. call this once before creating any endpoints. returns RELIABLE_OK on success
 
-int reliable_init(void);
+RELIABLE_EXPORT int reliable_init(void);
 
 // shut down the library. call this once after all endpoints are destroyed
 
-void reliable_term(void);
+RELIABLE_EXPORT void reliable_term(void);
 
 struct reliable_config_t
 {
@@ -139,85 +160,128 @@ struct reliable_config_t
     void (*free_function)(void*,void*);                                         // custom free. NULL = free
 };
 
+// pointer lifetimes across the callbacks and the config:
+//
+//   context, allocator_context      owned by you. the endpoint stores them and hands them
+//                                   back unchanged, so they must outlive the endpoint. the
+//                                   library never dereferences either one.
+//
+//   transmit_packet_function
+//     packet_data                   points into the endpoint's own transmit scratch buffer
+//                                   and is valid only for the duration of the call. the next
+//                                   send on that endpoint overwrites it, which is why the
+//                                   callback must not send on the same endpoint. copy the
+//                                   bytes if you need them after you return.
+//
+//   process_packet_function
+//     packet_data                   valid only for the duration of the call. for an
+//                                   unfragmented packet it points into the buffer you passed
+//                                   to reliable_endpoint_receive_packet, past the header. for
+//                                   a reassembled packet it points into an internal buffer
+//                                   that the endpoint may free as soon as you return. copy the
+//                                   bytes if you need them after you return. it is yours to
+//                                   read, not to free: reliable_endpoint_free_packet is for
+//                                   memory you allocated with the endpoint's allocator.
+//
+//   allocate_function, free_function
+//                                   called for every allocation the endpoint makes, including
+//                                   during reliable_endpoint_create. returning NULL from
+//                                   allocate_function is a supported outcome: create frees
+//                                   whatever it had allocated and returns NULL.
+
 // fills a config with sensible defaults for a client/server game exchanging packets at 60HZ
 
-void reliable_default_config( struct reliable_config_t * config );
+RELIABLE_EXPORT void reliable_default_config( struct reliable_config_t * config );
 
 // creates an endpoint. one endpoint per connection: a client has one, a server has one per client slot.
 // endpoints are not thread safe: use one endpoint per-thread or protect each endpoint with your own lock.
 // (the log level, printf and assert handlers are global to the process.)
+//
+// returns NULL in every build, debug and release, if the config is not valid or if any
+// allocation fails. a refused config is one whose fields are out of range or whose
+// relationships do not hold: fragment_above must not exceed max_packet_size, and
+// max_fragments * fragment_size must cover max_packet_size. on failure nothing is retained:
+// every allocation already made is handed back to free_function before create returns.
+// check the result.
 
-struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t * config, double time );
+RELIABLE_EXPORT struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t * config, double time );
 
 // returns the sequence number the next sent packet will have. use it to map acked sequence numbers back to the contents of packets you sent
 
-uint16_t reliable_endpoint_next_packet_sequence( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT uint16_t reliable_endpoint_next_packet_sequence( struct reliable_endpoint_t * endpoint );
 
 // sends a packet. the packet is handed to the transmit packet callback, split into fragments first if larger than config.fragment_above
 
-void reliable_endpoint_send_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
+RELIABLE_EXPORT void reliable_endpoint_send_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
 
 // call this for each packet received from your socket. valid packets are passed to the process packet callback. stale and duplicate packets are dropped
 
-void reliable_endpoint_receive_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
+RELIABLE_EXPORT void reliable_endpoint_receive_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
 
 // frees a packet using the endpoint's allocator
 
-void reliable_endpoint_free_packet( struct reliable_endpoint_t * endpoint, void * packet );
+RELIABLE_EXPORT void reliable_endpoint_free_packet( struct reliable_endpoint_t * endpoint, void * packet );
 
-// returns the array of sequence numbers of sent packets acked since the last clear
+// returns a read only view of the sequence numbers of sent packets acked since the last clear.
+// the array belongs to the endpoint. it stays valid until the next call to
+// reliable_endpoint_receive_packet, reliable_endpoint_clear_acks, reliable_endpoint_reset or
+// reliable_endpoint_destroy on that endpoint. copy what you need before calling any of those
 
-uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks );
+RELIABLE_EXPORT RELIABLE_CONST uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks );
 
 // clears the ack array. call this once per-frame after processing acks. if you don't, the ack buffer fills up and new acks are dropped
 
-void reliable_endpoint_clear_acks( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT void reliable_endpoint_clear_acks( struct reliable_endpoint_t * endpoint );
 
-// resets the endpoint to its initial state: acks, counters, sequence number and all tracking buffers are cleared
+// resets the endpoint to its initial state: acks, counters, sequence number, all tracking
+// buffers, the rtt history and every rtt, jitter, packet loss and bandwidth statistic are
+// cleared. the config and the allocator are kept, so the endpoint is immediately usable again
 
-void reliable_endpoint_reset( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT void reliable_endpoint_reset( struct reliable_endpoint_t * endpoint );
 
 // updates rtt, jitter, packet loss and bandwidth stats. call once per-frame with the current time
 
-void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double time );
+RELIABLE_EXPORT void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double time );
 
 // rtt and jitter are in milliseconds, packet loss is a percentage, bandwidth is in kilobits per-second
 
-float reliable_endpoint_rtt( struct reliable_endpoint_t * endpoint );       // exponentially smoothed moving average
+RELIABLE_EXPORT float reliable_endpoint_rtt( struct reliable_endpoint_t * endpoint );       // exponentially smoothed moving average
 
-float reliable_endpoint_rtt_min( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_rtt_min( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_rtt_max( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_rtt_max( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_rtt_avg( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_rtt_avg( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_jitter_avg_vs_min_rtt( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_jitter_avg_vs_min_rtt( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_jitter_max_vs_min_rtt( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_jitter_max_vs_min_rtt( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_jitter_stddev_vs_avg_rtt( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_jitter_stddev_vs_avg_rtt( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_packet_loss( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_packet_loss( struct reliable_endpoint_t * endpoint );
 
-void reliable_endpoint_bandwidth( struct reliable_endpoint_t * endpoint, float * sent_bandwidth_kbps, float * received_bandwidth_kbps, float * acked_bandwidth_kpbs );
+RELIABLE_EXPORT void reliable_endpoint_bandwidth( struct reliable_endpoint_t * endpoint, float * sent_bandwidth_kbps, float * received_bandwidth_kbps, float * acked_bandwidth_kpbs );
 
-// returns the array of RELIABLE_ENDPOINT_NUM_COUNTERS counters. index with RELIABLE_ENDPOINT_COUNTER_*
+// returns a read only view of the RELIABLE_ENDPOINT_NUM_COUNTERS counters, indexed with
+// RELIABLE_ENDPOINT_COUNTER_*. the array belongs to the endpoint and stays valid until it is
+// reset or destroyed
 
-RELIABLE_CONST uint64_t * reliable_endpoint_counters( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT RELIABLE_CONST uint64_t * reliable_endpoint_counters( struct reliable_endpoint_t * endpoint );
 
 // destroys an endpoint, freeing everything it allocated
 
-void reliable_endpoint_destroy( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT void reliable_endpoint_destroy( struct reliable_endpoint_t * endpoint );
 
 // sets the log level (process-wide). RELIABLE_LOG_LEVEL_NONE by default
 
-void reliable_log_level( int level );
+RELIABLE_EXPORT void reliable_log_level( int level );
 
 // overrides where log output goes (process-wide). default is printf
 
-void reliable_set_printf_function( int (*function)( RELIABLE_CONST char *, ... ) );
+RELIABLE_EXPORT void reliable_set_printf_function( int (*function)( RELIABLE_CONST char *, ... ) );
 
-extern void (*reliable_assert_function)( RELIABLE_CONST char *, RELIABLE_CONST char *, RELIABLE_CONST char * file, int line );
+RELIABLE_EXPORT extern void (*reliable_assert_function)( RELIABLE_CONST char *, RELIABLE_CONST char *, RELIABLE_CONST char * file, int line );
 
 #ifdef RELIABLE_DEBUG
 #define reliable_assert( condition )                                                        \
@@ -233,12 +297,12 @@ do                                                                              
 #define reliable_assert( ignore ) ((void)0)
 #endif
 
-void reliable_set_assert_function( void (*function)( RELIABLE_CONST char * /*condition*/, 
+RELIABLE_EXPORT void reliable_set_assert_function( void (*function)( RELIABLE_CONST char * /*condition*/, 
                                    RELIABLE_CONST char * /*function*/, 
                                    RELIABLE_CONST char * /*file*/, 
                                    int /*line*/ ) );
 
-void reliable_copy_string( char * dest, RELIABLE_CONST char * source, size_t dest_size );
+RELIABLE_EXPORT void reliable_copy_string( char * dest, RELIABLE_CONST char * source, size_t dest_size );
 
 #ifdef __cplusplus
 }

--- a/source/yojimbo_server.cpp
+++ b/source/yojimbo_server.cpp
@@ -36,6 +36,7 @@ namespace yojimbo
         : BaseServer( allocator, config, adapter, time )
     {
         yojimbo_assert( KeyBytes == NETCODE_KEY_BYTES );
+        yojimbo_assert( DefaultMaxConnectTokenLifetime == NETCODE_DEFAULT_MAX_CONNECT_TOKEN_LIFETIME );
         memcpy( m_privateKey, privateKey, NETCODE_KEY_BYTES );
         m_address = address;
         m_boundAddress = address;
@@ -67,6 +68,7 @@ namespace yojimbo
         netcodeConfig.allocator_context = &GetGlobalAllocator();
         netcodeConfig.allocate_function = StaticAllocateFunction;
         netcodeConfig.free_function     = StaticFreeFunction;
+        netcodeConfig.max_connect_token_lifetime = m_config.maxConnectTokenLifetime;
         netcodeConfig.callback_context = this;
         netcodeConfig.connect_disconnect_callback = StaticConnectDisconnectCallbackFunction;
         netcodeConfig.send_loopback_packet_callback = StaticSendLoopbackPacketCallbackFunction;

--- a/test.cpp
+++ b/test.cpp
@@ -36,6 +36,11 @@
 #include <sodium.h>
 #endif // #ifndef YOJIMBO_SYSTEM_DEPS
 
+// For netcode_generate_connect_token: one test mints a single connect token and keeps it,
+// which is what a matchmaker does and what Client::InsecureConnect deliberately will not do.
+// Present in both configurations, unlike sodium.h.
+#include "netcode.h"
+
 using namespace yojimbo;
 
 static void CheckHandler( const char * condition,
@@ -2472,6 +2477,127 @@ void test_client_is_loopback_when_disconnected()
     check( !client.IsConnected() );
 }
 
+void test_client_connect_twice_with_one_connect_token()
+{
+    // Mirrors netcode's test_client_reconnect_with_used_connect_token through yojimbo's API.
+    // A connect token is spent by the connection it admits: once the server has accepted a
+    // client holding it, presenting the same token again connects nothing, from the same
+    // address, after the client's slot is free again.
+    const uint64_t clientId = 1;
+
+    Address clientAddress( "0.0.0.0", ClientPort );
+    Address serverAddress( "127.0.0.1", ServerPort );
+
+    double time = 100.0;
+
+    ClientServerConfig config;
+
+    // The second connect attempt has to run all the way out to a connection request timeout,
+    // and the connect token's expiry has to stay above that so the failure is the timeout and
+    // not an expired token. A short timeout keeps both waits short.
+    config.timeout = 2;
+
+    uint8_t privateKey[KeyBytes];
+    memset( privateKey, 0, KeyBytes );
+
+    Server server( GetDefaultAllocator(), privateKey, serverAddress, config, adapter, time );
+
+    check( server.Start( MaxClients ) );
+
+    // One connect token, minted once and held, the way a matchmaker hands one to a client.
+
+    char serverAddressString[MaxAddressLength];
+    serverAddress.ToString( serverAddressString, MaxAddressLength );
+    const char * serverAddressStrings[] = { serverAddressString };
+
+    uint8_t userData[256];
+    memset( userData, 0, sizeof( userData ) );
+
+    uint8_t connectToken[ConnectTokenBytes];
+    check( netcode_generate_connect_token( 1,
+                                           serverAddressStrings,
+                                           serverAddressStrings,
+                                           InsecureConnectTokenExpirySeconds,
+                                           config.timeout,
+                                           clientId,
+                                           config.protocolId,
+                                           privateKey,
+                                           userData,
+                                           connectToken ) == NETCODE_OK );
+
+    const int NumIterations = 1000;
+
+    Client client( GetDefaultAllocator(), clientAddress, config, adapter, time );
+
+    // First use of the token connects.
+
+    check( client.Connect( clientId, connectToken ) );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        if ( !client.IsConnecting() && client.IsConnected() && server.GetNumConnectedClients() == 1 )
+            break;
+    }
+
+    check( client.IsConnected() );
+    check( server.GetNumConnectedClients() == 1 );
+    check( client.GetClientIndex() == 0 );
+
+    // Free the slot server side and let the client see it, so the second attempt runs against
+    // a server with room for it and nothing left over from the first connection.
+
+    server.DisconnectClient( 0 );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( !client.IsConnected() && server.GetNumConnectedClients() == 0 )
+            break;
+    }
+
+    check( !client.IsConnected() );
+    check( server.GetNumConnectedClients() == 0 );
+
+    // Second use of the same token connects nothing. The server ignores the connection
+    // requests, so the client runs out of retries and reports a connection request timeout.
+
+    check( client.Connect( clientId, connectToken ) );
+
+    for ( int i = 0; i < NumIterations; ++i )
+    {
+        Client * clients[] = { &client };
+        Server * servers[] = { &server };
+
+        PumpClientServerUpdate( time, clients, 1, servers, 1 );
+
+        if ( client.ConnectionFailed() )
+            break;
+
+        check( !client.IsConnected() );
+        check( server.GetNumConnectedClients() == 0 );
+    }
+
+    check( client.ConnectionFailed() );
+    check( !client.IsConnected() );
+    check( server.GetNumConnectedClients() == 0 );
+    check( client.GetDisconnectReason() == YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT );
+
+    client.Disconnect();
+    server.Stop();
+}
+
 void test_client_server_messages()
 {
     const uint64_t clientId = 1;
@@ -4206,6 +4332,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_client_connect_factory_failure );
         RUN_TEST( test_client_connect_socket_failure_no_crash );
         RUN_TEST( test_client_is_loopback_when_disconnected );
+        RUN_TEST( test_client_connect_twice_with_one_connect_token );
         RUN_TEST( test_client_server_messages );
         RUN_TEST( test_client_server_start_stop_restart );
         RUN_TEST( test_client_server_message_failed_to_serialize_reliable_ordered );

--- a/tools/gen_seed_corpus.c
+++ b/tools/gen_seed_corpus.c
@@ -79,7 +79,9 @@ static void verify_netcode( const uint8_t * data, int bytes )
 
     uint64_t sequence = 0;
     void * packet = netcode_read_packet( buffer, bytes, &sequence, key, FUZZ_PROTOCOL_ID,
-                                         FUZZ_TIMESTAMP, key, allowed, &replay, NULL, NULL );
+                                         FUZZ_TIMESTAMP,
+                                         0,     /* minimum expire timestamp: zero, so a seed's connect token is never refused for predating a server start */
+                                         key, allowed, &replay, NULL, NULL );
     assert( packet && "generated netcode seed failed to read back" );
     const int packet_type = *(const uint8_t*) packet;
     assert( packet_type >= 0 && packet_type < NETCODE_CONNECTION_NUM_PACKETS );
@@ -369,6 +371,7 @@ static void gen_reliable( const char * root )
     receiver_config.transmit_packet_function = reliable_receiver_noop_transmit;
     receiver_config.process_packet_function = reliable_count_received;
     g_reliable_receiver = reliable_endpoint_create( &receiver_config, 100.0 );
+    assert( g_reliable_receiver && "could not create the reliable receiver endpoint" );
 
     struct reliable_config_t config;
     reliable_default_config( &config );
@@ -376,6 +379,7 @@ static void gen_reliable( const char * root )
     config.process_packet_function = reliable_accept_all;
 
     struct reliable_endpoint_t * endpoint = reliable_endpoint_create( &config, 100.0 );
+    assert( endpoint && "could not create the reliable sender endpoint" );
 
     // a small payload -> one regular (non-fragmented) packet: prefix byte + header + payload
     uint8_t small_payload[512];


### PR DESCRIPTION
Ruling Y9: after netcode and reliable release, yojimbo vendors both and its interop and system-deps jobs pin the new tags.

## Vendored

| file | source | cmp against the tag |
| --- | --- | --- |
| `netcode/netcode.c` | netcode `v1.4.5` | identical |
| `netcode/netcode.h` | netcode `v1.4.5` | identical |
| `reliable/reliable.c` | reliable `v1.4.2` | identical |
| `reliable/reliable.h` | reliable `v1.4.2` | identical |
| `sodium/sodium.c`, `sodium/sodium.h` | netcode `v1.4.5` | already identical, unchanged |

sodium did not move between netcode 1.4.3 and 1.4.5, so the sodium parity job needs nothing. `sodium/NOTES.md` and `sodium/.clang-format` are yojimbo's own and stay as they are.

One pre-existing drift is closed on the way past: the vendored `reliable.h` was reliable v1.4.0 plus a local edit to the credit line. That edit is upstream now, so the vendored copy is the tag again.

## Manifest and CI

`dependencies.manifest` names `v1.4.5` and `v1.4.2` and raises the netcode floor to 1.4.5. The floor has to move: yojimbo's server config passes `max_connect_token_lifetime`, a field netcode 1.4.4 and earlier do not have, so a system netcode below 1.4.5 does not build. serialize stays at `v1.15.0`, which is the current release.

The system-deps CI tags are read out of the manifest, so they follow on their own. The floor-refusal step now knocks the installed netcode down to 1.4.4, the newest version the floor refuses, and matches the new sentence.

## Adapted

- `ClientServerConfig::maxConnectTokenLifetime` carries netcode's new server config field through to `netcode_server_config_t`, defaulting to `DefaultMaxConnectTokenLifetime` (30), netcode's own default. `Server`'s constructor asserts the two constants agree, beside the existing `KeyBytes == NETCODE_KEY_BYTES`. Documented in `USAGE.md`, including that the matcher in this repository issues 45 second tokens.
- `netcode_read_packet` takes a minimum expire timestamp now. The two callers outside the library, `fuzz/fuzz_netcode.c` and `tools/gen_seed_corpus.c`, pass zero: both feed synthetic packets that have to keep reaching the parser.
- `reliable_endpoint_create` can return NULL in every build. `BaseClient::CreateInternal` and `BaseServer::Start` already check it (#340), so only `fuzz/fuzz_reliable.c` and `tools/gen_seed_corpus.c` needed it.
- `reliable_endpoint_get_acks` returns a const view. Both call sites already stored it as `const uint16_t *`.
- `netcode_packet_queue_clear` pops until empty. yojimbo does not use the packet queue directly.
- netcode 1.4.5 exports a `netcode::` CMake target. yojimbo's `YojimboSystemDeps.cmake` resolves netcode with `find_path`/`find_library` into its own `Yojimbo::netcode` imported target and does not reference netcode's, so nothing changes there.

## Test

`test_client_connect_twice_with_one_connect_token` mirrors netcode's `test_client_reconnect_with_used_connect_token` through yojimbo's API: one connect token is minted and held the way a matchmaker hands one out, it connects, the server frees the slot with `DisconnectClient`, and the same token then connects nothing and ends in `YOJIMBO_CLIENT_DISCONNECT_REASON_CONNECTION_REQUEST_TIMED_OUT`.

**Negative control**: the same test against the previously vendored netcode 1.4.3 fails red, on the server accepting the second connection:

    test_client_connect_twice_with_one_connect_token
    check failed: ( server.GetNumConnectedClients() == 0 ), function
    test_client_connect_twice_with_one_connect_token, test.cpp, line 2589

## Local checks

Run on macOS arm64, one build at a time, no sanitizer runs on this machine.

- full test binary (debug): pass
- `custom_packet_io_test`: pass
- `verify_standard.py`: 13 corpus packets fully decoded, 0 failures
- `verify_state_machine.py`: 13 checks, 0 failures
- clean-prefix consumer against the default bundled install: pass
- seed corpus generator builds and runs
- every fuzz target compiles against the new sources

## Version

1.12.1 in `CMakeLists.txt` and `include/yojimbo_config.h`. `SECURITY.md` states in plain terms what vendoring netcode 1.4.5 changes for token handling. It names no advisory: one publishes with this release, and SECURITY.md links it then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)