### PR TITLE
SECURITY.md: link the published connect token reuse advisory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,7 +43,16 @@ Out of scope: bugs in your own game code built on top of yojimbo, denial-of-serv
 requires an already-authenticated malicious peer flooding traffic, and issues in build
 tooling or example/test code that are not reachable at runtime.
 
-## Connect token handling changed in 1.12.1
+## Known issue: connect token reuse after disconnect (fixed in 1.12.1)
+
+**Advisory: [GHSA-v29p-3vj4-vg4f](https://github.com/mas-bandwidth/netcode/security/advisories/GHSA-v29p-3vj4-vg4f)** (published 2026-09-04; filed against netcode, and it names yojimbo's affected range too).
+
+**Affected: yojimbo 1.12.0 and earlier. Fixed in 1.12.1.**
+
+A connect token that had already established a session could establish another one once that
+client disconnected, and the second session encrypts under the same keys from a packet
+sequence that starts over, so it repeats AEAD nonces. Upstream: `netcode` <= 1.4.4, fixed in
+1.4.5, which **yojimbo 1.12.1** is the first release to vendor.
 
 **yojimbo 1.12.1 vendors netcode 1.4.5.** That netcode tightens what the server accepts as a
 connect token, and the change is visible to anything built on yojimbo, so it is written down


### PR DESCRIPTION
[GHSA-v29p-3vj4-vg4f](https://github.com/mas-bandwidth/netcode/security/advisories/GHSA-v29p-3vj4-vg4f) published today, alongside netcode 1.4.5 and yojimbo 1.12.1.

The 1.12.1 section already said what changed for token handling, but named no advisory, because none was public when 1.12.1 landed. It now opens with the link, the affected range and the one sentence summary, in the shape of the 1.7.0 entry below it.

One sentence: a connect token that had already established a session could establish another one once that client disconnected, repeating AEAD nonces under the same keys. Affected yojimbo 1.12.0 and earlier, fixed in **1.12.1**; upstream `netcode` <= 1.4.4, fixed in **1.4.5**.

The advisory is filed against netcode and names yojimbo's affected range itself, so this entry points at netcode's rather than claiming one of its own, unlike the 1.7.0 entry. Documentation only, no code changes.

netcode's SECURITY.md gains the matching entry in mas-bandwidth/netcode#185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)