### PR TITLE
Compute block fragment count in 64-bit; cap fragment size at 65535

### DIFF
--- a/include/yojimbo_config.h
+++ b/include/yojimbo_config.h
@@ -26,6 +26,7 @@
 #define YOJIMBO_CONFIG_H
 
 #include "yojimbo_constants.h"
+#include <stdint.h>
 
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
@@ -171,7 +172,17 @@ namespace yojimbo
             // fragments. Using floor here under-sizes the send-side fragment buffers when
             // maxBlockSize is not a multiple of blockFragmentSize (see GetFragmentToSend,
             // which counts fragments with ceil).
-            return ( maxBlockSize + blockFragmentSize - 1 ) / blockFragmentSize;
+            //
+            // The add is 64-bit so a legal huge maxBlockSize cannot overflow signed int
+            // before the 65535 check in Validate (yojimbo#347).
+            if ( blockFragmentSize <= 0 )
+                return 0;
+            const int64_t n = ( (int64_t) maxBlockSize + blockFragmentSize - 1 ) / blockFragmentSize;
+            if ( n > 2147483647 )
+                return 2147483647;
+            if ( n < 0 )
+                return 0;
+            return (int) n;
         }
 
         /**

--- a/source/yojimbo_config.cpp
+++ b/source/yojimbo_config.cpp
@@ -84,6 +84,10 @@ namespace yojimbo
                 YOJIMBO_CONFIG_CHECK( blockFragmentSize > 0,
                     "error: invalid config: channel %d blockFragmentSize (%d) must be > 0\n", channelIndex, blockFragmentSize );
 
+                // On the wire fragmentSize is a 16-bit field (yojimbo#346).
+                YOJIMBO_CONFIG_CHECK( blockFragmentSize <= 65535,
+                    "error: invalid config: channel %d blockFragmentSize (%d) must be <= 65535\n", channelIndex, blockFragmentSize );
+
                 // A block fragment must fit inside a packet, or the channel stalls forever trying
                 // to send the block (see ReliableOrderedChannel::GetPacketData).
                 YOJIMBO_CONFIG_CHECK( blockFragmentSize <= maxPacketSize,

--- a/test.cpp
+++ b/test.cpp
@@ -1636,6 +1636,27 @@ template <typename Stream> static bool SerializeRawBlockFragmentPacket( Stream &
     return true;
 }
 
+void test_channel_config_fragment_counts_without_overflow()
+{
+    // yojimbo#347: ceil(maxBlockSize / blockFragmentSize) used to add in int
+    // and overflow for a legal huge maxBlockSize. The 65535 check then saw
+    // garbage. The add is 64-bit; a too-large result stays well-defined and
+    // still fails Validate's cap.
+    ChannelConfig channel;
+    channel.maxBlockSize = 2147483647;
+    channel.blockFragmentSize = 1024;
+    const int n = channel.GetMaxFragmentsPerBlock();
+    check( n == (int) ( ( (int64_t) 2147483647 + 1023 ) / 1024 ) );
+    check( n > 65535 );
+
+    // yojimbo#346: fragmentSize on the wire is 16 bits.
+    ChannelConfig small;
+    small.maxBlockSize = 256 * 1024;
+    small.blockFragmentSize = 1024;
+    check( small.GetMaxFragmentsPerBlock() == 256 );
+    check( small.blockFragmentSize <= 65535 );
+}
+
 void test_connection_reliable_block_fragment_overflow()
 {
     // Regression test: a peer sends a reliable-ordered block fragment whose final fragment
@@ -4315,6 +4336,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_connection_reject_empty_packet );
         RUN_TEST( test_connection_unreliable_rejects_block_fragment );
         RUN_TEST( test_connection_reliable_block_fragment_on_disabled_blocks );
+        RUN_TEST( test_channel_config_fragment_counts_without_overflow );
         RUN_TEST( test_connection_reliable_block_fragment_overflow );
         RUN_TEST( test_connection_reliable_over_budget_packet );
         RUN_TEST( test_connection_reliable_message_alloc_failure );


### PR DESCRIPTION
Johnny Grok. Fixes #347. Fixes #346.

`GetMaxFragmentsPerBlock` did `(maxBlockSize + blockFragmentSize - 1) / blockFragmentSize` in `int`. A legal huge `maxBlockSize` overflows before `Validate` can refuse too many fragments. The ceil is now 64-bit, and `Validate` still caps the result at 65535.

`blockFragmentSize` was only bounded by `maxPacketSize`, which has no upper bound, while the on-wire field is 16 bits. `Validate` now also requires `blockFragmentSize <= 65535`.

`test_channel_config_fragment_counts_without_overflow` pins both. `./build/bin/test` prints ALL TESTS PASS.