### PR TITLE
Copy connection packets into packetBytes+8 before deserialize

### DIFF
--- a/fuzz/fuzz_connection.cpp
+++ b/fuzz/fuzz_connection.cpp
@@ -64,8 +64,9 @@ extern "C" int LLVMFuzzerTestOneInput( const uint8_t * data, size_t size )
     FuzzMessageFactory messageFactory( GetDefaultAllocator() );
     Connection connection( GetDefaultAllocator(), messageFactory, config, 100.0 );
 
-    // The BitReader reads whole 32-bit words, so it may touch up to 3 bytes past the packet
-    // end. Real receive paths always have slack; mirror that with a padded, zeroed buffer.
+    // BitReader loads an 8-byte window from the byte at the read position, so a
+    // read in the last data byte can touch 7 bytes past the packet. ProcessPacket
+    // copies into packetBytes+8; the fuzzer mirrors that manufactured slack.
     static uint8_t buf[ 8 * 1024 + 16 ];
     if ( config.maxPacketSize + 16 > (int) sizeof( buf ) )
         return 0;

--- a/source/yojimbo_connection.cpp
+++ b/source/yojimbo_connection.cpp
@@ -2,6 +2,8 @@
 #include "yojimbo_reliable_ordered_channel.h"
 #include "yojimbo_unreliable_unordered_channel.h"
 
+#include <string.h>
+
 namespace yojimbo
 {
     struct ConnectionPacket
@@ -347,7 +349,22 @@ namespace yojimbo
 
         ConnectionPacket packet;
 
-        if ( !ReadPacket( context, *m_messageFactory, m_connectionConfig, packet, packetData, packetBytes ) )
+        // BitReader loads an 8-byte window. netcode/reliable hand back an exact
+        // payload allocation, so copy into packetBytes+8 before deserialize.
+        uint8_t * padded = (uint8_t *) YOJIMBO_ALLOCATE( *m_allocator, (size_t) packetBytes + 8 );
+        if ( !padded )
+        {
+            yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to allocate padded read buffer\n" );
+            m_errorLevel = CONNECTION_ERROR_ALLOCATOR;
+            return false;
+        }
+        memcpy( padded, packetData, (size_t) packetBytes );
+        memset( padded + packetBytes, 0, 8 );
+
+        const bool readOk = ReadPacket( context, *m_messageFactory, m_connectionConfig, packet, padded, packetBytes );
+        YOJIMBO_FREE( *m_allocator, padded );
+
+        if ( !readOk )
         {
             yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: failed to read packet\n" );
             m_errorLevel = CONNECTION_ERROR_READ_PACKET_FAILED;

--- a/test.cpp
+++ b/test.cpp
@@ -1486,6 +1486,40 @@ void test_connection_reject_empty_packet()
     check( connection.GetErrorLevel() == CONNECTION_ERROR_READ_PACKET_FAILED );
 }
 
+void test_connection_process_packet_exact_allocation()
+{
+    // Production receive hands ProcessPacket an exact payload allocation.
+    // BitReader needs 8 bytes of slack; ProcessPacket copies into packetBytes+8.
+    TestMessageFactory messageFactory( GetDefaultAllocator() );
+    double time = 100.0;
+    ConnectionConfig connectionConfig;
+    connectionConfig.numChannels = 1;
+    connectionConfig.channel[0].type = CHANNEL_TYPE_RELIABLE_ORDERED;
+    Connection sender( GetDefaultAllocator(), messageFactory, connectionConfig, time );
+    Connection receiver( GetDefaultAllocator(), messageFactory, connectionConfig, time );
+
+    TestMessage * message = (TestMessage*) messageFactory.CreateMessage( TEST_MESSAGE );
+    check( message );
+    message->sequence = 0;
+    sender.SendMessage( 0, message );
+
+    uint8_t packet[2048];
+    int packetBytes = 0;
+    check( sender.GeneratePacket( NULL, 0, packet, (int) sizeof( packet ), packetBytes ) );
+    check( packetBytes > 0 );
+
+    uint8_t * exact = (uint8_t *) malloc( (size_t) packetBytes );
+    check( exact );
+    memcpy( exact, packet, (size_t) packetBytes );
+    check( receiver.ProcessPacket( NULL, 0, exact, packetBytes ) );
+    free( exact );
+
+    Message * received = receiver.ReceiveMessage( 0 );
+    check( received );
+    check( received->GetType() == TEST_MESSAGE );
+    messageFactory.ReleaseMessage( received );
+}
+
 void test_connection_unreliable_rejects_block_fragment()
 {
     // An unreliable-unordered channel never sends a top-level block fragment (its blocks
@@ -4313,6 +4347,7 @@ int main( int argc, char ** argv )
         RUN_TEST( test_connection_unreliable_unordered_messages );
         RUN_TEST( test_connection_unreliable_unordered_blocks );
         RUN_TEST( test_connection_reject_empty_packet );
+        RUN_TEST( test_connection_process_packet_exact_allocation );
         RUN_TEST( test_connection_unreliable_rejects_block_fragment );
         RUN_TEST( test_connection_reliable_block_fragment_on_disabled_blocks );
         RUN_TEST( test_connection_reliable_block_fragment_overflow );


### PR DESCRIPTION
Johnny Grok.

`serialize::BitReader` loads an 8-byte window. `Connection::ProcessPacket` constructed `ReadStream` on the payload pointer and exact length from netcode/reliable, which do not keep eight bytes of slack after the payload.

Copy into `packetBytes+8` (zero the tail), then deserialize. The fuzzer already did this; production did not. Allocator failure is `CONNECTION_ERROR_ALLOCATOR`.

`test_connection_process_packet_exact_allocation` generates a well-formed packet, copies it into `malloc(packetBytes)`, and ProcessPackets it. `./build/bin/test` prints ALL TESTS PASS.